### PR TITLE
Add instructions to re-run setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -31,13 +31,31 @@ git submodule update --init
 
 done_text="$(tput bold)DONE.$(tput sgr0)"
 
+patch_conflict_detected () {
+  cat <<EOF
+
+This script cannot be run twice without reverting the patches.
+
+To do so, follow these instructions:
+1. Commit any changes you want to save.
+2. Run the ./reset.sh script to revert all uncommitted changes.
+3. Run the ./setup.sh script again.
+EOF
+  exit 1
+}
+
 # Apply patches to kernel. Do that in a sub-shell
 (
   cd third_party/tock/ && \
   for p in ../../patches/tock/[0-9][0-9]-*.patch
   do
     echo -n '[-] Applying patch "'$(basename $p)'"... '
-    git apply "$p" && echo $done_text
+    if git apply "$p"
+    then
+      echo $done_text
+    else
+      patch_conflict_detected
+    fi
   done
 )
 
@@ -47,7 +65,12 @@ done_text="$(tput bold)DONE.$(tput sgr0)"
   for p in ../../patches/libtock-rs/[0-9][0-9]-*.patch
   do
     echo -n '[-] Applying patch "'$(basename $p)'"... '
-    git apply "$p" && echo $done_text
+    if git apply "$p"
+    then
+      echo $done_text
+    else
+      patch_conflict_detected
+    fi
   done
 )
 


### PR DESCRIPTION
The reset script was apparently not documented. A user had to re-clone the project to restore a valid state: https://github.com/google/OpenSK/issues/25#issuecomment-583917950.