### PR TITLE
Depends on tockloader 1.4.x from now

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          pip install tockloader pylint
+          pip install 'tockloader~=1.4' pylint
       - name: Register matcher
         run: echo ::add-matcher::./.github/python_matcher.json
       - name: Test code with pylint

--- a/deploy.py
+++ b/deploy.py
@@ -524,9 +524,9 @@ class OpenSKInstaller:
     final_hex.tofile(dest_file, format="hex")
 
   def check_prerequisites(self):
-    if not tockloader.__version__.startswith("1.4"):
-      fatal(("Your version of tockloader is too old: found {}, expected "
-             "1.4.0.".format(tockloader.__version__)))
+    if not tockloader.__version__.startswith("1.4."):
+      fatal(("Your version of tockloader seems incompatible: found {}, "
+             "expected 1.4.x.".format(tockloader.__version__)))
 
     if self.args.programmer == "jlink":
       assert_mandatory_binary("JLinkExe")

--- a/setup.sh
+++ b/setup.sh
@@ -86,7 +86,7 @@ source tools/gen_key_materials.sh
 generate_crypto_materials N
 
 rustup install $(head -n 1 rust-toolchain)
-pip3 install --user --upgrade tockloader six intelhex
+pip3 install --user --upgrade 'tockloader~=1.4' six intelhex
 rustup target add thumbv7em-none-eabi
 
 # Install dependency to create applications.


### PR DESCRIPTION
Fixes #79 

tockloader 1.4.0 has been released and pushed to pypi.
Now we require at least tockloader 1.4.x for our `deploy.py` script.
Github workflows have been updated too.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR