### PR TITLE
Bump required version for nrfutil to 6.1+

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -607,8 +607,9 @@ class OpenSKInstaller:
       assert_python_library("intelhex")
       assert_python_library("nordicsemi.lister")
       nrfutil_version = __import__("nordicsemi.version").version.NRFUTIL_VERSION
-      if not nrfutil_version.startswith("6."):
-        fatal(("You need to install nrfutil python3 package v6.0 or above. "
+      nrfutil_major, nrfutil_minor, _ = nrfutil_version.split(".", 3)
+      if not (int(nrfutil_major) == 6 and int(nrfutil_minor) >= 1):
+        fatal(("You need to install nrfutil python3 package v6.1 or above. "
                "Found: {}".format(nrfutil_version)))
       if not SUPPORTED_BOARDS[self.args.board].nordic_dfu:
         fatal("This board doesn't support flashing over DFU.")
@@ -715,7 +716,7 @@ class OpenSKInstaller:
         info("Flashing device using DFU...")
         return subprocess.run(
             [
-                "nrfutil", "dfu", "usb-serial",
+                "nrfutil", "dfu", "usb_serial",
                 "--package={}".format(dfu_pkg_file),
                 "--serial-number={}".format(serial_number[0])
             ],


### PR DESCRIPTION
Fixes #135

Now requiring nrfutil package 6.1+ so that we don't have to handle the difference between v6.0 which expects `usb-serial` parameter and v6.1 which expects `usb_serial` instead.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR