### PR TITLE
Always run git-diff in reproducible workflow, even if the job failed so far.

### DIFF
--- a/.github/workflows/reproducible.yml
+++ b/.github/workflows/reproducible.yml
@@ -37,6 +37,8 @@ jobs:
           path: reproducible/reproduced.tar
 
       - name: Comparing binary sizes
+        if: always()
         run: git diff --no-index reproducible/reference_elf2tab_${{ matrix.os }}.txt reproducible/elf2tab.txt
       - name: Comparing cryptographic hashes
+        if: always()
         run: git diff --no-index reproducible/reference_binaries_${{ matrix.os }}.sha256sum reproducible/binaries.sha256sum


### PR DESCRIPTION
This change allows to see both the binary size comparison and the hashes comparison, even if the former failed. Otherwise, the job would be cancelled after the first failure, preventing us from seeing all the diffs.

Note: It's unclear from the documentation how GitHub will aggregate the status of the whole job in case one step fails but not the next. We might have to adjust that after seeing the effect in practice on pull requests. On the other hand, if the sizes don't match, the cryptographic hashes shouldn't match either.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR