### PR TITLE
Credential management

### DIFF
--- a/libraries/crypto/src/ecdh.rs
+++ b/libraries/crypto/src/ecdh.rs
@@ -62,8 +62,10 @@ impl SecKey {
         // - https://www.secg.org/sec1-v2.pdf
     }
 
-    // DH key agreement method defined in the FIDO2 specification, Section 5.5.4. "Getting
-    // sharedSecret from Authenticator"
+    /// Creates a shared key using the Diffie Hellman key agreement.
+    ///
+    /// The key agreement is defined in the FIDO2 specification,
+    /// Section 6.5.5.4. "Obtaining the Shared Secret"
     pub fn exchange_x_sha256(&self, other: &PubKey) -> [u8; 32] {
         let p = self.exchange_raw(other);
         let mut x: [u8; 32] = [Default::default(); 32];
@@ -83,12 +85,13 @@ impl PubKey {
         self.p.to_bytes_uncompressed(bytes);
     }
 
+    /// Creates a new PubKey from their coordinates.
     pub fn from_coordinates(x: &[u8; NBYTES], y: &[u8; NBYTES]) -> Option<PubKey> {
         PointP256::new_checked_vartime(Int256::from_bin(x), Int256::from_bin(y))
             .map(|p| PubKey { p })
     }
 
-    // Writes the coordinates into the passed in arrays.
+    /// Writes the coordinates into the passed in arrays.
     pub fn to_coordinates(&self, x: &mut [u8; NBYTES], y: &mut [u8; NBYTES]) {
         self.p.getx().to_int().to_bin(x);
         self.p.gety().to_int().to_bin(y);

--- a/libraries/crypto/src/ecdh.rs
+++ b/libraries/crypto/src/ecdh.rs
@@ -88,6 +88,7 @@ impl PubKey {
             .map(|p| PubKey { p })
     }
 
+    // Writes the coordinates into the passed in arrays.
     pub fn to_coordinates(&self, x: &mut [u8; NBYTES], y: &mut [u8; NBYTES]) {
         self.p.getx().to_int().to_bin(x);
         self.p.gety().to_int().to_bin(y);

--- a/libraries/crypto/src/ecdsa.rs
+++ b/libraries/crypto/src/ecdsa.rs
@@ -62,10 +62,11 @@ impl SecKey {
         }
     }
 
-    // ECDSA signature based on a RNG to generate a suitable randomization parameter.
-    // Under the hood, rejection sampling is used to make sure that the randomization parameter is
-    // uniformly distributed.
-    // The provided RNG must be cryptographically secure; otherwise this method is insecure.
+    /// Creates an ECDSA signature based on a RNG.
+    ///
+    /// Under the hood, rejection sampling is used to make sure that the
+    /// randomization parameter is uniformly distributed. The provided RNG must
+    /// be cryptographically secure; otherwise this method is insecure.
     pub fn sign_rng<H, R>(&self, msg: &[u8], rng: &mut R) -> Signature
     where
         H: Hash256,
@@ -81,8 +82,7 @@ impl SecKey {
         }
     }
 
-    // Deterministic ECDSA signature based on RFC 6979 to generate a suitable randomization
-    // parameter.
+    /// Creates a deterministic ECDSA signature based on RFC 6979.
     pub fn sign_rfc6979<H>(&self, msg: &[u8]) -> Signature
     where
         H: Hash256 + HashBlockSize64Bytes,
@@ -105,8 +105,10 @@ impl SecKey {
         }
     }
 
-    // Try signing a curve element given a randomization parameter k. If no signature can be
-    // obtained from this k, None is returned and the caller should try again with another value.
+    /// Try signing a curve element given a randomization parameter k.
+    ///
+    /// If no signature can be obtained from this k, None is returned and the
+    /// caller should try again with another value.
     fn try_sign(&self, k: &NonZeroExponentP256, msg: &ExponentP256) -> Option<Signature> {
         let r = ExponentP256::modn(PointP256::base_point_mul(k.as_exponent()).getx().to_int());
         // The branching here is fine because all this reveals is that k generated an unsuitable r.
@@ -246,7 +248,7 @@ impl PubKey {
         representation
     }
 
-    // Writes the coordinates into the passed in arrays.
+    /// Writes the coordinates into the passed in arrays.
     pub fn to_coordinates(&self, x: &mut [u8; NBYTES], y: &mut [u8; NBYTES]) {
         self.p.getx().to_int().to_bin(x);
         self.p.gety().to_int().to_bin(y);

--- a/src/ctap/credential_management.rs
+++ b/src/ctap/credential_management.rs
@@ -1,0 +1,900 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::command::AuthenticatorCredentialManagementParameters;
+use super::data_formats::{
+    CoseKey, CredentialManagementSubCommand, CredentialManagementSubCommandParameters,
+    PublicKeyCredentialDescriptor, PublicKeyCredentialRpEntity, PublicKeyCredentialSource,
+    PublicKeyCredentialUserEntity,
+};
+use super::pin_protocol_v1::{PinPermission, PinProtocolV1};
+use super::response::{AuthenticatorCredentialManagementResponse, ResponseData};
+use super::status_code::Ctap2StatusCode;
+use super::storage::PersistentStore;
+use super::timed_permission::TimedPermission;
+use super::{check_command_permission, StatefulCommand, STATEFUL_COMMAND_TIMEOUT_DURATION};
+use alloc::collections::BTreeSet;
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::iter::FromIterator;
+use crypto::sha256::Sha256;
+use crypto::Hash256;
+use libtock_drivers::timer::ClockValue;
+
+fn enumerate_rps_response(
+    rp_id: Option<String>,
+    total_rps: Option<u64>,
+) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
+    let rp = rp_id.clone().map(|rp_id| PublicKeyCredentialRpEntity {
+        rp_id,
+        rp_name: None,
+        rp_icon: None,
+    });
+    let rp_id_hash = rp_id.map(|rp_id| Sha256::hash(rp_id.as_bytes()).to_vec());
+
+    Ok(AuthenticatorCredentialManagementResponse {
+        existing_resident_credentials_count: None,
+        max_possible_remaining_resident_credentials_count: None,
+        rp,
+        rp_id_hash,
+        total_rps,
+        user: None,
+        credential_id: None,
+        public_key: None,
+        total_credentials: None,
+        cred_protect: None,
+        large_blob_key: None,
+    })
+}
+
+fn enumerate_credentials_response(
+    credential: PublicKeyCredentialSource,
+    total_credentials: Option<u64>,
+) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
+    let PublicKeyCredentialSource {
+        key_type,
+        credential_id,
+        private_key,
+        rp_id: _,
+        user_handle,
+        user_display_name,
+        cred_protect_policy,
+        creation_order: _,
+        user_name,
+        user_icon,
+    } = credential;
+    let user = PublicKeyCredentialUserEntity {
+        user_id: user_handle,
+        user_name,
+        user_display_name,
+        user_icon,
+    };
+    let credential_id = PublicKeyCredentialDescriptor {
+        key_type,
+        key_id: credential_id,
+        transports: None, // You can set USB as a hint here.
+    };
+    let public_key = CoseKey::from(private_key.genpk());
+    Ok(AuthenticatorCredentialManagementResponse {
+        existing_resident_credentials_count: None,
+        max_possible_remaining_resident_credentials_count: None,
+        rp: None,
+        rp_id_hash: None,
+        total_rps: None,
+        user: Some(user),
+        credential_id: Some(credential_id),
+        public_key: Some(public_key),
+        total_credentials,
+        cred_protect: cred_protect_policy,
+        // TODO(kaczmarczyck) add when largeBlobKey is implemented
+        large_blob_key: None,
+    })
+}
+
+fn process_get_creds_metadata(
+    persistent_store: &PersistentStore,
+) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
+    Ok(AuthenticatorCredentialManagementResponse {
+        existing_resident_credentials_count: Some(persistent_store.count_credentials()? as u64),
+        max_possible_remaining_resident_credentials_count: Some(
+            persistent_store.remaining_credentials()? as u64,
+        ),
+        rp: None,
+        rp_id_hash: None,
+        total_rps: None,
+        user: None,
+        credential_id: None,
+        public_key: None,
+        total_credentials: None,
+        cred_protect: None,
+        large_blob_key: None,
+    })
+}
+
+fn process_enumerate_rps_begin(
+    persistent_store: &PersistentStore,
+    stateful_command_permission: &mut TimedPermission,
+    stateful_command_type: &mut Option<StatefulCommand>,
+    now: ClockValue,
+) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
+    let credentials = persistent_store.all_credentials()?;
+    let mut rp_set = BTreeSet::new();
+    for cred in credentials {
+        rp_set.insert(cred.rp_id);
+    }
+    let mut rp_ids = Vec::from_iter(rp_set);
+    let total_rps = rp_ids.len();
+
+    // TODO(kaczmarczyck) behaviour with empty list?
+    let rp_id = rp_ids.pop();
+    if total_rps > 1 {
+        *stateful_command_permission =
+            TimedPermission::granted(now, STATEFUL_COMMAND_TIMEOUT_DURATION);
+        *stateful_command_type = Some(StatefulCommand::EnumerateRps(rp_ids));
+    }
+    enumerate_rps_response(rp_id, Some(total_rps as u64))
+}
+
+fn process_enumerate_rps_get_next_rp(
+    stateful_command_permission: &mut TimedPermission,
+    stateful_command_type: &mut Option<StatefulCommand>,
+    now: ClockValue,
+) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
+    check_command_permission(stateful_command_permission, now)?;
+    let rp_id = if let Some(StatefulCommand::EnumerateRps(rp_ids)) = stateful_command_type {
+        rp_ids.pop().ok_or(Ctap2StatusCode::CTAP2_ERR_NOT_ALLOWED)?
+    } else {
+        return Err(Ctap2StatusCode::CTAP2_ERR_NOT_ALLOWED);
+    };
+    enumerate_rps_response(Some(rp_id), None)
+}
+
+fn process_enumerate_credentials_begin(
+    persistent_store: &PersistentStore,
+    stateful_command_permission: &mut TimedPermission,
+    stateful_command_type: &mut Option<StatefulCommand>,
+    sub_command_params: CredentialManagementSubCommandParameters,
+    now: ClockValue,
+) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
+    let rp_id_hash = sub_command_params
+        .rp_id_hash
+        .ok_or(Ctap2StatusCode::CTAP2_ERR_NO_CREDENTIALS)?;
+    // TODO(kaczmarczyck) filter by rp_id_hash inside of storage?
+    let mut rp_credentials: Vec<PublicKeyCredentialSource> = persistent_store
+        .all_credentials()?
+        .into_iter()
+        .filter(|cred| {
+            let cred_rp_id_hash = Sha256::hash(cred.rp_id.as_bytes());
+            rp_id_hash == cred_rp_id_hash
+        })
+        .collect();
+    let total_credentials = rp_credentials.len();
+
+    let credential = rp_credentials
+        .pop()
+        .ok_or(Ctap2StatusCode::CTAP2_ERR_NO_CREDENTIALS)?;
+    if total_credentials > 1 {
+        *stateful_command_permission =
+            TimedPermission::granted(now, STATEFUL_COMMAND_TIMEOUT_DURATION);
+        *stateful_command_type = Some(StatefulCommand::EnumerateCredentials(rp_credentials));
+    }
+    enumerate_credentials_response(credential, Some(total_credentials as u64))
+}
+
+fn process_enumerate_credentials_get_next_credential(
+    stateful_command_permission: &mut TimedPermission,
+    mut stateful_command_type: &mut Option<StatefulCommand>,
+    now: ClockValue,
+) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
+    check_command_permission(stateful_command_permission, now)?;
+    let credential = if let Some(StatefulCommand::EnumerateCredentials(rp_credentials)) =
+        &mut stateful_command_type
+    {
+        rp_credentials
+            .pop()
+            .ok_or(Ctap2StatusCode::CTAP2_ERR_NOT_ALLOWED)?
+    } else {
+        return Err(Ctap2StatusCode::CTAP2_ERR_NOT_ALLOWED);
+    };
+    enumerate_credentials_response(credential, None)
+}
+
+fn process_delete_credential(
+    persistent_store: &mut PersistentStore,
+    sub_command_params: CredentialManagementSubCommandParameters,
+) -> Result<(), Ctap2StatusCode> {
+    let credential_id = sub_command_params
+        .credential_id
+        .ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?
+        .key_id;
+    persistent_store.delete_credential(&credential_id)
+}
+
+fn process_update_user_information(
+    persistent_store: &mut PersistentStore,
+    sub_command_params: CredentialManagementSubCommandParameters,
+) -> Result<(), Ctap2StatusCode> {
+    let credential_id = sub_command_params
+        .credential_id
+        .ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?
+        .key_id;
+    let user = sub_command_params
+        .user
+        .ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?;
+    persistent_store.update_credential(&credential_id, user)
+}
+
+fn pin_uv_auth_protocol_check(pin_uv_auth_protocol: Option<u64>) -> Result<(), Ctap2StatusCode> {
+    match pin_uv_auth_protocol {
+        Some(1) => Ok(()),
+        Some(_) => Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID),
+        None => Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID),
+    }
+}
+
+pub fn process_credential_management_subcommand(
+    persistent_store: &mut PersistentStore,
+    stateful_command_permission: &mut TimedPermission,
+    mut stateful_command_type: &mut Option<StatefulCommand>,
+    pin_protocol_v1: &mut PinProtocolV1,
+    cred_management_params: AuthenticatorCredentialManagementParameters,
+    now: ClockValue,
+) -> Result<ResponseData, Ctap2StatusCode> {
+    let AuthenticatorCredentialManagementParameters {
+        sub_command,
+        sub_command_params,
+        pin_protocol,
+        pin_auth,
+    } = cred_management_params;
+
+    match (sub_command, &mut stateful_command_type) {
+        (
+            CredentialManagementSubCommand::EnumerateRpsGetNextRp,
+            Some(StatefulCommand::EnumerateRps(_)),
+        ) => (),
+        (
+            CredentialManagementSubCommand::EnumerateCredentialsGetNextCredential,
+            Some(StatefulCommand::EnumerateCredentials(_)),
+        ) => (),
+        (_, _) => {
+            *stateful_command_type = None;
+        }
+    }
+
+    match sub_command {
+        CredentialManagementSubCommand::GetCredsMetadata
+        | CredentialManagementSubCommand::EnumerateRpsBegin
+        | CredentialManagementSubCommand::DeleteCredential
+        | CredentialManagementSubCommand::EnumerateCredentialsBegin
+        | CredentialManagementSubCommand::UpdateUserInformation => {
+            pin_uv_auth_protocol_check(pin_protocol)?;
+            persistent_store
+                .pin_hash()?
+                .ok_or(Ctap2StatusCode::CTAP2_ERR_PIN_REQUIRED)?;
+            let pin_auth = pin_auth.ok_or(Ctap2StatusCode::CTAP2_ERR_PIN_REQUIRED)?;
+            let mut management_data = vec![sub_command as u8];
+            if let Some(sub_command_params) = sub_command_params.clone() {
+                if !cbor::write(sub_command_params.into(), &mut management_data) {
+                    return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
+                }
+            }
+            if !pin_protocol_v1.verify_pin_auth_token(&management_data, &pin_auth) {
+                return Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID);
+            }
+            pin_protocol_v1.has_permission(PinPermission::CredentialManagement)?;
+            pin_protocol_v1.has_no_permission_rp_id()?;
+            // TODO(kaczmarczyck) sometimes allow a RP ID
+        }
+        CredentialManagementSubCommand::EnumerateRpsGetNextRp
+        | CredentialManagementSubCommand::EnumerateCredentialsGetNextCredential => {}
+    }
+
+    let response = match sub_command {
+        CredentialManagementSubCommand::GetCredsMetadata => {
+            Some(process_get_creds_metadata(persistent_store)?)
+        }
+        CredentialManagementSubCommand::EnumerateRpsBegin => Some(process_enumerate_rps_begin(
+            persistent_store,
+            stateful_command_permission,
+            stateful_command_type,
+            now,
+        )?),
+        CredentialManagementSubCommand::EnumerateRpsGetNextRp => {
+            Some(process_enumerate_rps_get_next_rp(
+                stateful_command_permission,
+                stateful_command_type,
+                now,
+            )?)
+        }
+        CredentialManagementSubCommand::EnumerateCredentialsBegin => {
+            Some(process_enumerate_credentials_begin(
+                persistent_store,
+                stateful_command_permission,
+                stateful_command_type,
+                sub_command_params.ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?,
+                now,
+            )?)
+        }
+        CredentialManagementSubCommand::EnumerateCredentialsGetNextCredential => {
+            Some(process_enumerate_credentials_get_next_credential(
+                stateful_command_permission,
+                stateful_command_type,
+                now,
+            )?)
+        }
+        CredentialManagementSubCommand::DeleteCredential => {
+            process_delete_credential(
+                persistent_store,
+                sub_command_params.ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?,
+            )?;
+            None
+        }
+        CredentialManagementSubCommand::UpdateUserInformation => {
+            process_update_user_information(
+                persistent_store,
+                sub_command_params.ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?,
+            )?;
+            None
+        }
+    };
+    Ok(ResponseData::AuthenticatorCredentialManagement(response))
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::data_formats::PublicKeyCredentialType;
+    use super::super::CtapState;
+    use super::*;
+    use crypto::rng256::{Rng256, ThreadRng256};
+
+    const CLOCK_FREQUENCY_HZ: usize = 32768;
+    const DUMMY_CLOCK_VALUE: ClockValue = ClockValue::new(0, CLOCK_FREQUENCY_HZ);
+
+    fn create_credential_source(rng: &mut impl Rng256) -> PublicKeyCredentialSource {
+        let private_key = crypto::ecdsa::SecKey::gensk(rng);
+        PublicKeyCredentialSource {
+            key_type: PublicKeyCredentialType::PublicKey,
+            credential_id: rng.gen_uniform_u8x32().to_vec(),
+            private_key,
+            rp_id: String::from("example.com"),
+            user_handle: vec![0x01],
+            user_display_name: Some("display_name".to_string()),
+            cred_protect_policy: None,
+            creation_order: 0,
+            user_name: Some("name".to_string()),
+            user_icon: Some("icon".to_string()),
+        }
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    #[test]
+    fn test_process_get_creds_metadata() {
+        let mut rng = ThreadRng256 {};
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let pin_uv_auth_token = [0x55; 32];
+        let pin_protocol_v1 = PinProtocolV1::new_test(key_agreement_key, pin_uv_auth_token);
+        let credential_source = create_credential_source(&mut rng);
+
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        ctap_state.pin_protocol_v1 = pin_protocol_v1;
+
+        ctap_state
+            .persistent_store
+            .set_pin_hash(&[0u8; 16])
+            .unwrap();
+        let pin_auth = Some(vec![
+            0xC5, 0xFB, 0x75, 0x55, 0x98, 0xB5, 0x19, 0x01, 0xB3, 0x31, 0x7D, 0xFE, 0x1D, 0xF5,
+            0xFB, 0x00,
+        ]);
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::GetCredsMetadata,
+            sub_command_params: None,
+            pin_protocol: Some(1),
+            pin_auth: pin_auth.clone(),
+        };
+        let cred_management_response = process_credential_management_subcommand(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        let initial_capacity = match cred_management_response.unwrap() {
+            ResponseData::AuthenticatorCredentialManagement(Some(response)) => {
+                assert_eq!(response.existing_resident_credentials_count, Some(0));
+                response
+                    .max_possible_remaining_resident_credentials_count
+                    .unwrap()
+            }
+            _ => panic!("Invalid response type"),
+        };
+
+        ctap_state
+            .persistent_store
+            .store_credential(credential_source)
+            .unwrap();
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::GetCredsMetadata,
+            sub_command_params: None,
+            pin_protocol: Some(1),
+            pin_auth,
+        };
+        let cred_management_response = process_credential_management_subcommand(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        match cred_management_response.unwrap() {
+            ResponseData::AuthenticatorCredentialManagement(Some(response)) => {
+                assert_eq!(response.existing_resident_credentials_count, Some(1));
+                assert_eq!(
+                    response.max_possible_remaining_resident_credentials_count,
+                    Some(initial_capacity - 1)
+                );
+            }
+            _ => panic!("Invalid response type"),
+        };
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    #[test]
+    fn test_process_enumerate_rps_with_uv() {
+        let mut rng = ThreadRng256 {};
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let pin_uv_auth_token = [0x55; 32];
+        let pin_protocol_v1 = PinProtocolV1::new_test(key_agreement_key, pin_uv_auth_token);
+        let credential_source1 = create_credential_source(&mut rng);
+        let mut credential_source2 = create_credential_source(&mut rng);
+        credential_source2.rp_id = "another.example.com".to_string();
+
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        ctap_state.pin_protocol_v1 = pin_protocol_v1;
+
+        ctap_state
+            .persistent_store
+            .store_credential(credential_source1)
+            .unwrap();
+        ctap_state
+            .persistent_store
+            .store_credential(credential_source2)
+            .unwrap();
+
+        ctap_state
+            .persistent_store
+            .set_pin_hash(&[0u8; 16])
+            .unwrap();
+        let pin_auth = Some(vec![
+            0x1A, 0xA4, 0x96, 0xDA, 0x62, 0x80, 0x28, 0x13, 0xEB, 0x32, 0xB9, 0xF1, 0xD2, 0xA9,
+            0xD0, 0xD1,
+        ]);
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::EnumerateRpsBegin,
+            sub_command_params: None,
+            pin_protocol: Some(1),
+            pin_auth,
+        };
+        let cred_management_response = process_credential_management_subcommand(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        let first_rp_id = match cred_management_response.unwrap() {
+            ResponseData::AuthenticatorCredentialManagement(Some(response)) => {
+                assert_eq!(response.total_rps, Some(2));
+                let rp_id = response.rp.unwrap().rp_id;
+                let rp_id_hash = Sha256::hash(rp_id.as_bytes());
+                assert_eq!(rp_id_hash, response.rp_id_hash.unwrap().as_slice());
+                rp_id
+            }
+            _ => panic!("Invalid response type"),
+        };
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::EnumerateRpsGetNextRp,
+            sub_command_params: None,
+            pin_protocol: None,
+            pin_auth: None,
+        };
+        let cred_management_response = process_credential_management_subcommand(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        let second_rp_id = match cred_management_response.unwrap() {
+            ResponseData::AuthenticatorCredentialManagement(Some(response)) => {
+                assert_eq!(response.total_rps, None);
+                let rp_id = response.rp.unwrap().rp_id;
+                let rp_id_hash = Sha256::hash(rp_id.as_bytes());
+                assert_eq!(rp_id_hash, response.rp_id_hash.unwrap().as_slice());
+                rp_id
+            }
+            _ => panic!("Invalid response type"),
+        };
+
+        assert!(first_rp_id != second_rp_id);
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::EnumerateRpsGetNextRp,
+            sub_command_params: None,
+            pin_protocol: None,
+            pin_auth: None,
+        };
+        let cred_management_response = process_credential_management_subcommand(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        assert_eq!(
+            cred_management_response,
+            Err(Ctap2StatusCode::CTAP2_ERR_NOT_ALLOWED)
+        );
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    #[test]
+    fn test_process_enumerate_credentials_with_uv() {
+        let mut rng = ThreadRng256 {};
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let pin_uv_auth_token = [0x55; 32];
+        let pin_protocol_v1 = PinProtocolV1::new_test(key_agreement_key, pin_uv_auth_token);
+        let credential_source1 = create_credential_source(&mut rng);
+        let mut credential_source2 = create_credential_source(&mut rng);
+        credential_source2.user_handle = vec![0x02];
+        credential_source2.user_name = Some("user2".to_string());
+        credential_source2.user_display_name = Some("User Two".to_string());
+        credential_source2.user_icon = Some("icon2".to_string());
+
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        ctap_state.pin_protocol_v1 = pin_protocol_v1;
+
+        ctap_state
+            .persistent_store
+            .store_credential(credential_source1)
+            .unwrap();
+        ctap_state
+            .persistent_store
+            .store_credential(credential_source2)
+            .unwrap();
+
+        ctap_state
+            .persistent_store
+            .set_pin_hash(&[0u8; 16])
+            .unwrap();
+        let pin_auth = Some(vec![
+            0xF8, 0xB0, 0x3C, 0xC1, 0xD5, 0x58, 0x9C, 0xB7, 0x4D, 0x42, 0xA1, 0x64, 0x14, 0x28,
+            0x2B, 0x68,
+        ]);
+
+        let sub_command_params = CredentialManagementSubCommandParameters {
+            rp_id_hash: Some(Sha256::hash(b"example.com").to_vec()),
+            credential_id: None,
+            user: None,
+        };
+        // RP ID hash:
+        // A379A6F6EEAFB9A55E378C118034E2751E682FAB9F2D30AB13D2125586CE1947
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::EnumerateCredentialsBegin,
+            sub_command_params: Some(sub_command_params),
+            pin_protocol: Some(1),
+            pin_auth,
+        };
+        let cred_management_response = process_credential_management_subcommand(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        let first_credential_id = match cred_management_response.unwrap() {
+            ResponseData::AuthenticatorCredentialManagement(Some(response)) => {
+                assert!(response.user.is_some());
+                assert!(response.public_key.is_some());
+                assert_eq!(response.total_credentials, Some(2));
+                response.credential_id.unwrap().key_id
+            }
+            _ => panic!("Invalid response type"),
+        };
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::EnumerateCredentialsGetNextCredential,
+            sub_command_params: None,
+            pin_protocol: None,
+            pin_auth: None,
+        };
+        let cred_management_response = process_credential_management_subcommand(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        let second_credential_id = match cred_management_response.unwrap() {
+            ResponseData::AuthenticatorCredentialManagement(Some(response)) => {
+                assert!(response.user.is_some());
+                assert!(response.public_key.is_some());
+                assert_eq!(response.total_credentials, None);
+                response.credential_id.unwrap().key_id
+            }
+            _ => panic!("Invalid response type"),
+        };
+
+        assert!(first_credential_id != second_credential_id);
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::EnumerateCredentialsGetNextCredential,
+            sub_command_params: None,
+            pin_protocol: None,
+            pin_auth: None,
+        };
+        let cred_management_response = process_credential_management_subcommand(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        assert_eq!(
+            cred_management_response,
+            Err(Ctap2StatusCode::CTAP2_ERR_NOT_ALLOWED)
+        );
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    #[test]
+    fn test_process_delete_credential() {
+        let mut rng = ThreadRng256 {};
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let pin_uv_auth_token = [0x55; 32];
+        let pin_protocol_v1 = PinProtocolV1::new_test(key_agreement_key, pin_uv_auth_token);
+        let mut credential_source = create_credential_source(&mut rng);
+        credential_source.credential_id = vec![0x1D; 32];
+
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        ctap_state.pin_protocol_v1 = pin_protocol_v1;
+
+        ctap_state
+            .persistent_store
+            .store_credential(credential_source)
+            .unwrap();
+
+        ctap_state
+            .persistent_store
+            .set_pin_hash(&[0u8; 16])
+            .unwrap();
+        let pin_auth = Some(vec![
+            0xBD, 0xE3, 0xEF, 0x8A, 0x77, 0x01, 0xB1, 0x69, 0x19, 0xE6, 0x62, 0xB9, 0x9B, 0x89,
+            0x9C, 0x64,
+        ]);
+
+        let credential_id = PublicKeyCredentialDescriptor {
+            key_type: PublicKeyCredentialType::PublicKey,
+            key_id: vec![0x1D; 32],
+            transports: None, // You can set USB as a hint here.
+        };
+        let sub_command_params = CredentialManagementSubCommandParameters {
+            rp_id_hash: None,
+            credential_id: Some(credential_id),
+            user: None,
+        };
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::DeleteCredential,
+            sub_command_params: Some(sub_command_params.clone()),
+            pin_protocol: Some(1),
+            pin_auth: pin_auth.clone(),
+        };
+        let cred_management_response = process_credential_management_subcommand(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        assert_eq!(
+            cred_management_response,
+            Ok(ResponseData::AuthenticatorCredentialManagement(None))
+        );
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::DeleteCredential,
+            sub_command_params: Some(sub_command_params),
+            pin_protocol: Some(1),
+            pin_auth,
+        };
+        let cred_management_response = process_credential_management_subcommand(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        assert_eq!(
+            cred_management_response,
+            Err(Ctap2StatusCode::CTAP2_ERR_NO_CREDENTIALS)
+        );
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    #[test]
+    fn test_process_update_user_information() {
+        let mut rng = ThreadRng256 {};
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let pin_uv_auth_token = [0x55; 32];
+        let pin_protocol_v1 = PinProtocolV1::new_test(key_agreement_key, pin_uv_auth_token);
+        let mut credential_source = create_credential_source(&mut rng);
+        credential_source.credential_id = vec![0x1D; 32];
+
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        ctap_state.pin_protocol_v1 = pin_protocol_v1;
+
+        ctap_state
+            .persistent_store
+            .store_credential(credential_source)
+            .unwrap();
+
+        ctap_state
+            .persistent_store
+            .set_pin_hash(&[0u8; 16])
+            .unwrap();
+        let pin_auth = Some(vec![
+            0xA5, 0x55, 0x8F, 0x03, 0xC3, 0xD3, 0x73, 0x1C, 0x07, 0xDA, 0x1F, 0x8C, 0xC7, 0xBD,
+            0x9D, 0xB7,
+        ]);
+
+        let credential_id = PublicKeyCredentialDescriptor {
+            key_type: PublicKeyCredentialType::PublicKey,
+            key_id: vec![0x1D; 32],
+            transports: None, // You can set USB as a hint here.
+        };
+        let new_user = PublicKeyCredentialUserEntity {
+            user_id: vec![0xFF],
+            user_name: Some("new_name".to_string()),
+            user_display_name: Some("new_display_name".to_string()),
+            user_icon: Some("new_icon".to_string()),
+        };
+        let sub_command_params = CredentialManagementSubCommandParameters {
+            rp_id_hash: None,
+            credential_id: Some(credential_id),
+            user: Some(new_user.clone()),
+        };
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::UpdateUserInformation,
+            sub_command_params: Some(sub_command_params.clone()),
+            pin_protocol: Some(1),
+            pin_auth: pin_auth.clone(),
+        };
+        let cred_management_response = process_credential_management_subcommand(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        assert_eq!(
+            cred_management_response,
+            Ok(ResponseData::AuthenticatorCredentialManagement(None))
+        );
+
+        let updated_credential = ctap_state
+            .persistent_store
+            .find_credential("example.com", &[0x1D; 32], false)
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated_credential.user_handle, vec![0x01]);
+        assert_eq!(&updated_credential.user_name.unwrap(), "new_name");
+        assert_eq!(
+            &updated_credential.user_display_name.unwrap(),
+            "new_display_name"
+        );
+        assert_eq!(&updated_credential.user_icon.unwrap(), "new_icon");
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    #[test]
+    fn test_process_credential_management_invalid_pin_protocol() {
+        let mut rng = ThreadRng256 {};
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let pin_uv_auth_token = [0x55; 32];
+        let pin_protocol_v1 = PinProtocolV1::new_test(key_agreement_key, pin_uv_auth_token);
+
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        ctap_state.pin_protocol_v1 = pin_protocol_v1;
+
+        ctap_state
+            .persistent_store
+            .set_pin_hash(&[0u8; 16])
+            .unwrap();
+        let pin_auth = Some(vec![
+            0xC5, 0xFB, 0x75, 0x55, 0x98, 0xB5, 0x19, 0x01, 0xB3, 0x31, 0x7D, 0xFE, 0x1D, 0xF5,
+            0xFB, 0x00,
+        ]);
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::GetCredsMetadata,
+            sub_command_params: None,
+            pin_protocol: Some(123456),
+            pin_auth,
+        };
+        let cred_management_response = process_credential_management_subcommand(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        assert_eq!(
+            cred_management_response,
+            Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
+        );
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    #[test]
+    fn test_process_credential_management_invalid_pin_auth() {
+        let mut rng = ThreadRng256 {};
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+
+        ctap_state
+            .persistent_store
+            .set_pin_hash(&[0u8; 16])
+            .unwrap();
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::GetCredsMetadata,
+            sub_command_params: None,
+            pin_protocol: Some(1),
+            pin_auth: Some(vec![0u8; 16]),
+        };
+        let cred_management_response = process_credential_management_subcommand(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        assert_eq!(
+            cred_management_response,
+            Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
+        );
+    }
+}

--- a/src/ctap/credential_management.rs
+++ b/src/ctap/credential_management.rs
@@ -33,6 +33,7 @@ use crypto::sha256::Sha256;
 use crypto::Hash256;
 use libtock_drivers::timer::ClockValue;
 
+/// Generates the response for subcommands enumerating RPs.
 fn enumerate_rps_response(
     rp_id: Option<String>,
     total_rps: Option<u64>,
@@ -59,6 +60,7 @@ fn enumerate_rps_response(
     })
 }
 
+/// Generates the response for subcommands enumerating credentials.
 fn enumerate_credentials_response(
     credential: PublicKeyCredentialSource,
     total_credentials: Option<u64>,
@@ -103,6 +105,7 @@ fn enumerate_credentials_response(
     })
 }
 
+/// Processes the subcommand getCredsMetadata for CredentialManagement.
 fn process_get_creds_metadata(
     persistent_store: &PersistentStore,
 ) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
@@ -123,6 +126,7 @@ fn process_get_creds_metadata(
     })
 }
 
+/// Processes the subcommand enumerateRPsBegin for CredentialManagement.
 fn process_enumerate_rps_begin(
     persistent_store: &PersistentStore,
     stateful_command_permission: &mut TimedPermission,
@@ -147,6 +151,7 @@ fn process_enumerate_rps_begin(
     enumerate_rps_response(rp_id, Some(total_rps as u64))
 }
 
+/// Processes the subcommand enumerateRPsGetNextRP for CredentialManagement.
 fn process_enumerate_rps_get_next_rp(
     stateful_command_permission: &mut TimedPermission,
     stateful_command_type: &mut Option<StatefulCommand>,
@@ -161,6 +166,7 @@ fn process_enumerate_rps_get_next_rp(
     enumerate_rps_response(Some(rp_id), None)
 }
 
+/// Processes the subcommand enumerateCredentialsBegin for CredentialManagement.
 fn process_enumerate_credentials_begin(
     persistent_store: &PersistentStore,
     stateful_command_permission: &mut TimedPermission,
@@ -193,6 +199,7 @@ fn process_enumerate_credentials_begin(
     enumerate_credentials_response(credential, Some(total_credentials as u64))
 }
 
+/// Processes the subcommand enumerateCredentialsGetNextCredential for CredentialManagement.
 fn process_enumerate_credentials_get_next_credential(
     stateful_command_permission: &mut TimedPermission,
     mut stateful_command_type: &mut Option<StatefulCommand>,
@@ -211,6 +218,7 @@ fn process_enumerate_credentials_get_next_credential(
     enumerate_credentials_response(credential, None)
 }
 
+/// Processes the subcommand deleteCredential for CredentialManagement.
 fn process_delete_credential(
     persistent_store: &mut PersistentStore,
     sub_command_params: CredentialManagementSubCommandParameters,
@@ -222,6 +230,7 @@ fn process_delete_credential(
     persistent_store.delete_credential(&credential_id)
 }
 
+/// Processes the subcommand updateUserInformation for CredentialManagement.
 fn process_update_user_information(
     persistent_store: &mut PersistentStore,
     sub_command_params: CredentialManagementSubCommandParameters,
@@ -236,6 +245,9 @@ fn process_update_user_information(
     persistent_store.update_credential(&credential_id, user)
 }
 
+/// Checks the PIN protocol.
+///
+/// TODO(#246) refactor after #246 is merged
 fn pin_uv_auth_protocol_check(pin_uv_auth_protocol: Option<u64>) -> Result<(), Ctap2StatusCode> {
     match pin_uv_auth_protocol {
         Some(1) => Ok(()),
@@ -244,6 +256,7 @@ fn pin_uv_auth_protocol_check(pin_uv_auth_protocol: Option<u64>) -> Result<(), C
     }
 }
 
+/// Processes the CredentialManagement command and all its subcommands.
 pub fn process_credential_management_subcommand(
     persistent_store: &mut PersistentStore,
     stateful_command_permission: &mut TimedPermission,

--- a/src/ctap/data_formats.rs
+++ b/src/ctap/data_formats.rs
@@ -56,7 +56,8 @@ impl TryFrom<cbor::Value> for PublicKeyCredentialRpEntity {
 }
 
 // https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialuserentity
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Clone, Debug, PartialEq))]
+#[derive(Clone)]
+#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
 pub struct PublicKeyCredentialUserEntity {
     pub user_id: Vec<u8>,
     pub user_name: Option<String>,
@@ -170,7 +171,8 @@ impl From<PublicKeyCredentialParameter> for cbor::Value {
 }
 
 // https://www.w3.org/TR/webauthn/#enumdef-authenticatortransport
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Clone, Debug, PartialEq))]
+#[derive(Clone)]
+#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
 #[cfg_attr(test, derive(IntoEnumIterator))]
 pub enum AuthenticatorTransport {
     Usb,
@@ -207,7 +209,8 @@ impl TryFrom<cbor::Value> for AuthenticatorTransport {
 }
 
 // https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialdescriptor
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Clone, Debug, PartialEq))]
+#[derive(Clone)]
+#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
 pub struct PublicKeyCredentialDescriptor {
     pub key_type: PublicKeyCredentialType,
     pub key_id: Vec<u8>,
@@ -743,6 +746,93 @@ impl TryFrom<cbor::Value> for ClientPinSubCommand {
             _ => Err(Ctap2StatusCode::CTAP2_ERR_INVALID_SUBCOMMAND),
             #[cfg(not(feature = "with_ctap2_1"))]
             _ => Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER),
+        }
+    }
+}
+
+#[cfg(feature = "with_ctap2_1")]
+#[cfg_attr(any(test, feature = "debug_ctap"), derive(Clone, Debug, PartialEq))]
+#[cfg_attr(test, derive(IntoEnumIterator))]
+pub enum CredentialManagementSubCommand {
+    GetCredsMetadata = 0x01,
+    EnumerateRpsBegin = 0x02,
+    EnumerateRpsGetNextRp = 0x03,
+    EnumerateCredentialsBegin = 0x04,
+    EnumerateCredentialsGetNextCredential = 0x05,
+    DeleteCredential = 0x06,
+    UpdateUserInformation = 0x07,
+}
+
+#[cfg(feature = "with_ctap2_1")]
+impl From<CredentialManagementSubCommand> for cbor::Value {
+    fn from(subcommand: CredentialManagementSubCommand) -> Self {
+        (subcommand as u64).into()
+    }
+}
+
+#[cfg(feature = "with_ctap2_1")]
+impl TryFrom<cbor::Value> for CredentialManagementSubCommand {
+    type Error = Ctap2StatusCode;
+
+    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+        let subcommand_int = extract_unsigned(cbor_value)?;
+        match subcommand_int {
+            0x01 => Ok(CredentialManagementSubCommand::GetCredsMetadata),
+            0x02 => Ok(CredentialManagementSubCommand::EnumerateRpsBegin),
+            0x03 => Ok(CredentialManagementSubCommand::EnumerateRpsGetNextRp),
+            0x04 => Ok(CredentialManagementSubCommand::EnumerateCredentialsBegin),
+            0x05 => Ok(CredentialManagementSubCommand::EnumerateCredentialsGetNextCredential),
+            0x06 => Ok(CredentialManagementSubCommand::DeleteCredential),
+            0x07 => Ok(CredentialManagementSubCommand::UpdateUserInformation),
+            _ => Err(Ctap2StatusCode::CTAP2_ERR_INVALID_SUBCOMMAND),
+        }
+    }
+}
+
+#[cfg(feature = "with_ctap2_1")]
+#[derive(Clone)]
+#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+pub struct CredentialManagementSubCommandParameters {
+    pub rp_id_hash: Option<Vec<u8>>,
+    pub credential_id: Option<PublicKeyCredentialDescriptor>,
+    pub user: Option<PublicKeyCredentialUserEntity>,
+}
+
+#[cfg(feature = "with_ctap2_1")]
+impl TryFrom<cbor::Value> for CredentialManagementSubCommandParameters {
+    type Error = Ctap2StatusCode;
+
+    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+        destructure_cbor_map! {
+            let {
+                0x01 => rp_id_hash,
+                0x02 => credential_id,
+                0x03 => user,
+            } = extract_map(cbor_value)?;
+        }
+
+        let rp_id_hash = rp_id_hash.map(extract_byte_string).transpose()?;
+        let credential_id = credential_id
+            .map(PublicKeyCredentialDescriptor::try_from)
+            .transpose()?;
+        let user = user
+            .map(PublicKeyCredentialUserEntity::try_from)
+            .transpose()?;
+        Ok(Self {
+            rp_id_hash,
+            credential_id,
+            user,
+        })
+    }
+}
+
+#[cfg(feature = "with_ctap2_1")]
+impl From<CredentialManagementSubCommandParameters> for cbor::Value {
+    fn from(sub_command_params: CredentialManagementSubCommandParameters) -> Self {
+        cbor_map_options! {
+            0x01 => sub_command_params.rp_id_hash,
+            0x02 => sub_command_params.credential_id,
+            0x03 => sub_command_params.user,
         }
     }
 }
@@ -1356,6 +1446,54 @@ mod test {
             let reconstructed = ClientPinSubCommand::try_from(created_cbor).unwrap();
             assert_eq!(command, reconstructed);
         }
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    #[test]
+    fn test_from_into_cred_management_sub_command() {
+        let cbor_sub_command: cbor::Value = cbor_int!(0x01);
+        let sub_command = CredentialManagementSubCommand::try_from(cbor_sub_command.clone());
+        let expected_sub_command = CredentialManagementSubCommand::GetCredsMetadata;
+        assert_eq!(sub_command, Ok(expected_sub_command));
+        let created_cbor: cbor::Value = sub_command.unwrap().into();
+        assert_eq!(created_cbor, cbor_sub_command);
+
+        for command in CredentialManagementSubCommand::into_enum_iter() {
+            let created_cbor: cbor::Value = command.clone().into();
+            let reconstructed = CredentialManagementSubCommand::try_from(created_cbor).unwrap();
+            assert_eq!(command, reconstructed);
+        }
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    #[test]
+    fn test_from_into_cred_management_sub_command_params() {
+        let credential_id = PublicKeyCredentialDescriptor {
+            key_type: PublicKeyCredentialType::PublicKey,
+            key_id: vec![0x2D, 0x2D, 0x2D, 0x2D],
+            transports: Some(vec![AuthenticatorTransport::Usb]),
+        };
+        let user_entity = PublicKeyCredentialUserEntity {
+            user_id: vec![0x1D, 0x1D, 0x1D, 0x1D],
+            user_name: Some("foo".to_string()),
+            user_display_name: Some("bar".to_string()),
+            user_icon: Some("example.com/foo/icon.png".to_string()),
+        };
+        let cbor_sub_command_params = cbor_map! {
+            0x01 => vec![0x1D; 32],
+            0x02 => credential_id.clone(),
+            0x03 => user_entity.clone(),
+        };
+        let sub_command_params =
+            CredentialManagementSubCommandParameters::try_from(cbor_sub_command_params.clone());
+        let expected_sub_command_params = CredentialManagementSubCommandParameters {
+            rp_id_hash: Some(vec![0x1D; 32]),
+            credential_id: Some(credential_id),
+            user: Some(user_entity),
+        };
+        assert_eq!(sub_command_params, Ok(expected_sub_command_params));
+        let created_cbor: cbor::Value = sub_command_params.unwrap().into();
+        assert_eq!(created_cbor, cbor_sub_command_params);
     }
 
     #[test]

--- a/src/ctap/data_formats.rs
+++ b/src/ctap/data_formats.rs
@@ -25,6 +25,7 @@ use enum_iterator::IntoEnumIterator;
 
 // https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialrpentity
 #[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[cfg_attr(all(test, feature = "with_ctap2_1"), derive(Clone))]
 pub struct PublicKeyCredentialRpEntity {
     pub rp_id: String,
     pub rp_name: Option<String>,
@@ -52,6 +53,17 @@ impl TryFrom<cbor::Value> for PublicKeyCredentialRpEntity {
             rp_name,
             rp_icon,
         })
+    }
+}
+
+#[cfg(feature = "with_ctap2_1")]
+impl From<PublicKeyCredentialRpEntity> for cbor::Value {
+    fn from(entity: PublicKeyCredentialRpEntity) -> Self {
+        cbor_map_options! {
+            "id" => entity.rp_id,
+            "name" => entity.rp_name,
+            "icon" => entity.rp_icon,
+        }
     }
 }
 

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -32,9 +32,12 @@ use self::command::{
 #[cfg(feature = "with_ctap2_1")]
 use self::command::{AuthenticatorCredentialManagementParameters, MAX_CREDENTIAL_COUNT_IN_LIST};
 #[cfg(feature = "with_ctap2_1")]
-use self::data_formats::AuthenticatorTransport;
 use self::data_formats::{
-    CredentialProtectionPolicy, GetAssertionHmacSecretInput, PackedAttestationStatement,
+    AuthenticatorTransport, CredentialManagementSubCommand,
+    CredentialManagementSubCommandParameters, PublicKeyCredentialRpEntity,
+};
+use self::data_formats::{
+    CoseKey, CredentialProtectionPolicy, GetAssertionHmacSecretInput, PackedAttestationStatement,
     PublicKeyCredentialDescriptor, PublicKeyCredentialParameter, PublicKeyCredentialSource,
     PublicKeyCredentialType, PublicKeyCredentialUserEntity, SignatureAlgorithm,
 };
@@ -42,6 +45,8 @@ use self::hid::ChannelID;
 #[cfg(feature = "with_ctap2_1")]
 use self::pin_protocol_v1::PinPermission;
 use self::pin_protocol_v1::PinProtocolV1;
+#[cfg(feature = "with_ctap2_1")]
+use self::response::AuthenticatorCredentialManagementResponse;
 use self::response::{
     AuthenticatorGetAssertionResponse, AuthenticatorGetInfoResponse,
     AuthenticatorMakeCredentialResponse, AuthenticatorVendorResponse, ResponseData,
@@ -52,6 +57,8 @@ use self::timed_permission::TimedPermission;
 #[cfg(feature = "with_ctap1")]
 use self::timed_permission::U2fUserPresenceState;
 use alloc::collections::BTreeMap;
+#[cfg(feature = "with_ctap2_1")]
+use alloc::collections::BTreeSet;
 use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
@@ -60,6 +67,8 @@ use byteorder::{BigEndian, ByteOrder};
 use cbor::{cbor_map, cbor_map_options};
 #[cfg(feature = "debug_ctap")]
 use core::fmt::Write;
+#[cfg(feature = "with_ctap2_1")]
+use core::iter::FromIterator;
 use crypto::cbc::{cbc_decrypt, cbc_encrypt};
 use crypto::hmac::{hmac_256, verify_hmac_256};
 use crypto::rng256::Rng256;
@@ -153,6 +162,82 @@ struct AssertionState {
 enum StatefulCommand {
     Reset,
     GetAssertion(AssertionState),
+    #[cfg(feature = "with_ctap2_1")]
+    EnumerateRps(Vec<String>),
+    #[cfg(feature = "with_ctap2_1")]
+    EnumerateCredentials(Vec<PublicKeyCredentialSource>),
+}
+
+#[cfg(feature = "with_ctap2_1")]
+fn enumerate_rps_response(
+    rp_id: Option<String>,
+    total_rps: Option<u64>,
+) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
+    let rp = rp_id.clone().map(|rp_id| PublicKeyCredentialRpEntity {
+        rp_id,
+        rp_name: None,
+        rp_icon: None,
+    });
+    let rp_id_hash = rp_id.map(|rp_id| Sha256::hash(rp_id.as_bytes()).to_vec());
+
+    Ok(AuthenticatorCredentialManagementResponse {
+        existing_resident_credentials_count: None,
+        max_possible_remaining_resident_credentials_count: None,
+        rp,
+        rp_id_hash,
+        total_rps,
+        user: None,
+        credential_id: None,
+        public_key: None,
+        total_credentials: None,
+        cred_protect: None,
+        large_blob_key: None,
+    })
+}
+
+#[cfg(feature = "with_ctap2_1")]
+fn enumerate_credentials_response(
+    credential: PublicKeyCredentialSource,
+    total_credentials: Option<u64>,
+) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
+    let PublicKeyCredentialSource {
+        key_type,
+        credential_id,
+        private_key,
+        rp_id: _,
+        user_handle,
+        user_display_name,
+        cred_protect_policy,
+        creation_order: _,
+        user_name,
+        user_icon,
+    } = credential;
+    let user = PublicKeyCredentialUserEntity {
+        user_id: user_handle,
+        user_name,
+        user_display_name,
+        user_icon,
+    };
+    let credential_id = PublicKeyCredentialDescriptor {
+        key_type,
+        key_id: credential_id,
+        transports: None, // You can set USB as a hint here.
+    };
+    let public_key = CoseKey::from(private_key.genpk());
+    Ok(AuthenticatorCredentialManagementResponse {
+        existing_resident_credentials_count: None,
+        max_possible_remaining_resident_credentials_count: None,
+        rp: None,
+        rp_id_hash: None,
+        total_rps: None,
+        user: Some(user),
+        credential_id: Some(credential_id),
+        public_key: Some(public_key),
+        total_credentials,
+        cred_protect: cred_protect_policy,
+        // TODO(kaczmarczyck) add when largeBlobKey is implemented
+        large_blob_key: None,
+    })
 }
 
 // This struct currently holds all state, not only the persistent memory. The persistent members are
@@ -336,6 +421,16 @@ where
                         Some(StatefulCommand::GetAssertion(_)),
                     ) => (),
                     (Command::AuthenticatorReset, Some(StatefulCommand::Reset)) => (),
+                    #[cfg(feature = "with_ctap2_1")]
+                    (
+                        Command::AuthenticatorCredentialManagement(_),
+                        Some(StatefulCommand::EnumerateRps(_)),
+                    ) => (),
+                    #[cfg(feature = "with_ctap2_1")]
+                    (
+                        Command::AuthenticatorCredentialManagement(_),
+                        Some(StatefulCommand::EnumerateCredentials(_)),
+                    ) => (),
                     // GetInfo does not reset stateful commands.
                     (Command::AuthenticatorGetInfo, _) => (),
                     // AuthenticatorSelection does not reset stateful commands.
@@ -358,7 +453,7 @@ where
                     Command::AuthenticatorReset => self.process_reset(cid, now),
                     #[cfg(feature = "with_ctap2_1")]
                     Command::AuthenticatorCredentialManagement(params) => {
-                        self.process_credential_management(params)
+                        self.process_credential_management(params, now)
                     }
                     #[cfg(feature = "with_ctap2_1")]
                     Command::AuthenticatorSelection => self.process_selection(cid),
@@ -550,11 +645,9 @@ where
         }
         auth_data.extend(vec![0x00, credential_id.len() as u8]);
         auth_data.extend(&credential_id);
-        let cose_key = match pk.to_cose_key() {
-            Some(cose_key) => cose_key,
-            None => return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_RESPONSE_CANNOT_WRITE_CBOR),
-        };
-        auth_data.extend(cose_key);
+        if !cbor::write(cbor::Value::Map(CoseKey::from(pk).0), &mut auth_data) {
+            return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
+        }
         if has_extension_output {
             let hmac_secret_output = if use_hmac_extension { Some(true) } else { None };
             let extensions_output = cbor_map_options! {
@@ -923,11 +1016,249 @@ where
     }
 
     #[cfg(feature = "with_ctap2_1")]
+    fn process_get_creds_metadata(
+        &mut self,
+    ) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
+        Ok(AuthenticatorCredentialManagementResponse {
+            existing_resident_credentials_count: Some(
+                self.persistent_store.count_credentials()? as u64
+            ),
+            max_possible_remaining_resident_credentials_count: Some(
+                self.persistent_store.remaining_credentials()? as u64,
+            ),
+            rp: None,
+            rp_id_hash: None,
+            total_rps: None,
+            user: None,
+            credential_id: None,
+            public_key: None,
+            total_credentials: None,
+            cred_protect: None,
+            large_blob_key: None,
+        })
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    fn process_enumerate_rps_begin(
+        &mut self,
+        now: ClockValue,
+    ) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
+        let credentials = self.persistent_store.all_credentials()?;
+        let mut rp_set = BTreeSet::new();
+        for cred in credentials {
+            rp_set.insert(cred.rp_id);
+        }
+        let mut rp_ids = Vec::from_iter(rp_set);
+        let total_rps = rp_ids.len();
+
+        // TODO(kaczmarczyck) behaviour with empty list?
+        let rp_id = rp_ids.pop();
+        if total_rps > 1 {
+            self.stateful_command_permission =
+                TimedPermission::granted(now, STATEFUL_COMMAND_TIMEOUT_DURATION);
+            self.stateful_command_type = Some(StatefulCommand::EnumerateRps(rp_ids));
+        }
+        enumerate_rps_response(rp_id, Some(total_rps as u64))
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    fn process_enumerate_rps_get_next_rp(
+        &mut self,
+        now: ClockValue,
+    ) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
+        self.check_command_permission(now)?;
+        let rp_id =
+            if let Some(StatefulCommand::EnumerateRps(rp_ids)) = &mut self.stateful_command_type {
+                rp_ids.pop().ok_or(Ctap2StatusCode::CTAP2_ERR_NOT_ALLOWED)?
+            } else {
+                return Err(Ctap2StatusCode::CTAP2_ERR_NOT_ALLOWED);
+            };
+        enumerate_rps_response(Some(rp_id), None)
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    fn process_enumerate_credentials_begin(
+        &mut self,
+        sub_command_params: CredentialManagementSubCommandParameters,
+        now: ClockValue,
+    ) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
+        let rp_id_hash = sub_command_params
+            .rp_id_hash
+            .ok_or(Ctap2StatusCode::CTAP2_ERR_NO_CREDENTIALS)?;
+        // TODO(kaczmarczyck) filter by rp_id_hash inside of storage?
+        let mut rp_credentials: Vec<PublicKeyCredentialSource> = self
+            .persistent_store
+            .all_credentials()?
+            .into_iter()
+            .filter(|cred| {
+                let cred_rp_id_hash = Sha256::hash(cred.rp_id.as_bytes());
+                rp_id_hash == cred_rp_id_hash
+            })
+            .collect();
+        let total_credentials = rp_credentials.len();
+
+        let credential = rp_credentials
+            .pop()
+            .ok_or(Ctap2StatusCode::CTAP2_ERR_NO_CREDENTIALS)?;
+        if total_credentials > 1 {
+            self.stateful_command_permission =
+                TimedPermission::granted(now, STATEFUL_COMMAND_TIMEOUT_DURATION);
+            self.stateful_command_type =
+                Some(StatefulCommand::EnumerateCredentials(rp_credentials));
+        }
+        enumerate_credentials_response(credential, Some(total_credentials as u64))
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    fn process_enumerate_credentials_get_next_credential(
+        &mut self,
+        now: ClockValue,
+    ) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
+        self.check_command_permission(now)?;
+        let credential = if let Some(StatefulCommand::EnumerateCredentials(rp_credentials)) =
+            &mut self.stateful_command_type
+        {
+            rp_credentials
+                .pop()
+                .ok_or(Ctap2StatusCode::CTAP2_ERR_NOT_ALLOWED)?
+        } else {
+            return Err(Ctap2StatusCode::CTAP2_ERR_NOT_ALLOWED);
+        };
+        enumerate_credentials_response(credential, None)
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    fn process_delete_credential(
+        &mut self,
+        sub_command_params: CredentialManagementSubCommandParameters,
+    ) -> Result<(), Ctap2StatusCode> {
+        let credential_id = sub_command_params
+            .credential_id
+            .ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?
+            .key_id;
+        self.persistent_store.delete_credential(&credential_id)
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    fn process_update_user_information(
+        &mut self,
+        sub_command_params: CredentialManagementSubCommandParameters,
+    ) -> Result<(), Ctap2StatusCode> {
+        let credential_id = sub_command_params
+            .credential_id
+            .ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?
+            .key_id;
+        let user = sub_command_params
+            .user
+            .ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?;
+        self.persistent_store
+            .update_credential(&credential_id, user)
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    fn pin_uv_auth_protocol_check(
+        &self,
+        pin_uv_auth_protocol: Option<u64>,
+    ) -> Result<(), Ctap2StatusCode> {
+        match pin_uv_auth_protocol {
+            Some(CtapState::<R, CheckUserPresence>::PIN_PROTOCOL_VERSION) => Ok(()),
+            Some(_) => Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID),
+            None => Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID),
+        }
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
     fn process_credential_management(
         &mut self,
-        _cred_management_params: AuthenticatorCredentialManagementParameters,
+        cred_management_params: AuthenticatorCredentialManagementParameters,
+        now: ClockValue,
     ) -> Result<ResponseData, Ctap2StatusCode> {
-        Err(Ctap2StatusCode::CTAP1_ERR_INVALID_COMMAND)
+        let AuthenticatorCredentialManagementParameters {
+            sub_command,
+            sub_command_params,
+            pin_protocol,
+            pin_auth,
+        } = cred_management_params;
+
+        match (sub_command, &self.stateful_command_type) {
+            (
+                CredentialManagementSubCommand::EnumerateRpsGetNextRp,
+                Some(StatefulCommand::EnumerateRps(_)),
+            ) => (),
+            (
+                CredentialManagementSubCommand::EnumerateCredentialsGetNextCredential,
+                Some(StatefulCommand::EnumerateCredentials(_)),
+            ) => (),
+            (_, _) => {
+                self.stateful_command_type = None;
+            }
+        }
+
+        match sub_command {
+            CredentialManagementSubCommand::GetCredsMetadata
+            | CredentialManagementSubCommand::EnumerateRpsBegin
+            | CredentialManagementSubCommand::DeleteCredential
+            | CredentialManagementSubCommand::EnumerateCredentialsBegin
+            | CredentialManagementSubCommand::UpdateUserInformation => {
+                self.pin_uv_auth_protocol_check(pin_protocol)?;
+                self.persistent_store
+                    .pin_hash()?
+                    .ok_or(Ctap2StatusCode::CTAP2_ERR_PIN_REQUIRED)?;
+                let pin_auth = pin_auth.ok_or(Ctap2StatusCode::CTAP2_ERR_PIN_REQUIRED)?;
+                let mut management_data = vec![sub_command as u8];
+                if let Some(sub_command_params) = sub_command_params.clone() {
+                    if !cbor::write(sub_command_params.into(), &mut management_data) {
+                        return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
+                    }
+                }
+                if !self
+                    .pin_protocol_v1
+                    .verify_pin_auth_token(&management_data, &pin_auth)
+                {
+                    return Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID);
+                }
+                self.pin_protocol_v1
+                    .has_permission(PinPermission::CredentialManagement)?;
+                self.pin_protocol_v1.has_no_permission_rp_id()?;
+                // TODO(kaczmarczyck) sometimes allow a RP ID
+            }
+            CredentialManagementSubCommand::EnumerateRpsGetNextRp
+            | CredentialManagementSubCommand::EnumerateCredentialsGetNextCredential => {}
+        }
+
+        let response = match sub_command {
+            CredentialManagementSubCommand::GetCredsMetadata => {
+                Some(self.process_get_creds_metadata()?)
+            }
+            CredentialManagementSubCommand::EnumerateRpsBegin => {
+                Some(self.process_enumerate_rps_begin(now)?)
+            }
+            CredentialManagementSubCommand::EnumerateRpsGetNextRp => {
+                Some(self.process_enumerate_rps_get_next_rp(now)?)
+            }
+            CredentialManagementSubCommand::EnumerateCredentialsBegin => {
+                Some(self.process_enumerate_credentials_begin(
+                    sub_command_params.ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?,
+                    now,
+                )?)
+            }
+            CredentialManagementSubCommand::EnumerateCredentialsGetNextCredential => {
+                Some(self.process_enumerate_credentials_get_next_credential(now)?)
+            }
+            CredentialManagementSubCommand::DeleteCredential => {
+                self.process_delete_credential(
+                    sub_command_params.ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?,
+                )?;
+                None
+            }
+            CredentialManagementSubCommand::UpdateUserInformation => {
+                self.process_update_user_information(
+                    sub_command_params.ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?,
+                )?;
+                None
+            }
+        };
+        Ok(ResponseData::AuthenticatorCredentialManagement(response))
     }
 
     #[cfg(feature = "with_ctap2_1")]
@@ -2061,6 +2392,503 @@ mod test {
         assert_eq!(reset_reponse, Err(Ctap2StatusCode::CTAP2_ERR_NOT_ALLOWED));
     }
 
+    #[cfg(feature = "with_ctap2_1")]
+    #[test]
+    fn test_process_get_creds_metadata() {
+        let mut rng = ThreadRng256 {};
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let pin_uv_auth_token = [0x55; 32];
+        let pin_protocol_v1 = PinProtocolV1::new_test(key_agreement_key, pin_uv_auth_token);
+        let private_key = crypto::ecdsa::SecKey::gensk(&mut rng);
+        let credential_source = PublicKeyCredentialSource {
+            key_type: PublicKeyCredentialType::PublicKey,
+            credential_id: rng.gen_uniform_u8x32().to_vec(),
+            private_key,
+            rp_id: String::from("example.com"),
+            user_handle: vec![0x01],
+            user_display_name: None,
+            cred_protect_policy: None,
+            creation_order: 0,
+            user_name: None,
+            user_icon: None,
+        };
+
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        ctap_state.pin_protocol_v1 = pin_protocol_v1;
+
+        ctap_state
+            .persistent_store
+            .set_pin_hash(&[0u8; 16])
+            .unwrap();
+        let pin_auth = Some(vec![
+            0xC5, 0xFB, 0x75, 0x55, 0x98, 0xB5, 0x19, 0x01, 0xB3, 0x31, 0x7D, 0xFE, 0x1D, 0xF5,
+            0xFB, 0x00,
+        ]);
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::GetCredsMetadata,
+            sub_command_params: None,
+            pin_protocol: Some(1),
+            pin_auth: pin_auth.clone(),
+        };
+        let cred_management_response =
+            ctap_state.process_credential_management(cred_management_params, DUMMY_CLOCK_VALUE);
+        let initial_capacity = match cred_management_response.unwrap() {
+            ResponseData::AuthenticatorCredentialManagement(Some(response)) => {
+                assert_eq!(response.existing_resident_credentials_count, Some(0));
+                response
+                    .max_possible_remaining_resident_credentials_count
+                    .unwrap()
+            }
+            _ => panic!("Invalid response type"),
+        };
+
+        ctap_state
+            .persistent_store
+            .store_credential(credential_source)
+            .unwrap();
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::GetCredsMetadata,
+            sub_command_params: None,
+            pin_protocol: Some(1),
+            pin_auth,
+        };
+        let cred_management_response =
+            ctap_state.process_credential_management(cred_management_params, DUMMY_CLOCK_VALUE);
+        match cred_management_response.unwrap() {
+            ResponseData::AuthenticatorCredentialManagement(Some(response)) => {
+                assert_eq!(response.existing_resident_credentials_count, Some(1));
+                assert_eq!(
+                    response.max_possible_remaining_resident_credentials_count,
+                    Some(initial_capacity - 1)
+                );
+            }
+            _ => panic!("Invalid response type"),
+        };
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    #[test]
+    fn test_process_enumerate_rps_with_uv() {
+        let mut rng = ThreadRng256 {};
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let pin_uv_auth_token = [0x55; 32];
+        let pin_protocol_v1 = PinProtocolV1::new_test(key_agreement_key, pin_uv_auth_token);
+
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        ctap_state.pin_protocol_v1 = pin_protocol_v1;
+
+        let make_credential_params = create_minimal_make_credential_parameters();
+        assert!(ctap_state
+            .process_make_credential(make_credential_params, DUMMY_CHANNEL_ID)
+            .is_ok());
+        let mut make_credential_params = create_minimal_make_credential_parameters();
+        let rp = PublicKeyCredentialRpEntity {
+            rp_id: "another.example.com".to_string(),
+            rp_name: None,
+            rp_icon: None,
+        };
+        make_credential_params.rp = rp;
+        assert!(ctap_state
+            .process_make_credential(make_credential_params, DUMMY_CHANNEL_ID)
+            .is_ok());
+
+        ctap_state
+            .persistent_store
+            .set_pin_hash(&[0u8; 16])
+            .unwrap();
+        let pin_auth = Some(vec![
+            0x1A, 0xA4, 0x96, 0xDA, 0x62, 0x80, 0x28, 0x13, 0xEB, 0x32, 0xB9, 0xF1, 0xD2, 0xA9,
+            0xD0, 0xD1,
+        ]);
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::EnumerateRpsBegin,
+            sub_command_params: None,
+            pin_protocol: Some(1),
+            pin_auth,
+        };
+        let cred_management_response =
+            ctap_state.process_credential_management(cred_management_params, DUMMY_CLOCK_VALUE);
+        let first_rp_id = match cred_management_response.unwrap() {
+            ResponseData::AuthenticatorCredentialManagement(Some(response)) => {
+                assert_eq!(response.total_rps, Some(2));
+                let rp_id = response.rp.unwrap().rp_id;
+                let rp_id_hash = Sha256::hash(rp_id.as_bytes());
+                assert_eq!(rp_id_hash, response.rp_id_hash.unwrap().as_slice());
+                rp_id
+            }
+            _ => panic!("Invalid response type"),
+        };
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::EnumerateRpsGetNextRp,
+            sub_command_params: None,
+            pin_protocol: None,
+            pin_auth: None,
+        };
+        let cred_management_response =
+            ctap_state.process_credential_management(cred_management_params, DUMMY_CLOCK_VALUE);
+        let second_rp_id = match cred_management_response.unwrap() {
+            ResponseData::AuthenticatorCredentialManagement(Some(response)) => {
+                assert_eq!(response.total_rps, None);
+                let rp_id = response.rp.unwrap().rp_id;
+                let rp_id_hash = Sha256::hash(rp_id.as_bytes());
+                assert_eq!(rp_id_hash, response.rp_id_hash.unwrap().as_slice());
+                rp_id
+            }
+            _ => panic!("Invalid response type"),
+        };
+
+        assert!(first_rp_id != second_rp_id);
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::EnumerateRpsGetNextRp,
+            sub_command_params: None,
+            pin_protocol: None,
+            pin_auth: None,
+        };
+        let cred_management_response =
+            ctap_state.process_credential_management(cred_management_params, DUMMY_CLOCK_VALUE);
+        assert_eq!(
+            cred_management_response,
+            Err(Ctap2StatusCode::CTAP2_ERR_NOT_ALLOWED)
+        );
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    #[test]
+    fn test_process_enumerate_credentials_with_uv() {
+        let mut rng = ThreadRng256 {};
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let pin_uv_auth_token = [0x55; 32];
+        let pin_protocol_v1 = PinProtocolV1::new_test(key_agreement_key, pin_uv_auth_token);
+
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        ctap_state.pin_protocol_v1 = pin_protocol_v1;
+
+        let make_credential_params = create_minimal_make_credential_parameters();
+        assert!(ctap_state
+            .process_make_credential(make_credential_params, DUMMY_CHANNEL_ID)
+            .is_ok());
+        let mut make_credential_params = create_minimal_make_credential_parameters();
+        let user = PublicKeyCredentialUserEntity {
+            user_id: vec![0x02],
+            user_name: Some("user2".to_string()),
+            user_display_name: Some("User Two".to_string()),
+            user_icon: Some("icon2".to_string()),
+        };
+        make_credential_params.user = user;
+        assert!(ctap_state
+            .process_make_credential(make_credential_params, DUMMY_CHANNEL_ID)
+            .is_ok());
+
+        ctap_state
+            .persistent_store
+            .set_pin_hash(&[0u8; 16])
+            .unwrap();
+        let pin_auth = Some(vec![
+            0xF8, 0xB0, 0x3C, 0xC1, 0xD5, 0x58, 0x9C, 0xB7, 0x4D, 0x42, 0xA1, 0x64, 0x14, 0x28,
+            0x2B, 0x68,
+        ]);
+
+        let sub_command_params = CredentialManagementSubCommandParameters {
+            rp_id_hash: Some(Sha256::hash(b"example.com").to_vec()),
+            credential_id: None,
+            user: None,
+        };
+        // RP ID hash:
+        // A379A6F6EEAFB9A55E378C118034E2751E682FAB9F2D30AB13D2125586CE1947
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::EnumerateCredentialsBegin,
+            sub_command_params: Some(sub_command_params),
+            pin_protocol: Some(1),
+            pin_auth,
+        };
+        let cred_management_response =
+            ctap_state.process_credential_management(cred_management_params, DUMMY_CLOCK_VALUE);
+        let first_credential_id = match cred_management_response.unwrap() {
+            ResponseData::AuthenticatorCredentialManagement(Some(response)) => {
+                assert!(response.user.is_some());
+                assert!(response.public_key.is_some());
+                assert_eq!(response.total_credentials, Some(2));
+                response.credential_id.unwrap().key_id
+            }
+            _ => panic!("Invalid response type"),
+        };
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::EnumerateCredentialsGetNextCredential,
+            sub_command_params: None,
+            pin_protocol: None,
+            pin_auth: None,
+        };
+        let cred_management_response =
+            ctap_state.process_credential_management(cred_management_params, DUMMY_CLOCK_VALUE);
+        let second_credential_id = match cred_management_response.unwrap() {
+            ResponseData::AuthenticatorCredentialManagement(Some(response)) => {
+                assert!(response.user.is_some());
+                assert!(response.public_key.is_some());
+                assert_eq!(response.total_credentials, None);
+                response.credential_id.unwrap().key_id
+            }
+            _ => panic!("Invalid response type"),
+        };
+
+        assert!(first_credential_id != second_credential_id);
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::EnumerateCredentialsGetNextCredential,
+            sub_command_params: None,
+            pin_protocol: None,
+            pin_auth: None,
+        };
+        let cred_management_response =
+            ctap_state.process_credential_management(cred_management_params, DUMMY_CLOCK_VALUE);
+        assert_eq!(
+            cred_management_response,
+            Err(Ctap2StatusCode::CTAP2_ERR_NOT_ALLOWED)
+        );
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    #[test]
+    fn test_process_delete_credential() {
+        let mut rng = ThreadRng256 {};
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let pin_uv_auth_token = [0x55; 32];
+        let pin_protocol_v1 = PinProtocolV1::new_test(key_agreement_key, pin_uv_auth_token);
+        let private_key = crypto::ecdsa::SecKey::gensk(&mut rng);
+
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        ctap_state.pin_protocol_v1 = pin_protocol_v1;
+
+        let credential_source = PublicKeyCredentialSource {
+            key_type: PublicKeyCredentialType::PublicKey,
+            credential_id: vec![0x1D; 32],
+            private_key,
+            rp_id: String::from("example.com"),
+            user_handle: vec![0x01],
+            user_display_name: None,
+            cred_protect_policy: None,
+            creation_order: 0,
+            user_name: None,
+            user_icon: None,
+        };
+        ctap_state
+            .persistent_store
+            .store_credential(credential_source)
+            .unwrap();
+
+        ctap_state
+            .persistent_store
+            .set_pin_hash(&[0u8; 16])
+            .unwrap();
+        let pin_auth = Some(vec![
+            0xBD, 0xE3, 0xEF, 0x8A, 0x77, 0x01, 0xB1, 0x69, 0x19, 0xE6, 0x62, 0xB9, 0x9B, 0x89,
+            0x9C, 0x64,
+        ]);
+
+        let credential_id = PublicKeyCredentialDescriptor {
+            key_type: PublicKeyCredentialType::PublicKey,
+            key_id: vec![0x1D; 32],
+            transports: None, // You can set USB as a hint here.
+        };
+        let sub_command_params = CredentialManagementSubCommandParameters {
+            rp_id_hash: None,
+            credential_id: Some(credential_id),
+            user: None,
+        };
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::DeleteCredential,
+            sub_command_params: Some(sub_command_params.clone()),
+            pin_protocol: Some(1),
+            pin_auth: pin_auth.clone(),
+        };
+        let cred_management_response =
+            ctap_state.process_credential_management(cred_management_params, DUMMY_CLOCK_VALUE);
+        assert_eq!(
+            cred_management_response,
+            Ok(ResponseData::AuthenticatorCredentialManagement(None))
+        );
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::DeleteCredential,
+            sub_command_params: Some(sub_command_params),
+            pin_protocol: Some(1),
+            pin_auth,
+        };
+        let cred_management_response =
+            ctap_state.process_credential_management(cred_management_params, DUMMY_CLOCK_VALUE);
+        assert_eq!(
+            cred_management_response,
+            Err(Ctap2StatusCode::CTAP2_ERR_NO_CREDENTIALS)
+        );
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    #[test]
+    fn test_process_update_user_information() {
+        let mut rng = ThreadRng256 {};
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let pin_uv_auth_token = [0x55; 32];
+        let pin_protocol_v1 = PinProtocolV1::new_test(key_agreement_key, pin_uv_auth_token);
+        let private_key = crypto::ecdsa::SecKey::gensk(&mut rng);
+
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        ctap_state.pin_protocol_v1 = pin_protocol_v1;
+
+        let credential_source = PublicKeyCredentialSource {
+            key_type: PublicKeyCredentialType::PublicKey,
+            credential_id: vec![0x1D; 32],
+            private_key,
+            rp_id: String::from("example.com"),
+            user_handle: vec![0x01],
+            user_display_name: Some("display_name".to_string()),
+            cred_protect_policy: None,
+            creation_order: 0,
+            user_name: Some("name".to_string()),
+            user_icon: Some("icon".to_string()),
+        };
+        ctap_state
+            .persistent_store
+            .store_credential(credential_source)
+            .unwrap();
+
+        ctap_state
+            .persistent_store
+            .set_pin_hash(&[0u8; 16])
+            .unwrap();
+        let pin_auth = Some(vec![
+            0xA5, 0x55, 0x8F, 0x03, 0xC3, 0xD3, 0x73, 0x1C, 0x07, 0xDA, 0x1F, 0x8C, 0xC7, 0xBD,
+            0x9D, 0xB7,
+        ]);
+
+        let credential_id = PublicKeyCredentialDescriptor {
+            key_type: PublicKeyCredentialType::PublicKey,
+            key_id: vec![0x1D; 32],
+            transports: None, // You can set USB as a hint here.
+        };
+        let new_user = PublicKeyCredentialUserEntity {
+            user_id: vec![0xFF],
+            user_name: Some("new_name".to_string()),
+            user_display_name: Some("new_display_name".to_string()),
+            user_icon: Some("new_icon".to_string()),
+        };
+        let sub_command_params = CredentialManagementSubCommandParameters {
+            rp_id_hash: None,
+            credential_id: Some(credential_id),
+            user: Some(new_user.clone()),
+        };
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::UpdateUserInformation,
+            sub_command_params: Some(sub_command_params.clone()),
+            pin_protocol: Some(1),
+            pin_auth: pin_auth.clone(),
+        };
+        let cred_management_response =
+            ctap_state.process_credential_management(cred_management_params, DUMMY_CLOCK_VALUE);
+        assert_eq!(
+            cred_management_response,
+            Ok(ResponseData::AuthenticatorCredentialManagement(None))
+        );
+
+        let updated_credential = ctap_state
+            .persistent_store
+            .find_credential("example.com", &[0x1D; 32], false)
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated_credential.user_handle, vec![0x01]);
+        assert_eq!(&updated_credential.user_name.unwrap(), "new_name");
+        assert_eq!(
+            &updated_credential.user_display_name.unwrap(),
+            "new_display_name"
+        );
+        assert_eq!(&updated_credential.user_icon.unwrap(), "new_icon");
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    #[test]
+    fn test_process_credential_management_invalid_pin_protocol() {
+        let mut rng = ThreadRng256 {};
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let pin_uv_auth_token = [0x55; 32];
+        let pin_protocol_v1 = PinProtocolV1::new_test(key_agreement_key, pin_uv_auth_token);
+
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        ctap_state.pin_protocol_v1 = pin_protocol_v1;
+
+        ctap_state
+            .persistent_store
+            .set_pin_hash(&[0u8; 16])
+            .unwrap();
+        let pin_auth = Some(vec![
+            0xC5, 0xFB, 0x75, 0x55, 0x98, 0xB5, 0x19, 0x01, 0xB3, 0x31, 0x7D, 0xFE, 0x1D, 0xF5,
+            0xFB, 0x00,
+        ]);
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::GetCredsMetadata,
+            sub_command_params: None,
+            pin_protocol: Some(123456),
+            pin_auth,
+        };
+        let cred_management_response =
+            ctap_state.process_credential_management(cred_management_params, DUMMY_CLOCK_VALUE);
+        assert_eq!(
+            cred_management_response,
+            Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
+        );
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    #[test]
+    fn test_process_credential_management_invalid_pin_auth() {
+        let mut rng = ThreadRng256 {};
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+
+        ctap_state
+            .persistent_store
+            .set_pin_hash(&[0u8; 16])
+            .unwrap();
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::GetCredsMetadata,
+            sub_command_params: None,
+            pin_protocol: Some(1),
+            pin_auth: Some(vec![0u8; 16]),
+        };
+        let cred_management_response =
+            ctap_state.process_credential_management(cred_management_params, DUMMY_CLOCK_VALUE);
+        assert_eq!(
+            cred_management_response,
+            Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
+        );
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    #[test]
+    fn test_process_credential_management_unknown_subcommand() {
+        let mut rng = ThreadRng256 {};
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+
+        // The subcommand 0xEE does not exist.
+        let reponse = ctap_state.process_command(
+            &[0x0A, 0xA1, 0x01, 0x18, 0xEE],
+            DUMMY_CHANNEL_ID,
+            DUMMY_CLOCK_VALUE,
+        );
+        let expected_response = vec![Ctap2StatusCode::CTAP2_ERR_INVALID_SUBCOMMAND as u8];
+        assert_eq!(reponse, expected_response);
+    }
+
     #[test]
     fn test_process_unknown_command() {
         let mut rng = ThreadRng256 {};
@@ -2068,10 +2896,9 @@ mod test {
         let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
 
         // This command does not exist.
-        let reset_reponse =
-            ctap_state.process_command(&[0xDF], DUMMY_CHANNEL_ID, DUMMY_CLOCK_VALUE);
+        let reponse = ctap_state.process_command(&[0xDF], DUMMY_CHANNEL_ID, DUMMY_CLOCK_VALUE);
         let expected_response = vec![Ctap2StatusCode::CTAP1_ERR_INVALID_COMMAND as u8];
-        assert_eq!(reset_reponse, expected_response);
+        assert_eq!(reponse, expected_response);
     }
 
     #[test]

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -25,12 +25,12 @@ pub mod status_code;
 mod storage;
 mod timed_permission;
 
-#[cfg(feature = "with_ctap2_1")]
-use self::command::MAX_CREDENTIAL_COUNT_IN_LIST;
 use self::command::{
     AuthenticatorClientPinParameters, AuthenticatorGetAssertionParameters,
     AuthenticatorMakeCredentialParameters, AuthenticatorVendorConfigureParameters, Command,
 };
+#[cfg(feature = "with_ctap2_1")]
+use self::command::{AuthenticatorCredentialManagementParameters, MAX_CREDENTIAL_COUNT_IN_LIST};
 #[cfg(feature = "with_ctap2_1")]
 use self::data_formats::AuthenticatorTransport;
 use self::data_formats::{
@@ -356,6 +356,10 @@ where
                     Command::AuthenticatorGetInfo => self.process_get_info(),
                     Command::AuthenticatorClientPin(params) => self.process_client_pin(params),
                     Command::AuthenticatorReset => self.process_reset(cid, now),
+                    #[cfg(feature = "with_ctap2_1")]
+                    Command::AuthenticatorCredentialManagement(params) => {
+                        self.process_credential_management(params)
+                    }
                     #[cfg(feature = "with_ctap2_1")]
                     Command::AuthenticatorSelection => self.process_selection(cid),
                     // TODO(kaczmarczyck) implement FIDO 2.1 commands
@@ -916,6 +920,14 @@ where
             );
         }
         Ok(ResponseData::AuthenticatorReset)
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    fn process_credential_management(
+        &mut self,
+        _cred_management_params: AuthenticatorCredentialManagementParameters,
+    ) -> Result<ResponseData, Ctap2StatusCode> {
+        Err(Ctap2StatusCode::CTAP1_ERR_INVALID_COMMAND)
     }
 
     #[cfg(feature = "with_ctap2_1")]

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -944,6 +944,8 @@ where
             String::from("clientPin"),
             self.persistent_store.pin_hash()?.is_some(),
         );
+        #[cfg(feature = "with_ctap2_1")]
+        options_map.insert(String::from("credMgmt"), true);
         Ok(ResponseData::AuthenticatorGetInfo(
             AuthenticatorGetInfoResponse {
                 versions: vec![
@@ -1410,9 +1412,19 @@ mod test {
             0x03, 0x50,
         ]);
         expected_response.extend(&ctap_state.persistent_store.aaguid().unwrap());
+        let mut option_count = 0;
+        option_count += 3;
+        #[cfg(feature = "with_ctap2_1")]
+        {
+            option_count += 1;
+        }
+        expected_response.extend(&[0x04, 0xA0 + option_count]);
+        expected_response.extend(&[0x62, 0x72, 0x6B, 0xF5, 0x62, 0x75, 0x70, 0xF5]);
+        #[cfg(feature = "with_ctap2_1")]
+        expected_response.extend(&[0x68, 0x63, 0x72, 0x65, 0x64, 0x4D, 0x67, 0x6D, 0x74, 0xF5]);
         expected_response.extend(&[
-            0x04, 0xA3, 0x62, 0x72, 0x6B, 0xF5, 0x62, 0x75, 0x70, 0xF5, 0x69, 0x63, 0x6C, 0x69,
-            0x65, 0x6E, 0x74, 0x50, 0x69, 0x6E, 0xF4, 0x05, 0x19, 0x04, 0x00, 0x06, 0x81, 0x01,
+            0x69, 0x63, 0x6C, 0x69, 0x65, 0x6E, 0x74, 0x50, 0x69, 0x6E, 0xF4, 0x05, 0x19, 0x04,
+            0x00, 0x06, 0x81, 0x01,
         ]);
         #[cfg(feature = "with_ctap2_1")]
         expected_response.extend(

--- a/src/ctap/pin_protocol_v1.rs
+++ b/src/ctap/pin_protocol_v1.rs
@@ -609,6 +609,14 @@ impl PinProtocolV1 {
     }
 
     #[cfg(feature = "with_ctap2_1")]
+    pub fn has_no_permission_rp_id(&self) -> Result<(), Ctap2StatusCode> {
+        if self.permissions_rp_id.is_some() {
+            return Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID);
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
     pub fn has_permission_for_rp_id(&mut self, rp_id: &str) -> Result<(), Ctap2StatusCode> {
         if let Some(permissions_rp_id) = &self.permissions_rp_id {
             if rp_id != permissions_rp_id {
@@ -1250,6 +1258,20 @@ mod test {
                 Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
             );
         }
+    }
+
+    #[cfg(feature = "with_ctap2_1")]
+    #[test]
+    fn test_has_no_permission_rp_id() {
+        let mut rng = ThreadRng256 {};
+        let mut pin_protocol_v1 = PinProtocolV1::new(&mut rng);
+        assert_eq!(pin_protocol_v1.has_no_permission_rp_id(), Ok(()));
+        assert_eq!(pin_protocol_v1.permissions_rp_id, None,);
+        pin_protocol_v1.permissions_rp_id = Some("example.com".to_string());
+        assert_eq!(
+            pin_protocol_v1.has_no_permission_rp_id(),
+            Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
+        );
     }
 
     #[cfg(feature = "with_ctap2_1")]

--- a/src/ctap/response.rs
+++ b/src/ctap/response.rs
@@ -251,7 +251,7 @@ pub struct AuthenticatorCredentialManagementResponse {
     pub credential_id: Option<PublicKeyCredentialDescriptor>,
     pub public_key: Option<CoseKey>,
     pub total_credentials: Option<u64>,
-    pub cred_protect: Option<u64>,
+    pub cred_protect: Option<CredentialProtectionPolicy>,
     pub large_blob_key: Option<Vec<u8>>,
 }
 
@@ -527,7 +527,7 @@ mod test {
             credential_id: Some(cred_descriptor.clone()),
             public_key: Some(cose_key.clone()),
             total_credentials: Some(2),
-            cred_protect: Some(0),
+            cred_protect: Some(CredentialProtectionPolicy::UserVerificationOptional),
             large_blob_key: Some(vec![0xBB; 64]),
         };
         let response_cbor: Option<cbor::Value> =
@@ -542,7 +542,7 @@ mod test {
             0x07 => cred_descriptor,
             0x08 => cbor_map_btree!(cose_key.0),
             0x09 => 2,
-            0x0A => 0,
+            0x0A => 0x01,
             0x0B => vec![0xBB; 64],
         };
         assert_eq!(response_cbor, Some(expected_cbor));

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -204,6 +204,10 @@ impl PersistentStore {
     }
 
     /// Finds the key and value for a given credential ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns `CTAP2_ERR_NO_CREDENTIALS` if the credential is not found.
     #[cfg(feature = "with_ctap2_1")]
     fn find_credential_item(
         &mut self,
@@ -223,14 +227,22 @@ impl PersistentStore {
             .ok_or(Ctap2StatusCode::CTAP2_ERR_NO_CREDENTIALS)
     }
 
-    /// Deletes a credential. Returns an error if the credential was not found.
+    /// Deletes a credential.
+    ///
+    /// # Errors
+    ///
+    /// Returns `CTAP2_ERR_NO_CREDENTIALS` if the credential is not found.
     #[cfg(feature = "with_ctap2_1")]
     pub fn delete_credential(&mut self, credential_id: &[u8]) -> Result<(), Ctap2StatusCode> {
         let (key, _) = self.find_credential_item(credential_id)?;
         Ok(self.store.remove(key)?)
     }
 
-    /// Update a credential's user information. Returns an error if the credential was not found.
+    /// Updates a credential's user information.
+    ///
+    /// # Errors
+    ///
+    /// Returns `CTAP2_ERR_NO_CREDENTIALS` if the credential is not found.
     #[cfg(feature = "with_ctap2_1")]
     pub fn update_credential(
         &mut self,


### PR DESCRIPTION
New command for #106 . This PR contains all changes for reference, and will be split into smaller chunks. The commit `6724acf` moves all changes to a separate file. While they belong to `mod` conceptually, this file has grown too large already and the commit is for opening discussion about if we want to split `mod` up like that.