### PR TITLE
Avoid erasing uicr

### DIFF
--- a/boards/nordic/nrf52840_mdk_dfu/src/main.rs
+++ b/boards/nordic/nrf52840_mdk_dfu/src/main.rs
@@ -26,7 +26,7 @@ const LED1_B_PIN: Pin = Pin::P0_24;
 
 // The nRF52840 Dongle button
 const BUTTON_PIN: Pin = Pin::P0_18;
-const BUTTON_RST_PIN: Pin = Pin::P0_02;
+// const BUTTON_RST_PIN: Pin = Pin::P0_02;
 
 const UART_RTS: Option<Pin> = Some(Pin::P0_21);
 const UART_TXD: Pin = Pin::P0_20;
@@ -209,12 +209,12 @@ pub unsafe fn reset_handler() {
     let chip = static_init!(nrf52840::chip::Chip, nrf52840::chip::new());
     CHIP = Some(chip);
 
-    nrf52_components::startup::NrfStartupComponent::new(
-        false,
-        BUTTON_RST_PIN,
-        nrf52840::uicr::Regulator0Output::V3_0,
-    )
-    .finalize(());
+    // nrf52_components::startup::NrfStartupComponent::new(
+    //     false,
+    //     BUTTON_RST_PIN,
+    //     nrf52840::uicr::Regulator0Output::V3_0,
+    // )
+    // .finalize(());
 
     // Create capabilities that the board needs to call certain protected kernel
     // functions.


### PR DESCRIPTION
Do not use `nrf52_components::startup::NrfStartupComponent::new` to change the reset pin, which will erase UICR.
As the start address of the bootloader is stored at UICR, erasing UICR will make the bootloader invalid.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR