### PR TITLE
Make internal python linter happy.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -12,6 +12,12 @@ cache-size=500
 # Ignore Py3 files
 ignore=get_references_web.py,get_references_web_single_group.py
 
+load-plugins=
+    pylint.extensions.bad_builtin,
+    pylint.extensions.docparams,
+    pylint.extensions.docstyle,
+    pylint.extensions.redefined_variable_type,
+    pylint.extensions.overlapping_exceptions,
 
 [REPORTS]
 
@@ -32,6 +38,8 @@ disable-report=R0001,R0002,R0003,R0004,R0101,R0102,R0201,R0202,R0220,R0401,R0402
 # Error message template (continued on second line)
 msg-template={msg_id}:{line:3} {obj}: {msg} [{symbol}]
 
+# We don't need evaluation score
+score=no
 
 [MESSAGES CONTROL]
 # List of checkers and warnings to enable.
@@ -220,3 +228,8 @@ ignore-exceptions=AssertionError,NotImplementedError,StopIteration,TypeError
 # Number of spaces of indent required when the last token on the preceding line
 # is an open (, [, or {.
 indent-after-paren=4
+
+# Set the linting for string quotes
+string-quote=double
+triple-quote=double
+docstring-quote=double

--- a/deploy.py
+++ b/deploy.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # Lint as: python3
+# pylint: disable=C0111
 
 from __future__ import absolute_import
 from __future__ import division
@@ -26,8 +27,10 @@ import subprocess
 import sys
 
 import colorama
+from tockloader import tab
+from tockloader import tbfh
+from tockloader import tockloader as loader
 from tockloader.exceptions import TockLoaderException
-from tockloader import tab, tbfh, tockloader
 
 # This structure allows us in the future to also support out-of-tree boards.
 SUPPORTED_BOARDS = {
@@ -78,7 +81,7 @@ def info(msg):
 
 class RemoveConstAction(argparse.Action):
 
-  #pylint: disable=W0622
+  # pylint: disable=W0622
   def __init__(self,
                option_strings,
                dest,
@@ -155,7 +158,7 @@ class OpenSKInstaller:
       # associated to the version and split will only return 1 item.
       # To avoid failing later when accessing the date, we insert an
       # empty value.
-      target_toolchain.append('')
+      target_toolchain.append("")
     current_version = self.checked_command_output(["rustc", "--version"])
     if not all((target_toolchain[0] in current_version,
                 target_toolchain[1] in current_version)):
@@ -209,7 +212,7 @@ class OpenSKInstaller:
     assert self.args.application
     package_parameter = "-n"
     elf2tab_ver = self.checked_command_output(["elf2tab", "--version"]).split(
-        ' ', maxsplit=1)[1]
+        " ", maxsplit=1)[1]
     # Starting from v0.5.0-dev the parameter changed.
     # Current pyblished crate is 0.4.0 but we don't want developers
     # running the HEAD from github to be stuck
@@ -232,7 +235,7 @@ class OpenSKInstaller:
     setattr(args, "erase", self.args.clear_apps)
     setattr(args, "make", False)
     setattr(args, "no_replace", False)
-    tock = tockloader.TockLoader(args)
+    tock = loader.TockLoader(args)
     tock.open(args)
     tabs = [tab.TAB(tab_filename)]
     try:
@@ -251,7 +254,7 @@ class OpenSKInstaller:
     info("Flashing padding application")
     args = copy.copy(self.tockloader_default_args)
     setattr(args, "address", 0x30000)
-    tock = tockloader.TockLoader(args)
+    tock = loader.TockLoader(args)
     tock.open(args)
     try:
       tock.flash_binary(padding, args.address)
@@ -262,7 +265,7 @@ class OpenSKInstaller:
     args = copy.copy(self.tockloader_default_args)
     setattr(args, "app_address", 0x40000)
     info("Erasing all installed applications")
-    tock = tockloader.TockLoader(args)
+    tock = loader.TockLoader(args)
     tock.open(args)
     try:
       tock.erase_apps(False)
@@ -271,9 +274,10 @@ class OpenSKInstaller:
       info(("A non-critical error occured while erasing "
             "apps: {}".format(str(e))))
 
+  # pylint: disable=W0212
   def verify_flashed_app(self, expected_app):
     args = copy.copy(self.tockloader_default_args)
-    tock = tockloader.TockLoader(args)
+    tock = loader.TockLoader(args)
     app_found = False
     with tock._start_communication_with_board():
       apps = [app.name for app in tock._extract_all_app_headers()]
@@ -322,7 +326,7 @@ def main(args):
   OpenSKInstaller(args).run()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
   shared_parser = argparse.ArgumentParser(add_help=False)
   shared_parser.add_argument(
       "--dont-clear-apps",


### PR DESCRIPTION
It seems that our internal linter is stricter than what pylint does.
Fixing the python code to make both happy and tries to fix the gap by
modifying pylintrc configuration file

- [x] Tests pass
- [x] Appropriate changes to README are included in PR