### PR TITLE
Add missing parameter that got introduced in tockloader 1.4

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -251,6 +251,7 @@ class OpenSKInstaller:
     self.tockloader_default_args = argparse.Namespace(
         arch=board.arch,
         board=self.args.board,
+        bundle_apps=False,
         debug=False,
         force=False,
         jlink_cmd="JLinkExe",


### PR DESCRIPTION
Tockloader 1.4 added the parameter to bundle apps and bails out if this parameter doesn't exists.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR