### PR TITLE
Sync upstream kernel to get more reproducible builds.

### DIFF
--- a/.github/workflows/opensk_build.yml
+++ b/.github/workflows/opensk_build.yml
@@ -24,8 +24,16 @@ jobs:
       - name: Set up OpenSK
         run: ./setup.sh
 
+      - name: Building sha256sum tool
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --manifest-path third_party/tock/tools/sha256sum/Cargo.toml
+
       - name: Building OpenSK
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release --target=thumbv7em-none-eabi --features with_ctap1
+      - name: Compute SHA-256 sum
+        run: ./third_party/tock/tools/sha256sum/target/debug/sha256sum target/thumbv7em-none-eabi/release/ctap2

--- a/boards/nrf52840_mdk_dfu/src/main.rs
+++ b/boards/nrf52840_mdk_dfu/src/main.rs
@@ -22,9 +22,9 @@ const LED1_B_PIN: Pin = Pin::P0_24;
 const BUTTON_PIN: Pin = Pin::P0_18;
 const BUTTON_RST_PIN: Pin = Pin::P0_02;
 
-const UART_RTS: Pin = Pin::P0_21;
+const UART_RTS: Option<Pin> = Some(Pin::P0_21);
 const UART_TXD: Pin = Pin::P0_20;
-const UART_CTS: Pin = Pin::P0_03;
+const UART_CTS: Option<Pin> = Some(Pin::P0_03);
 const UART_RXD: Pin = Pin::P0_19;
 
 const SPI_MOSI: Pin = Pin::P0_05;
@@ -76,7 +76,7 @@ pub unsafe fn reset_handler() {
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
         components::button_component_helper!((
             &nrf52840::gpio::PORT[BUTTON_PIN],
-            capsules::button::GpioMode::LowWhenPressed,
+            kernel::hil::ActivationMode::ActiveLow,
             kernel::hil::gpio::FloatingState::PullUp
         )),
     );
@@ -84,15 +84,15 @@ pub unsafe fn reset_handler() {
     let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
         (
             &nrf52840::gpio::PORT[LED1_R_PIN],
-            capsules::led::ActivationMode::ActiveLow
+            kernel::hil::gpio::ActivationMode::ActiveLow
         ),
         (
             &nrf52840::gpio::PORT[LED1_G_PIN],
-            capsules::led::ActivationMode::ActiveLow
+            kernel::hil::gpio::ActivationMode::ActiveLow
         ),
         (
             &nrf52840::gpio::PORT[LED1_B_PIN],
-            capsules::led::ActivationMode::ActiveLow
+            kernel::hil::gpio::ActivationMode::ActiveLow
         )
     ));
     let chip = static_init!(nrf52840::chip::Chip, nrf52840::chip::new());

--- a/boards/nrf52840_mdk_dfu/src/main.rs
+++ b/boards/nrf52840_mdk_dfu/src/main.rs
@@ -76,7 +76,7 @@ pub unsafe fn reset_handler() {
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
         components::button_component_helper!((
             &nrf52840::gpio::PORT[BUTTON_PIN],
-            kernel::hil::ActivationMode::ActiveLow,
+            kernel::hil::gpio::ActivationMode::ActiveLow,
             kernel::hil::gpio::FloatingState::PullUp
         )),
     );

--- a/run_desktop_tests.sh
+++ b/run_desktop_tests.sh
@@ -48,6 +48,10 @@ echo "Checking that supported boards build properly..."
 make -C third_party/tock/boards/nordic/nrf52840dk
 make -C third_party/tock/boards/nordic/nrf52840_dongle
 
+echo "Checking that other boards build properly..."
+make -C boards/nrf52840_dongle_dfu
+make -C boards/nrf52840_mdk_dfu
+
 if [ -z "${TRAVIS_OS_NAME}" -o "${TRAVIS_OS_NAME}" = "linux" ]
 then
   echo "Running unit tests on the desktop (release mode)..."

--- a/run_desktop_tests.sh
+++ b/run_desktop_tests.sh
@@ -24,6 +24,9 @@ cd libraries/crypto
 cargo fmt --all -- --check
 cd ../..
 
+echo "Building sha256sum tool..."
+cargo build --manifest-path third_party/tock/tools/sha256sum/Cargo.toml
+
 echo "Checking that CTAP2 builds properly..."
 cargo check --release --target=thumbv7em-none-eabi
 cargo check --release --target=thumbv7em-none-eabi --features with_ctap1
@@ -39,6 +42,7 @@ cargo check --release --target=thumbv7em-none-eabi --examples
 
 echo "Checking that CTAP2 builds and links properly (1 set of features)..."
 cargo build --release --target=thumbv7em-none-eabi --features with_ctap1
+./third_party/tock/tools/sha256sum/target/debug/sha256sum target/thumbv7em-none-eabi/release/ctap2
 
 echo "Checking that supported boards build properly..."
 make -C third_party/tock/boards/nordic/nrf52840dk


### PR DESCRIPTION
To move towards reproducible builds (#70), this pull-request syncs the kernel with upstream now that https://github.com/tock/tock/pull/1668 and https://github.com/tock/tock/pull/1669 have been merged. The `sha256sum` tool is also used to compute the sum of the built binary on CI.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR