### PR TITLE
Update the ring dev dependency version.

### DIFF
--- a/libraries/crypto/Cargo.toml
+++ b/libraries/crypto/Cargo.toml
@@ -16,8 +16,8 @@ arrayref = "0.3.6"
 subtle = { version = "2.2", default-features = false, features = ["nightly"] }
 byteorder = { version = "1", default-features = false }
 hex = { version = "0.3.2", default-features = false, optional = true }
-ring = { version = "0.14.6", optional = true }
-untrusted = { version = "0.6.2", optional = true }
+ring = { version = "0.16.11", optional = true }
+untrusted = { version = "0.7.0", optional = true }
 rand = { version = "0.6.5", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }


### PR DESCRIPTION
This updates the `ring` dependency to the latest available version. This also allows to check if the `cargo audit` warning is resolved by that.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR