### PR TITLE
adding HMAC-secret support

### DIFF
--- a/src/ctap/data_formats.rs
+++ b/src/ctap/data_formats.rs
@@ -224,8 +224,8 @@ impl From<Extensions> for cbor::Value {
     fn from(extensions: Extensions) -> Self {
         cbor_map_btree!(extensions
             .0
-            .iter()
-            .map(|(key, value)| (cbor_text!(key), value.clone()))
+            .into_iter()
+            .map(|(key, value)| (cbor_text!(key), value))
             .collect())
     }
 }
@@ -1095,7 +1095,7 @@ mod test {
         );
 
         let credential = PublicKeyCredentialSource {
-            cred_random: Some([0x00; 32].to_vec()),
+            cred_random: Some(vec![0x00; 32]),
             ..credential
         };
 

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -445,6 +445,7 @@ mod test {
             rp_id: String::from(rp_id),
             user_handle,
             other_ui: None,
+            cred_random: None,
         }
     }
 
@@ -613,6 +614,7 @@ mod test {
             rp_id: String::from("example.com"),
             user_handle: vec![0x00],
             other_ui: None,
+            cred_random: None,
         };
         assert_eq!(found_credential, Some(expected_credential));
     }


### PR DESCRIPTION
Fixes #74 

This is the extension implementation for HMAC-secret. This is required for Windows Hello passwordless logins.

This is still WIP, the extension has not been tested on Windows 10 yet.