### PR TITLE
Decrease the number of tests in debug mode, to account for slower CI on Travis

### DIFF
--- a/libraries/crypto/src/ec/point.rs
+++ b/libraries/crypto/src/ec/point.rs
@@ -912,6 +912,8 @@ pub mod test {
         }
     }
 
+    // Due to the 3 nested loops, this test is super slow with debug assertions enabled.
+    #[cfg(not(debug_assertions))]
     #[test]
     fn test_add_is_associative() {
         for x in &get_test_values_projective() {

--- a/libraries/crypto/src/ecdh.rs
+++ b/libraries/crypto/src/ecdh.rs
@@ -103,7 +103,7 @@ mod test {
     #[cfg(not(debug_assertions))]
     const ITERATIONS: u32 = 10000;
     #[cfg(debug_assertions)]
-    const ITERATIONS: u32 = 1000;
+    const ITERATIONS: u32 = 500;
 
     /** Test that key generation creates valid keys **/
     #[test]

--- a/libraries/crypto/src/ecdsa.rs
+++ b/libraries/crypto/src/ecdsa.rs
@@ -357,7 +357,7 @@ mod test {
     #[cfg(not(debug_assertions))]
     const ITERATIONS: u32 = 10000;
     #[cfg(debug_assertions)]
-    const ITERATIONS: u32 = 1000;
+    const ITERATIONS: u32 = 500;
 
     /** Test that key generation creates valid keys **/
     #[test]


### PR DESCRIPTION
Some tests take more than 60 seconds to run on Travis. This PR disables some tests or decreases the number of iterations when debug assertions are enabled, according to the tests taking more than 60 seconds on this build: https://travis-ci.org/google/OpenSK/builds/646810262.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR