### PR TITLE
Add console_test example to stress-test Tock's console driver.

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -913,6 +913,13 @@ if __name__ == "__main__":
       const="oom_test",
       help=("Compiles and installs the oom_test example that tests the "
             "allocator until an out-of-memory error occurs."))
+  apps_group.add_argument(
+      "--console_test",
+      dest="application",
+      action="store_const",
+      const="console_test",
+      help=("Compiles and installs the console_test example that tests the "
+            "console driver with messages of various lengths."))
 
   main_parser.set_defaults(features=["with_ctap1"])
 

--- a/examples/console_test.rs
+++ b/examples/console_test.rs
@@ -1,0 +1,33 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![no_std]
+
+extern crate lang_items;
+
+use libtock_drivers::console::{Console, BUFFER_SIZE};
+
+fn main() {
+    // Write messages of length up to the console driver's buffer size.
+    let mut buf = [0; BUFFER_SIZE];
+    loop {
+        for i in 1..buf.len() {
+            for j in 0..i {
+                buf[j] = b'0' + ((i % 10) as u8);
+            }
+            buf[i] = b'\n';
+            Console::write_unbuffered(&mut buf[..(i + 1)]);
+        }
+    }
+}

--- a/third_party/libtock-drivers/src/console.rs
+++ b/third_party/libtock-drivers/src/console.rs
@@ -17,7 +17,7 @@ mod allow_nr {
     pub const SHARE_BUFFER: usize = 1;
 }
 
-const BUFFER_SIZE: usize = 1024;
+pub const BUFFER_SIZE: usize = 1024;
 
 pub struct Console {
     allow_buffer: [u8; BUFFER_SIZE],
@@ -70,11 +70,13 @@ impl Console {
         // Clear the buffer even in case of error, to avoid an infinite loop.
         self.count_pending = 0;
 
-        let result = syscalls::allow(
-            DRIVER_NUMBER,
-            allow_nr::SHARE_BUFFER,
-            &mut self.allow_buffer[..count],
-        );
+        Console::write_unbuffered(&mut self.allow_buffer[..count]);
+    }
+
+    pub fn write_unbuffered(buf: &mut [u8]) {
+        let count = buf.len();
+
+        let result = syscalls::allow(DRIVER_NUMBER, allow_nr::SHARE_BUFFER, buf);
         if result.is_err() {
             return;
         }


### PR DESCRIPTION
This example is inspired by https://github.com/gendx/libtock-rs/commit/9a25591ccdfa51c99a6b641a11bcc9eeb32967da and the discussion at https://github.com/tock/tock/issues/1697. It can be used to make sure that the buffering performed by the `Console` driver is handled properly by TockOS.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR