### PR TITLE
Install elf2tab in its own directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,13 @@
-bin/
 target/
 Cargo.lock
 
+# Local installation of elf2tab.
+/elf2tab/
+
 # Prevent people from commiting sensitive files.
-crypto_data/
+/crypto_data/
 
 # Temporary files.
-reproducible/binaries.sha256sum
-reproducible/elf2tab.txt
-reproducible/reproduced.tar
+/reproducible/binaries.sha256sum
+/reproducible/elf2tab.txt
+/reproducible/reproduced.tar

--- a/deploy.py
+++ b/deploy.py
@@ -404,9 +404,9 @@ class OpenSKInstaller:
     assert self.args.application
     info("Generating Tock TAB file for application/example {}".format(
         self.args.application))
-    elf2tab_ver = self.checked_command_output(["bin/elf2tab",
-                                               "--version"]).split(
-                                                   "\n", maxsplit=1)[0]
+    elf2tab_ver = self.checked_command_output(
+        ["elf2tab/bin/elf2tab", "--version"]).split(
+            "\n", maxsplit=1)[0]
     if elf2tab_ver != "elf2tab 0.6.0":
       error(
           ("Detected unsupported elf2tab version {!a}. The following "
@@ -415,7 +415,7 @@ class OpenSKInstaller:
     tab_filename = os.path.join(self.tab_folder,
                                 "{}.tab".format(self.args.application))
     elf2tab_args = [
-        "bin/elf2tab", "--deterministic", "--package-name",
+        "elf2tab/bin/elf2tab", "--deterministic", "--package-name",
         self.args.application, "-o", tab_filename
     ]
     if self.args.verbose_build:

--- a/reset.sh
+++ b/reset.sh
@@ -26,7 +26,7 @@ while
       # Reset the submodules
       git submodule foreach 'git reset --hard && git clean -fxd'
       # Reset also the main repository
-      git reset --hard && git clean -fxd
+      git reset --hard && git clean -fxd --exclude elf2tab
 
       set +x
       echo "DONE."

--- a/setup.sh
+++ b/setup.sh
@@ -42,4 +42,5 @@ pip3 install --user --upgrade 'tockloader==1.5' six intelhex
 rustup target add thumbv7em-none-eabi
 
 # Install dependency to create applications.
-cargo install elf2tab --version 0.6.0 --root .
+mkdir -p elf2tab
+cargo install elf2tab --version 0.6.0 --root elf2tab/


### PR DESCRIPTION
Since #145, `elf2tab` is installed in the OpenSK root directory.
- This is not clean as the `.crates.toml` and `.crates2.json` files appear in the root.
- The `reset.sh` script removes this local `elf2tab` installation, which means that a full compilation of `elf2tab` will happen again on the next `./setup.sh` run. This is not necessary, as the setup script will check the version and re-install it if a version upgrade is needed.

This pull request installs `elf2tab` in its own sub-directory instead, which is excluded from the `reset.sh` script.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR