### PR TITLE
Add elf2tab output to the reproducible checks

### DIFF
--- a/.github/workflows/reproducible.yml
+++ b/.github/workflows/reproducible.yml
@@ -37,6 +37,6 @@ jobs:
           path: reproducible/reproduced.tar
 
       - name: Comparing binary sizes
-        run: git diff --no-index reproducible/reference_elf2tab.txt reproducible/elf2tab.txt
+        run: git diff --no-index reproducible/reference_elf2tab_${{ matrix.os }}.txt reproducible/elf2tab.txt
       - name: Comparing cryptographic hashes
         run: git diff --no-index reproducible/reference_binaries_${{ matrix.os }}.sha256sum reproducible/binaries.sha256sum

--- a/.github/workflows/reproducible.yml
+++ b/.github/workflows/reproducible.yml
@@ -36,5 +36,7 @@ jobs:
           name: reproduced-${{ matrix.os }}
           path: reproducible/reproduced.tar
 
+      - name: Comparing binary sizes
+        run: git diff --no-index reproducible/reference_elf2tab.txt reproducible/elf2tab.txt
       - name: Comparing cryptographic hashes
         run: git diff --no-index reproducible/reference_binaries_${{ matrix.os }}.sha256sum reproducible/binaries.sha256sum

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ Cargo.lock
 
 # Prevent people from commiting sensitive files.
 crypto_data/
+
+# Temporary files.
+reproducible/binaries.sha256sum
+reproducible/elf2tab.txt
+reproducible/reproduced.tar

--- a/deploy.py
+++ b/deploy.py
@@ -428,7 +428,12 @@ class OpenSKInstaller:
         "--stack={}".format(STACK_SIZE), "--app-heap={}".format(APP_HEAP_SIZE),
         "--kernel-heap=1024", "--protected-region-size=64"
     ])
-    self.checked_command(elf2tab_args)
+    if self.args.elf2tab_output:
+      output = self.checked_command_output(elf2tab_args)
+      with open(self.args.elf2tab_output, 'a') as f:
+        f.write(output)
+    else:
+      self.checked_command(elf2tab_args)
 
   def install_tab_file(self, tab_filename):
     assert self.args.application
@@ -859,6 +864,14 @@ if __name__ == "__main__":
       dest="features",
       help=("Compiles and installs the OpenSK application without persistent "
             "storage (i.e. unplugging the key will reset the key)."),
+  )
+
+  main_parser.add_argument(
+      "--elf2tab-output",
+      metavar="FILE",
+      dest="elf2tab_output",
+      default=None,
+      help=("When set, the output of elf2tab is appended to this file."),
   )
 
   apps_group = main_parser.add_mutually_exclusive_group(required=True)

--- a/deploy.py
+++ b/deploy.py
@@ -430,8 +430,7 @@ class OpenSKInstaller:
     ])
     if self.args.elf2tab_output:
       output = self.checked_command_output(elf2tab_args)
-      with open(self.args.elf2tab_output, 'a') as f:
-        f.write(output)
+      self.args.elf2tab_output.write(output)
     else:
       self.checked_command(elf2tab_args)
 
@@ -869,6 +868,7 @@ if __name__ == "__main__":
   main_parser.add_argument(
       "--elf2tab-output",
       metavar="FILE",
+      type=argparse.FileType("a"),
       dest="elf2tab_output",
       default=None,
       help=("When set, the output of elf2tab is appended to this file."),

--- a/reproduce_board.sh
+++ b/reproduce_board.sh
@@ -24,6 +24,6 @@ echo "----------------------------------------" >> reproducible/elf2tab.txt
 ./third_party/tock/tools/sha256sum/target/debug/sha256sum third_party/tock/target/thumbv7em-none-eabi/release/$BOARD.bin >> reproducible/binaries.sha256sum
 tar -rvf reproducible/reproduced.tar third_party/tock/target/thumbv7em-none-eabi/release/$BOARD.bin
 
-./deploy.py --verbose-build --board=$BOARD --opensk --programmer=none --elf2tab-output reproducible/elf2tab.txt
+./deploy.py --verbose-build --board=$BOARD --opensk --programmer=none --elf2tab-output=reproducible/elf2tab.txt
 ./third_party/tock/tools/sha256sum/target/debug/sha256sum target/${BOARD}_merged.hex >> reproducible/binaries.sha256sum
 tar -rvf reproducible/reproduced.tar target/${BOARD}_merged.hex

--- a/reproduce_board.sh
+++ b/reproduce_board.sh
@@ -16,10 +16,14 @@
 set -ex
 
 echo "Board: $BOARD"
+echo "========================================" >> reproducible/elf2tab.txt
+echo "Board: $BOARD" >> reproducible/elf2tab.txt
+echo "----------------------------------------" >> reproducible/elf2tab.txt
+
 ./deploy.py --verbose-build --board=$BOARD --no-app --programmer=none
 ./third_party/tock/tools/sha256sum/target/debug/sha256sum third_party/tock/target/thumbv7em-none-eabi/release/$BOARD.bin >> reproducible/binaries.sha256sum
 tar -rvf reproducible/reproduced.tar third_party/tock/target/thumbv7em-none-eabi/release/$BOARD.bin
 
-./deploy.py --verbose-build --board=$BOARD --opensk --programmer=none
+./deploy.py --verbose-build --board=$BOARD --opensk --programmer=none --elf2tab-output reproducible/elf2tab.txt
 ./third_party/tock/tools/sha256sum/target/debug/sha256sum target/${BOARD}_merged.hex >> reproducible/binaries.sha256sum
 tar -rvf reproducible/reproduced.tar target/${BOARD}_merged.hex

--- a/reproduce_hashes.sh
+++ b/reproduce_hashes.sh
@@ -16,6 +16,7 @@
 set -ex
 
 rm -f reproducible/binaries.sha256sum
+rm -f reproducible/elf2tab.txt
 
 echo "Creating reproducible/reproduced.tar"
 touch empty_file

--- a/reproducible/reference_elf2tab.txt
+++ b/reproducible/reference_elf2tab.txt
@@ -1,0 +1,76 @@
+========================================
+Board: nrf52840dk
+----------------------------------------
+Min RAM size from sections in ELF: 16 bytes
+Number of writeable flash regions: 0
+  Adding .crt0_header section. Offset: 64 (0x40). Length: 64 (0x40) bytes.
+Entry point is in .text section
+  Adding .text section. Offset: 128 (0x80). Length: 176436 (0x2b134) bytes.
+  Adding .stack section. Offset: 176564 (0x2b1b4). Length: 16384 (0x4000) bytes.
+Searching for .rel.X sections to add.
+TBF Header:
+               version:        2        0x2
+           header_size:       44       0x2C
+            total_size:   262144    0x40000
+                 flags:        1        0x1
+
+        init_fn_offset:       85       0x55
+        protected_size:       20       0x14
+      minimum_ram_size:   107424    0x1A3A0
+========================================
+Board: nrf52840_dongle
+----------------------------------------
+Min RAM size from sections in ELF: 16 bytes
+Number of writeable flash regions: 0
+  Adding .crt0_header section. Offset: 64 (0x40). Length: 64 (0x40) bytes.
+Entry point is in .text section
+  Adding .text section. Offset: 128 (0x80). Length: 176436 (0x2b134) bytes.
+  Adding .stack section. Offset: 176564 (0x2b1b4). Length: 16384 (0x4000) bytes.
+Searching for .rel.X sections to add.
+TBF Header:
+               version:        2        0x2
+           header_size:       44       0x2C
+            total_size:   262144    0x40000
+                 flags:        1        0x1
+
+        init_fn_offset:       85       0x55
+        protected_size:       20       0x14
+      minimum_ram_size:   107424    0x1A3A0
+========================================
+Board: nrf52840_dongle_dfu
+----------------------------------------
+Min RAM size from sections in ELF: 16 bytes
+Number of writeable flash regions: 0
+  Adding .crt0_header section. Offset: 64 (0x40). Length: 64 (0x40) bytes.
+Entry point is in .text section
+  Adding .text section. Offset: 128 (0x80). Length: 176436 (0x2b134) bytes.
+  Adding .stack section. Offset: 176564 (0x2b1b4). Length: 16384 (0x4000) bytes.
+Searching for .rel.X sections to add.
+TBF Header:
+               version:        2        0x2
+           header_size:       44       0x2C
+            total_size:   262144    0x40000
+                 flags:        1        0x1
+
+        init_fn_offset:       85       0x55
+        protected_size:       20       0x14
+      minimum_ram_size:   107424    0x1A3A0
+========================================
+Board: nrf52840_mdk_dfu
+----------------------------------------
+Min RAM size from sections in ELF: 16 bytes
+Number of writeable flash regions: 0
+  Adding .crt0_header section. Offset: 64 (0x40). Length: 64 (0x40) bytes.
+Entry point is in .text section
+  Adding .text section. Offset: 128 (0x80). Length: 176436 (0x2b134) bytes.
+  Adding .stack section. Offset: 176564 (0x2b1b4). Length: 16384 (0x4000) bytes.
+Searching for .rel.X sections to add.
+TBF Header:
+               version:        2        0x2
+           header_size:       44       0x2C
+            total_size:   262144    0x40000
+                 flags:        1        0x1
+
+        init_fn_offset:       85       0x55
+        protected_size:       20       0x14
+      minimum_ram_size:   107424    0x1A3A0

--- a/reproducible/reference_elf2tab_macos-10.15.txt
+++ b/reproducible/reference_elf2tab_macos-10.15.txt
@@ -5,8 +5,8 @@ Min RAM size from sections in ELF: 16 bytes
 Number of writeable flash regions: 0
   Adding .crt0_header section. Offset: 64 (0x40). Length: 64 (0x40) bytes.
 Entry point is in .text section
-  Adding .text section. Offset: 128 (0x80). Length: 176436 (0x2b134) bytes.
-  Adding .stack section. Offset: 176564 (0x2b1b4). Length: 16384 (0x4000) bytes.
+  Adding .text section. Offset: 128 (0x80). Length: 175636 (0x2ae14) bytes.
+  Adding .stack section. Offset: 175764 (0x2ae94). Length: 16384 (0x4000) bytes.
 Searching for .rel.X sections to add.
 TBF Header:
                version:        2        0x2
@@ -24,8 +24,8 @@ Min RAM size from sections in ELF: 16 bytes
 Number of writeable flash regions: 0
   Adding .crt0_header section. Offset: 64 (0x40). Length: 64 (0x40) bytes.
 Entry point is in .text section
-  Adding .text section. Offset: 128 (0x80). Length: 176436 (0x2b134) bytes.
-  Adding .stack section. Offset: 176564 (0x2b1b4). Length: 16384 (0x4000) bytes.
+  Adding .text section. Offset: 128 (0x80). Length: 175636 (0x2ae14) bytes.
+  Adding .stack section. Offset: 175764 (0x2ae94). Length: 16384 (0x4000) bytes.
 Searching for .rel.X sections to add.
 TBF Header:
                version:        2        0x2
@@ -43,8 +43,8 @@ Min RAM size from sections in ELF: 16 bytes
 Number of writeable flash regions: 0
   Adding .crt0_header section. Offset: 64 (0x40). Length: 64 (0x40) bytes.
 Entry point is in .text section
-  Adding .text section. Offset: 128 (0x80). Length: 176436 (0x2b134) bytes.
-  Adding .stack section. Offset: 176564 (0x2b1b4). Length: 16384 (0x4000) bytes.
+  Adding .text section. Offset: 128 (0x80). Length: 175636 (0x2ae14) bytes.
+  Adding .stack section. Offset: 175764 (0x2ae94). Length: 16384 (0x4000) bytes.
 Searching for .rel.X sections to add.
 TBF Header:
                version:        2        0x2
@@ -62,8 +62,8 @@ Min RAM size from sections in ELF: 16 bytes
 Number of writeable flash regions: 0
   Adding .crt0_header section. Offset: 64 (0x40). Length: 64 (0x40) bytes.
 Entry point is in .text section
-  Adding .text section. Offset: 128 (0x80). Length: 176436 (0x2b134) bytes.
-  Adding .stack section. Offset: 176564 (0x2b1b4). Length: 16384 (0x4000) bytes.
+  Adding .text section. Offset: 128 (0x80). Length: 175636 (0x2ae14) bytes.
+  Adding .stack section. Offset: 175764 (0x2ae94). Length: 16384 (0x4000) bytes.
 Searching for .rel.X sections to add.
 TBF Header:
                version:        2        0x2

--- a/reproducible/reference_elf2tab_ubuntu-18.04.txt
+++ b/reproducible/reference_elf2tab_ubuntu-18.04.txt
@@ -1,0 +1,76 @@
+========================================
+Board: nrf52840dk
+----------------------------------------
+Min RAM size from sections in ELF: 16 bytes
+Number of writeable flash regions: 0
+  Adding .crt0_header section. Offset: 64 (0x40). Length: 64 (0x40) bytes.
+Entry point is in .text section
+  Adding .text section. Offset: 128 (0x80). Length: 175252 (0x2ac94) bytes.
+  Adding .stack section. Offset: 175380 (0x2ad14). Length: 16384 (0x4000) bytes.
+Searching for .rel.X sections to add.
+TBF Header:
+               version:        2        0x2
+           header_size:       44       0x2C
+            total_size:   262144    0x40000
+                 flags:        1        0x1
+
+        init_fn_offset:       85       0x55
+        protected_size:       20       0x14
+      minimum_ram_size:   107424    0x1A3A0
+========================================
+Board: nrf52840_dongle
+----------------------------------------
+Min RAM size from sections in ELF: 16 bytes
+Number of writeable flash regions: 0
+  Adding .crt0_header section. Offset: 64 (0x40). Length: 64 (0x40) bytes.
+Entry point is in .text section
+  Adding .text section. Offset: 128 (0x80). Length: 175252 (0x2ac94) bytes.
+  Adding .stack section. Offset: 175380 (0x2ad14). Length: 16384 (0x4000) bytes.
+Searching for .rel.X sections to add.
+TBF Header:
+               version:        2        0x2
+           header_size:       44       0x2C
+            total_size:   262144    0x40000
+                 flags:        1        0x1
+
+        init_fn_offset:       85       0x55
+        protected_size:       20       0x14
+      minimum_ram_size:   107424    0x1A3A0
+========================================
+Board: nrf52840_dongle_dfu
+----------------------------------------
+Min RAM size from sections in ELF: 16 bytes
+Number of writeable flash regions: 0
+  Adding .crt0_header section. Offset: 64 (0x40). Length: 64 (0x40) bytes.
+Entry point is in .text section
+  Adding .text section. Offset: 128 (0x80). Length: 175252 (0x2ac94) bytes.
+  Adding .stack section. Offset: 175380 (0x2ad14). Length: 16384 (0x4000) bytes.
+Searching for .rel.X sections to add.
+TBF Header:
+               version:        2        0x2
+           header_size:       44       0x2C
+            total_size:   262144    0x40000
+                 flags:        1        0x1
+
+        init_fn_offset:       85       0x55
+        protected_size:       20       0x14
+      minimum_ram_size:   107424    0x1A3A0
+========================================
+Board: nrf52840_mdk_dfu
+----------------------------------------
+Min RAM size from sections in ELF: 16 bytes
+Number of writeable flash regions: 0
+  Adding .crt0_header section. Offset: 64 (0x40). Length: 64 (0x40) bytes.
+Entry point is in .text section
+  Adding .text section. Offset: 128 (0x80). Length: 175252 (0x2ac94) bytes.
+  Adding .stack section. Offset: 175380 (0x2ad14). Length: 16384 (0x4000) bytes.
+Searching for .rel.X sections to add.
+TBF Header:
+               version:        2        0x2
+           header_size:       44       0x2C
+            total_size:   262144    0x40000
+                 flags:        1        0x1
+
+        init_fn_offset:       85       0x55
+        protected_size:       20       0x14
+      minimum_ram_size:   107424    0x1A3A0


### PR DESCRIPTION
This pull request adds a dump of elf2tab to the reproducible workflow. This allows to easily check for regressions in binary size, notably thanks to the following lines.

```
Number of writeable flash regions: 0
  Adding .crt0_header section. Offset: 64 (0x40). Length: 64 (0x40) bytes.
Entry point is in .text section
  Adding .text section. Offset: 128 (0x80). Length: 176436 (0x2b134) bytes.
  Adding .stack section. Offset: 176564 (0x2b1b4). Length: 16384 (0x4000) bytes.
```

- [x] Tests pass
- [x] Appropriate changes to README are included in PR