### PR TITLE
Don't dereference slices obtained from include_bytes.

### DIFF
--- a/src/ctap/ctap1.rs
+++ b/src/ctap/ctap1.rs
@@ -309,7 +309,7 @@ impl Ctap1Command {
         signature_data.extend(key_handle);
         signature_data.extend_from_slice(&user_pk);
 
-        let attestation_key = crypto::ecdsa::SecKey::from_bytes(&ATTESTATION_PRIVATE_KEY).unwrap();
+        let attestation_key = crypto::ecdsa::SecKey::from_bytes(ATTESTATION_PRIVATE_KEY).unwrap();
         let signature = attestation_key.sign_rfc6979::<crypto::sha256::Sha256>(&signature_data);
 
         response.extend(signature.to_asn1_der());

--- a/src/ctap/key_material.rs
+++ b/src/ctap/key_material.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub const AAGUID: [u8; 16] = *include_bytes!(concat!(env!("OUT_DIR"), "/opensk_aaguid.bin"));
+pub const AAGUID: &[u8; 16] = include_bytes!(concat!(env!("OUT_DIR"), "/opensk_aaguid.bin"));
 
 pub const ATTESTATION_CERTIFICATE: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/opensk_cert.bin"));
 
-pub const ATTESTATION_PRIVATE_KEY: [u8; 32] =
-    *include_bytes!(concat!(env!("OUT_DIR"), "/opensk_pkey.bin"));
+pub const ATTESTATION_PRIVATE_KEY: &[u8; 32] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/opensk_pkey.bin"));

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -429,7 +429,7 @@ where
         };
 
         let mut auth_data = self.generate_auth_data(&rp_id_hash, flags);
-        auth_data.extend(&AAGUID);
+        auth_data.extend(AAGUID);
         // The length is fixed to 0x20 or 0x70 and fits one byte.
         if credential_id.len() > 0xFF {
             return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_RESPONSE_TOO_LONG);
@@ -446,7 +446,7 @@ where
         signature_data.extend(client_data_hash);
         let (signature, x5c) = if USE_BATCH_ATTESTATION {
             let attestation_key =
-                crypto::ecdsa::SecKey::from_bytes(&ATTESTATION_PRIVATE_KEY).unwrap();
+                crypto::ecdsa::SecKey::from_bytes(ATTESTATION_PRIVATE_KEY).unwrap();
             (
                 attestation_key.sign_rfc6979::<crypto::sha256::Sha256>(&signature_data),
                 Some(vec![ATTESTATION_CERTIFICATE.to_vec()]),
@@ -640,7 +640,7 @@ where
                     String::from(FIDO2_VERSION_STRING),
                 ],
                 extensions: Some(vec![]),
-                aaguid: AAGUID,
+                aaguid: *AAGUID,
                 options: Some(options_map),
                 max_msg_size: Some(1024),
                 pin_protocols: Some(vec![
@@ -978,7 +978,7 @@ mod test {
             0x82, 0x66, 0x55, 0x32, 0x46, 0x5F, 0x56, 0x32, 0x68, 0x46, 0x49, 0x44, 0x4F, 0x5F,
             0x32, 0x5F, 0x30, 0x02, 0x80, 0x03, 0x50,
         ]);
-        expected_response.extend(&AAGUID);
+        expected_response.extend(AAGUID);
         expected_response.extend(&[
             0x04, 0xA3, 0x62, 0x72, 0x6B, 0xF5, 0x62, 0x75, 0x70, 0xF5, 0x69, 0x63, 0x6C, 0x69,
             0x65, 0x6E, 0x74, 0x50, 0x69, 0x6E, 0xF4, 0x05, 0x19, 0x04, 0x00, 0x06, 0x81, 0x01,
@@ -1045,7 +1045,7 @@ mod test {
                     0x34, 0xE2, 0x75, 0x1E, 0x68, 0x2F, 0xAB, 0x9F, 0x2D, 0x30, 0xAB, 0x13, 0xD2,
                     0x12, 0x55, 0x86, 0xCE, 0x19, 0x47, 0x41, 0x00, 0x00, 0x00, 0x00,
                 ];
-                expected_auth_data.extend(&AAGUID);
+                expected_auth_data.extend(AAGUID);
                 expected_auth_data.extend(&[0x00, 0x20]);
                 assert_eq!(
                     auth_data[0..expected_auth_data.len()],
@@ -1082,7 +1082,7 @@ mod test {
                     0x34, 0xE2, 0x75, 0x1E, 0x68, 0x2F, 0xAB, 0x9F, 0x2D, 0x30, 0xAB, 0x13, 0xD2,
                     0x12, 0x55, 0x86, 0xCE, 0x19, 0x47, 0x41, 0x00, 0x00, 0x00, 0x00,
                 ];
-                expected_auth_data.extend(&AAGUID);
+                expected_auth_data.extend(AAGUID);
                 expected_auth_data.extend(&[0x00, ENCRYPTED_CREDENTIAL_ID_SIZE as u8]);
                 assert_eq!(
                     auth_data[0..expected_auth_data.len()],


### PR DESCRIPTION
Some of the slices obtained with `include_bytes` were dereferenced to be stored in arrays, and were then referenced again upon use. This change removes these back and forth conversions.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR