### PR TITLE
Adds a UP check for device identification

### DIFF
--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -342,6 +342,7 @@ where
         if let Some(auth_param) = &pin_uv_auth_param {
             // This case was added in FIDO 2.1.
             if auth_param.is_empty() {
+                let _ = (self.check_user_presence)(cid);
                 if self.persistent_store.pin_hash()?.is_none() {
                     return Err(Ctap2StatusCode::CTAP2_ERR_PIN_NOT_SET);
                 } else {
@@ -545,6 +546,7 @@ where
         if let Some(auth_param) = &pin_uv_auth_param {
             // This case was added in FIDO 2.1.
             if auth_param.is_empty() {
+                let _ = (self.check_user_presence)(cid);
                 if self.persistent_store.pin_hash()?.is_none() {
                     return Err(Ctap2StatusCode::CTAP2_ERR_PIN_NOT_SET);
                 } else {

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -345,7 +345,7 @@ where
         if let Some(auth_param) = &pin_uv_auth_param {
             // This case was added in FIDO 2.1.
             if auth_param.is_empty() {
-                let _ = (self.check_user_presence)(cid);
+                (self.check_user_presence)(cid)?;
                 if self.persistent_store.pin_hash()?.is_none() {
                     return Err(Ctap2StatusCode::CTAP2_ERR_PIN_NOT_SET);
                 } else {
@@ -549,7 +549,7 @@ where
         if let Some(auth_param) = &pin_uv_auth_param {
             // This case was added in FIDO 2.1.
             if auth_param.is_empty() {
-                let _ = (self.check_user_presence)(cid);
+                (self.check_user_presence)(cid)?;
                 if self.persistent_store.pin_hash()?.is_none() {
                     return Err(Ctap2StatusCode::CTAP2_ERR_PIN_NOT_SET);
                 } else {


### PR DESCRIPTION
The spec introduced a feature where empty PIN auth parameters are used to trigger user presence checks. This is already checked in the test tool, and now also reflected here.

- [x] Tests pass

#106 