### PR TITLE
Add reference elf2tab and binary hashes to the uploaded reproduced.tar file

### DIFF
--- a/reproduce_hashes.sh
+++ b/reproduce_hashes.sh
@@ -35,3 +35,6 @@ done
 echo "Computing SHA-256 sum of the TAB file..."
 ./third_party/tock/tools/sha256sum/target/debug/sha256sum target/tab/ctap2.tab >> reproducible/binaries.sha256sum
 tar -rvf reproducible/reproduced.tar target/tab/ctap2.tab
+
+tar -rvf reproducible/reproduced.tar reproducible/elf2tab.txt
+tar -rvf reproducible/reproduced.tar reproducible/binaries.sha256sum


### PR DESCRIPTION
This adds the `reproducible/elf2tab.txt` and `reproducible/binaries.sha256sum` files to the `reproduced.tar` archive that is uploaded in the "check reproducible" GitHub action, to make it easier to update the reference binaries in pull requests.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR