### PR TITLE
Enable Travis on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ rust:
 
 os:
   - linux
+  - osx
 
 addons:
   apt:

--- a/run_desktop_tests.sh
+++ b/run_desktop_tests.sh
@@ -13,17 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eu
-
-# Ensure we have the key_material.rs file before running the tests
-if [ ! -f src/ctap/key_material.rs ]
-then
-  echo "$(tput bold)ERROR:$(tput sgr0) Cannot find src/ctap/key_material.rs file."
-  echo "Please make sure that you have run the following script: ./setup.sh"
-  exit 2
-fi
-
-set -x
+set -eux
 
 echo "Checking formatting..."
 cargo fmt --all -- --check
@@ -46,27 +36,29 @@ cargo check --release --target=thumbv7em-none-eabi --examples
 echo "Checking that CTAP2 builds and links properly (1 set of features)..."
 cargo build --release --target=thumbv7em-none-eabi --features with_ctap1
 
-echo "Running unit tests on the desktop (release mode)..."
-cd libraries/cbor
-cargo test --release --features std
-cd ../..
-cd libraries/crypto
-RUSTFLAGS='-C target-feature=+aes' cargo test --release --features std,derive_debug
-cd ../..
-cargo test --release --features std
+if [ "${TRAVIS_OS_NAME}" = "linux" ]
+then
+  echo "Running unit tests on the desktop (release mode)..."
+  cd libraries/cbor
+  cargo test --release --features std
+  cd ../..
+  cd libraries/crypto
+  RUSTFLAGS='-C target-feature=+aes' cargo test --release --features std,derive_debug
+  cd ../..
+  cargo test --release --features std
 
-echo "Running unit tests on the desktop (debug mode)..."
-cd libraries/cbor
-cargo test --features std
-cd ../..
-cd libraries/crypto
-RUSTFLAGS='-C target-feature=+aes' cargo test --features std,derive_debug
-cd ../..
-cargo test --features std
+  echo "Running unit tests on the desktop (debug mode)..."
+  cd libraries/cbor
+  cargo test --features std
+  cd ../..
+  cd libraries/crypto
+  RUSTFLAGS='-C target-feature=+aes' cargo test --features std,derive_debug
+  cd ../..
+  cargo test --features std
 
-echo "Running unit tests on the desktop (release mode + CTAP1)..."
-cargo test --release --features std,with_ctap1
+  echo "Running unit tests on the desktop (release mode + CTAP1)..."
+  cargo test --release --features std,with_ctap1
 
-echo "Running unit tests on the desktop (debug mode + CTAP1)..."
-cargo test --features std,with_ctap1
-
+  echo "Running unit tests on the desktop (debug mode + CTAP1)..."
+  cargo test --features std,with_ctap1
+fi

--- a/run_desktop_tests.sh
+++ b/run_desktop_tests.sh
@@ -36,7 +36,7 @@ cargo check --release --target=thumbv7em-none-eabi --examples
 echo "Checking that CTAP2 builds and links properly (1 set of features)..."
 cargo build --release --target=thumbv7em-none-eabi --features with_ctap1
 
-if [ "${TRAVIS_OS_NAME}" = "linux" ]
+if [ -z "${TRAVIS_OS_NAME}" -o "${TRAVIS_OS_NAME}" = "linux" ]
 then
   echo "Running unit tests on the desktop (release mode)..."
   cd libraries/cbor


### PR DESCRIPTION
Try to catch bugs earlier on Mac OS X by also running travis-ci on this os.
In order to speed up the builds, unit testing is only enabled on Linux or outside of Travis.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR