### PR TITLE
Add a --verbose parameter to print all USB packets at the OpenSK level.

### DIFF
--- a/.github/workflows/cargo_check.yml
+++ b/.github/workflows/cargo_check.yml
@@ -64,17 +64,23 @@ jobs:
           command: check
           args: --target thumbv7em-none-eabi --release --features ram_storage
 
+      - name: Check OpenSK verbose
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --target thumbv7em-none-eabi --release --features verbose
+
       - name: Check OpenSK debug_ctap,with_ctap1
         uses: actions-rs/cargo@v1
         with:
           command: check
           args: --target thumbv7em-none-eabi --release --features debug_ctap,with_ctap1
 
-      - name: Check OpenSK debug_ctap,with_ctap1,panic_console,debug_allocations
+      - name: Check OpenSK debug_ctap,with_ctap1,panic_console,debug_allocations,verbose
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --target thumbv7em-none-eabi --release --features debug_ctap,with_ctap1,panic_console,debug_allocations
+          args: --target thumbv7em-none-eabi --release --features debug_ctap,with_ctap1,panic_console,debug_allocations,verbose
 
       - name: Check examples
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,13 @@ arrayref = "0.3.6"
 subtle = { version = "2.2", default-features = false, features = ["nightly"] }
 
 [features]
-std = ["cbor/std", "crypto/std", "crypto/derive_debug"]
-debug_ctap = ["crypto/derive_debug"]
-with_ctap1 = ["crypto/with_ctap1"]
-panic_console = ["libtock/panic_console"]
 debug_allocations = ["libtock/debug_allocations"]
+debug_ctap = ["crypto/derive_debug"]
+panic_console = ["libtock/panic_console"]
+std = ["cbor/std", "crypto/std", "crypto/derive_debug"]
 ram_storage = []
+verbose = ["debug_ctap"]
+with_ctap1 = ["crypto/with_ctap1"]
 
 [dev-dependencies]
 elf2tab = "0.4.0"

--- a/deploy.py
+++ b/deploy.py
@@ -702,12 +702,29 @@ if __name__ == "__main__":
             "board."),
   )
   main_parser.add_argument(
+      "--debug",
+      action="append_const",
+      const="debug_ctap",
+      dest="features",
+      help=("Compiles and installs the OpenSK application in debug mode "
+            "(i.e. more debug messages will be sent over the console port "
+            "such as hexdumps of packets)."),
+  )
+  main_parser.add_argument(
       "--debug-allocations",
       action="append_const",
       const="debug_allocations",
       dest="features",
       help=("The console will be used to output allocator statistics every "
             "time an allocation/deallocation happens."),
+  )
+  main_parser.add_argument(
+      "--verbose",
+      action="append_const",
+      const="verbose",
+      dest="features",
+      help=("The console will be used to output verbose information about the "
+            "OpenSK application. This also automatically activates --debug."),
   )
   main_parser.add_argument(
       "--no-u2f",
@@ -726,15 +743,6 @@ if __name__ == "__main__":
             "under the crypto_data/ directory. "
             "This is useful to allow flashing multiple OpenSK authenticators "
             "in a row without them being considered clones."),
-  )
-  main_parser.add_argument(
-      "--debug",
-      action="append_const",
-      const="debug_ctap",
-      dest="features",
-      help=("Compiles and installs the  OpenSK application in debug mode "
-            "(i.e. more debug messages will be sent over the console port "
-            "such as hexdumps of packets)."),
   )
   main_parser.add_argument(
       "--no-persistent-storage",

--- a/run_desktop_tests.sh
+++ b/run_desktop_tests.sh
@@ -34,8 +34,9 @@ cargo check --release --target=thumbv7em-none-eabi --features debug_ctap
 cargo check --release --target=thumbv7em-none-eabi --features panic_console
 cargo check --release --target=thumbv7em-none-eabi --features debug_allocations
 cargo check --release --target=thumbv7em-none-eabi --features ram_storage
+cargo check --release --target=thumbv7em-none-eabi --features verbose
 cargo check --release --target=thumbv7em-none-eabi --features debug_ctap,with_ctap1
-cargo check --release --target=thumbv7em-none-eabi --features debug_ctap,with_ctap1,panic_console,debug_allocations
+cargo check --release --target=thumbv7em-none-eabi --features debug_ctap,with_ctap1,panic_console,debug_allocations,verbose
 
 echo "Checking that examples build properly..."
 cargo check --release --target=thumbv7em-none-eabi --examples


### PR DESCRIPTION
This pull request adds a `--verbose` parameter to print all USB packets sent or received by the OpenSK app. The "Cancelling USB due to timeout" messages are also now gated by this `--verbose` flag, as they otherwise add quite some noise.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR