### PR TITLE
Update install.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -23,7 +23,7 @@ hardware:
 *   a [Segger J-Link](https://www.segger.com/products/debug-probes/j-link/) JTAG
     probe.
 *   a
-    [TC2050 Tag-Connect programming cable](http://www.tag-connect.com/TC2050-IDC-NL-050-ALL).
+    [TC2050 Tag-Connect programming cable](https://www.tag-connect.com/product/tc2050-idc-nl-10-pin-no-legs-cable-with-ribbon-connector).
 *   a [Tag-Connect TC2050 ARM2010](http://www.tag-connect.com/TC2050-ARM2010)
     adaptor
 *   optionally a


### PR DESCRIPTION
Fixed the link for TC2050 Tag-Connect programming cable.

I just ordered the cable and fortunately the seller gives a warning. The right cable that connect to the Tag-Connect TC2050 ARM2010 adapter is the TC2050-IDC-NL instead of TC2050-IDC-NL-050-ALL.

![Screen Shot 2020-02-06 at 12 53 47 PM](https://user-images.githubusercontent.com/3958152/73904577-cc41e980-48df-11ea-9f17-6754bbfc390f.png)
