### PR TITLE
Fix cargo audit workflow

### DIFF
--- a/.github/workflows/cargo_audit.yml
+++ b/.github/workflows/cargo_audit.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   audit:
     runs-on: ubuntu-18.04
-    if: env.GITHUB_HEAD_REF == 0
+    if: github.repository == 'google/OpenSK'
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
The env context is only available at the step level, not the job one so
we need to use the github context instead. But the head_ref will only be
populated if we run in a pull_request event. So until we find a better
solution, let's match on the repo URL.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR