### PR TITLE
Disable reproducible workflow

### DIFF
--- a/.github/workflows/reproducible.yml
+++ b/.github/workflows/reproducible.yml
@@ -38,9 +38,9 @@ jobs:
           name: reproduced-${{ matrix.os }}
           path: reproducible/reproduced.tar
 
-      - name: Comparing binary sizes
-        if: always()
-        run: git diff --no-index reproducible/reference_elf2tab_${{ matrix.os }}.txt reproducible/elf2tab.txt
-      - name: Comparing cryptographic hashes
-        if: always()
-        run: git diff --no-index reproducible/reference_binaries_${{ matrix.os }}.sha256sum reproducible/binaries.sha256sum
+      # - name: Comparing binary sizes
+      #   if: always()
+      #   run: git diff --no-index reproducible/reference_elf2tab_${{ matrix.os }}.txt reproducible/elf2tab.txt
+      # - name: Comparing cryptographic hashes
+      #   if: always()
+      #   run: git diff --no-index reproducible/reference_binaries_${{ matrix.os }}.sha256sum reproducible/binaries.sha256sum


### PR DESCRIPTION
As illustrated by #180, our build is not hermetic. As a consequence this workflow fails for unrelated reasons. Disabling until it brings any value.