### PR TITLE
Pass features to crypto bench example.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -160,7 +160,7 @@ comma_separated () {
 }
 
 build_app () {
-  local feature_list="$(comma_separated $@)"
+  local feature_list="$(comma_separated "$@")"
   cargo build \
     --release \
     --target=thumbv7em-none-eabi \
@@ -180,7 +180,7 @@ build_app () {
 }
 
 build_crypto_bench () {
-  local feature_list="$(comma_separated $@)"
+  local feature_list="$(comma_separated "$@")"
   cargo build \
     --release \
     --target=thumbv7em-none-eabi \

--- a/deploy.sh
+++ b/deploy.sh
@@ -148,15 +148,19 @@ build_app_padding () {
   ) | xxd -p -r > "${tab_folder}/padding.bin"
 }
 
-build_app () {
+comma_separated () {
   # Flatten the array
   # This is equivalent to the following python snippet: ' '.join(arr).replace(' ', ',')
-  local feature_list=$(IFS=$'\n'; echo "$@")
-  if [ "X${feature_list}" != "X" ]
+  local list=$(IFS=$'\n'; echo "$@")
+  if [ "X${list}" != "X" ]
   then
-    feature_list="${feature_list// /,}"
+    feature_list="${list// /,}"
   fi
+  echo ${list}
+}
 
+build_app () {
+  local feature_list="$(comma_separated $@)"
   cargo build \
     --release \
     --target=thumbv7em-none-eabi \
@@ -176,14 +180,7 @@ build_app () {
 }
 
 build_crypto_bench () {
-  # Flatten the array
-  # This is equivalent to the following python snippet: ' '.join(arr).replace(' ', ',')
-  local feature_list=$(IFS=$'\n'; echo "$@")
-  if [ "X${feature_list}" != "X" ]
-  then
-    feature_list="${feature_list// /,}"
-  fi
-
+  local feature_list="$(comma_separated $@)"
   cargo build \
     --release \
     --target=thumbv7em-none-eabi \

--- a/deploy.sh
+++ b/deploy.sh
@@ -176,9 +176,18 @@ build_app () {
 }
 
 build_crypto_bench () {
+  # Flatten the array
+  # This is equivalent to the following python snippet: ' '.join(arr).replace(' ', ',')
+  local feature_list=$(IFS=$'\n'; echo "$@")
+  if [ "X${feature_list}" != "X" ]
+  then
+    feature_list="${feature_list// /,}"
+  fi
+
   cargo build \
     --release \
     --target=thumbv7em-none-eabi \
+    --features="${feature_list}" \
     --example crypto_bench
 
   mkdir -p "target/tab"
@@ -310,7 +319,7 @@ fi
 
 if [ "$install_app" = "crypto_bench" ]
 then
-  build_crypto_bench
+  build_crypto_bench "${!enabled_features[@]}"
 fi
 
 if [ "$install_app" != "none" ]


### PR DESCRIPTION
This change forwards enabled features to the crypto bench example, like it's done for the CTAP app. This allows to deploy things like `./deploy.sh --panic-console crypto_bench` and indeed have the panic message being printed to the console.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR