### PR TITLE
Move to tockloader 1.5

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          pip install 'tockloader==1.4' pylint
+          pip install 'tockloader==1.5' pylint
       - name: Register matcher
         run: echo ::add-matcher::./.github/python_matcher.json
       - name: Test code with pylint

--- a/setup.sh
+++ b/setup.sh
@@ -38,7 +38,7 @@ source tools/gen_key_materials.sh
 generate_crypto_materials N
 
 rustup install $(head -n 1 rust-toolchain)
-pip3 install --user --upgrade 'tockloader==1.4' six intelhex
+pip3 install --user --upgrade 'tockloader==1.5' six intelhex
 rustup target add thumbv7em-none-eabi
 
 # Install dependency to create applications.


### PR DESCRIPTION
Fixes #130 

Just moving to a newer version of tockloader.
We don't need anymore to craft a fake app for padding as tockloader 1.5 understand what padding is and provides a dedicated object.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR