### PR TITLE
Fix run_desktop_tests.sh script

### DIFF
--- a/run_desktop_tests.sh
+++ b/run_desktop_tests.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eux
+set -ex
 
 echo "Checking formatting..."
 cargo fmt --all -- --check


### PR DESCRIPTION
The script begins with `set -eux` and therefore will fail when using an
undefined variable. This is the case with `TRAVIS_OS_NAME` outside of
Travis.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR