### PR TITLE
Update arrayref version in libraries/crypto.

### DIFF
--- a/libraries/crypto/Cargo.toml
+++ b/libraries/crypto/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 libtock = { path = "../../third_party/libtock-rs" }
 cbor = { path = "../cbor" }
-arrayref = "0.3.5"
+arrayref = "0.3.6"
 subtle = { version = "2.2", default-features = false, features = ["nightly"] }
 byteorder = { version = "1", default-features = false }
 hex = { version = "0.3.2", default-features = false, optional = true }


### PR DESCRIPTION
The `Cargo.toml` at the root directory already uses version 0.3.6, let's update the one in the crypto library as well.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR