### PR TITLE
Add a --verbose-build option to the deploy script.

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -310,13 +310,13 @@ class OpenSKInstaller:
       # Need to update
       rustup_install = ["rustup"]
       if self.args.verbose_build:
-        rustup_install.extend(["--verbose"])
+        rustup_install.extend("--verbose")
       rustup_install.extend(["install", target_toolchain_fullstring])
       self.checked_command(rustup_install)
 
     rustup_target = ["rustup"]
     if self.args.verbose_build:
-      rustup_target.extend(["--verbose"])
+      rustup_target.extend("--verbose")
     rustup_target.extend(
         ["target", "add", SUPPORTED_BOARDS[self.args.board].arch])
     self.checked_command(rustup_target)
@@ -368,7 +368,7 @@ class OpenSKInstaller:
     if is_example:
       command.extend(["--example", self.args.application])
     if self.args.verbose_build:
-      command.extend(["--verbose"])
+      command.extend("--verbose")
     self.checked_command(command, env=env)
     app_path = os.path.join("target", props.arch, "release")
     if is_example:
@@ -406,7 +406,7 @@ class OpenSKInstaller:
         "elf2tab", package_parameter, self.args.application, "-o", tab_filename
     ]
     if self.args.verbose_build:
-      elf2tab_args.extend(["--verbose"])
+      elf2tab_args.extend("--verbose")
     for arch, app_file in binaries.items():
       dest_file = os.path.join(self.tab_folder, "{}.elf".format(arch))
       shutil.copyfile(app_file, dest_file)
@@ -698,7 +698,7 @@ if __name__ == "__main__":
       choices=("boards", "programmers"),
       default=None,
       dest="listing",
-      help=("List supported boards or programmers, 1 per line and then exit."),
+      help="List supported boards or programmers, 1 per line and then exit.",
   )
   action_group.add_argument(
       "--board",
@@ -740,7 +740,7 @@ if __name__ == "__main__":
       action="store_true",
       default=False,
       dest="verbose_build",
-      help=("Build everything in verbose mode."),
+      help="Build everything in verbose mode.",
   )
 
   main_parser.add_argument(

--- a/deploy.py
+++ b/deploy.py
@@ -310,13 +310,13 @@ class OpenSKInstaller:
       # Need to update
       rustup_install = ["rustup"]
       if self.args.verbose_build:
-        rustup_install.extend(["--verbose"])
+        rustup_install.append("--verbose")
       rustup_install.extend(["install", target_toolchain_fullstring])
       self.checked_command(rustup_install)
 
     rustup_target = ["rustup"]
     if self.args.verbose_build:
-      rustup_target.extend(["--verbose"])
+      rustup_target.append("--verbose")
     rustup_target.extend(
         ["target", "add", SUPPORTED_BOARDS[self.args.board].arch])
     self.checked_command(rustup_target)
@@ -368,7 +368,7 @@ class OpenSKInstaller:
     if is_example:
       command.extend(["--example", self.args.application])
     if self.args.verbose_build:
-      command.extend(["--verbose"])
+      command.append("--verbose")
     self.checked_command(command, env=env)
     app_path = os.path.join("target", props.arch, "release")
     if is_example:
@@ -406,7 +406,7 @@ class OpenSKInstaller:
         "elf2tab", package_parameter, self.args.application, "-o", tab_filename
     ]
     if self.args.verbose_build:
-      elf2tab_args.extend(["--verbose"])
+      elf2tab_args.append("--verbose")
     for arch, app_file in binaries.items():
       dest_file = os.path.join(self.tab_folder, "{}.elf".format(arch))
       shutil.copyfile(app_file, dest_file)

--- a/deploy.py
+++ b/deploy.py
@@ -313,8 +313,7 @@ class OpenSKInstaller:
             target_toolchain[1] in current_version):
       info("Updating rust toolchain to {}".format("-".join(target_toolchain)))
       # Need to update
-      self.checked_command(
-          ["rustup", "install", target_toolchain_fullstring])
+      self.checked_command(["rustup", "install", target_toolchain_fullstring])
     self.checked_command(
         ["rustup", "target", "add", SUPPORTED_BOARDS[self.args.board].arch])
     info("Rust toolchain up-to-date")

--- a/deploy.py
+++ b/deploy.py
@@ -310,13 +310,13 @@ class OpenSKInstaller:
       # Need to update
       rustup_install = ["rustup"]
       if self.args.verbose_build:
-        rustup_install.extend("--verbose")
+        rustup_install.extend(["--verbose"])
       rustup_install.extend(["install", target_toolchain_fullstring])
       self.checked_command(rustup_install)
 
     rustup_target = ["rustup"]
     if self.args.verbose_build:
-      rustup_target.extend("--verbose")
+      rustup_target.extend(["--verbose"])
     rustup_target.extend(
         ["target", "add", SUPPORTED_BOARDS[self.args.board].arch])
     self.checked_command(rustup_target)
@@ -368,7 +368,7 @@ class OpenSKInstaller:
     if is_example:
       command.extend(["--example", self.args.application])
     if self.args.verbose_build:
-      command.extend("--verbose")
+      command.extend(["--verbose"])
     self.checked_command(command, env=env)
     app_path = os.path.join("target", props.arch, "release")
     if is_example:
@@ -406,7 +406,7 @@ class OpenSKInstaller:
         "elf2tab", package_parameter, self.args.application, "-o", tab_filename
     ]
     if self.args.verbose_build:
-      elf2tab_args.extend("--verbose")
+      elf2tab_args.extend(["--verbose"])
     for arch, app_file in binaries.items():
       dest_file = os.path.join(self.tab_folder, "{}.elf".format(arch))
       shutil.copyfile(app_file, dest_file)

--- a/deploy.py
+++ b/deploy.py
@@ -273,12 +273,7 @@ class OpenSKInstaller:
     stdout = None if self.args.verbose_build else subprocess.DEVNULL
     try:
       subprocess.run(
-          cmd,
-          stdout=stdout,
-          timeout=None,
-          check=True,
-          env=env,
-          cwd=cwd)
+          cmd, stdout=stdout, timeout=None, check=True, env=env, cwd=cwd)
     except subprocess.CalledProcessError as e:
       fatal("Failed to execute {}: {}".format(cmd[0], str(e)))
 
@@ -322,7 +317,8 @@ class OpenSKInstaller:
     rustup_target = ["rustup"]
     if self.args.verbose_build:
       rustup_target.extend(["--verbose"])
-    rustup_target.extend(["target", "add", SUPPORTED_BOARDS[self.args.board].arch])
+    rustup_target.extend(
+        ["target", "add", SUPPORTED_BOARDS[self.args.board].arch])
     self.checked_command(rustup_target)
     info("Rust toolchain up-to-date")
 

--- a/deploy.py
+++ b/deploy.py
@@ -269,6 +269,19 @@ class OpenSKInstaller:
         port=None,
     )
 
+  def checked_command(self, cmd, env=None, cwd=None):
+    stdout = None if self.args.verbose_build else subprocess.DEVNULL
+    try:
+      subprocess.run(
+          cmd,
+          stdout=stdout,
+          timeout=None,
+          check=True,
+          env=env,
+          cwd=cwd)
+    except subprocess.CalledProcessError as e:
+      fatal("Failed to execute {}: {}".format(cmd[0], str(e)))
+
   def checked_command_output(self, cmd, env=None, cwd=None):
     cmd_output = ""
     try:
@@ -300,9 +313,9 @@ class OpenSKInstaller:
             target_toolchain[1] in current_version):
       info("Updating rust toolchain to {}".format("-".join(target_toolchain)))
       # Need to update
-      self.checked_command_output(
+      self.checked_command(
           ["rustup", "install", target_toolchain_fullstring])
-    self.checked_command_output(
+    self.checked_command(
         ["rustup", "target", "add", SUPPORTED_BOARDS[self.args.board].arch])
     info("Rust toolchain up-to-date")
 
@@ -312,7 +325,11 @@ class OpenSKInstaller:
     out_directory = os.path.join("third_party", "tock", "target", props.arch,
                                  "release")
     os.makedirs(out_directory, exist_ok=True)
-    self.checked_command_output(["make"], cwd=props.path)
+
+    env = os.environ.copy()
+    if self.args.verbose_build:
+      env["V"] = "1"
+    self.checked_command(["make"], cwd=props.path, env=env)
 
   def build_example(self):
     info("Building example {}".format(self.args.application))
@@ -347,7 +364,9 @@ class OpenSKInstaller:
     ]
     if is_example:
       command.extend(["--example", self.args.application])
-    self.checked_command_output(command, env=env)
+    if self.args.verbose_build:
+      command.extend(["--verbose"])
+    self.checked_command(command, env=env)
     app_path = os.path.join("target", props.arch, "release")
     if is_example:
       app_path = os.path.join(app_path, "examples")
@@ -383,6 +402,8 @@ class OpenSKInstaller:
     elf2tab_args = [
         "elf2tab", package_parameter, self.args.application, "-o", tab_filename
     ]
+    if self.args.verbose_build:
+      elf2tab_args.extend(["--verbose"])
     for arch, app_file in binaries.items():
       dest_file = os.path.join(self.tab_folder, "{}.elf".format(arch))
       shutil.copyfile(app_file, dest_file)
@@ -392,7 +413,7 @@ class OpenSKInstaller:
         "--stack={}".format(STACK_SIZE), "--app-heap={}".format(APP_HEAP_SIZE),
         "--kernel-heap=1024", "--protected-region-size=64"
     ])
-    self.checked_command_output(elf2tab_args)
+    self.checked_command(elf2tab_args)
 
   def install_tab_file(self, tab_filename):
     assert self.args.application
@@ -616,14 +637,14 @@ class OpenSKInstaller:
 
       if self.args.programmer == "pyocd":
         info("Flashing HEX file")
-        self.checked_command_output([
+        self.checked_command([
             "pyocd", "flash", "--target={}".format(board_props.pyocd_target),
             "--format=hex", "--erase=auto", dest_file
         ])
       if self.args.programmer == "nordicdfu":
         info("Creating DFU package")
         dfu_pkg_file = "target/{}_dfu.zip".format(self.args.board)
-        self.checked_command_output([
+        self.checked_command([
             "nrfutil", "pkg", "generate", "--hw-version=52", "--sd-req=0",
             "--application-version=1", "--application={}".format(dest_file),
             dfu_pkg_file
@@ -710,6 +731,13 @@ if __name__ == "__main__":
       dest="tockos",
       help=("Only compiles and flash the application/example. "
             "Otherwise TockOS will also be bundled and flashed."),
+  )
+  main_parser.add_argument(
+      "--verbose-build",
+      action="store_true",
+      default=False,
+      dest="verbose_build",
+      help=("Build everything in verbose mode."),
   )
 
   main_parser.add_argument(

--- a/deploy.py
+++ b/deploy.py
@@ -313,9 +313,17 @@ class OpenSKInstaller:
             target_toolchain[1] in current_version):
       info("Updating rust toolchain to {}".format("-".join(target_toolchain)))
       # Need to update
-      self.checked_command(["rustup", "install", target_toolchain_fullstring])
-    self.checked_command(
-        ["rustup", "target", "add", SUPPORTED_BOARDS[self.args.board].arch])
+      rustup_install = ["rustup"]
+      if self.args.verbose_build:
+        rustup_install.extend(["--verbose"])
+      rustup_install.extend(["install", target_toolchain_fullstring])
+      self.checked_command(rustup_install)
+
+    rustup_target = ["rustup"]
+    if self.args.verbose_build:
+      rustup_target.extend(["--verbose"])
+    rustup_target.extend(["target", "add", SUPPORTED_BOARDS[self.args.board].arch])
+    self.checked_command(rustup_target)
     info("Rust toolchain up-to-date")
 
   def build_tockos(self):


### PR DESCRIPTION
This pull request adds a `--verbose-build` option to the deploy script, to print detailed output about the various building steps.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR