### PR TITLE
nano33ble support

### DIFF
--- a/boards/nano33ble/Cargo.toml
+++ b/boards/nano33ble/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "nano33ble"
+version = "0.1.0"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+build = "build.rs"
+edition = "2018"
+
+[dependencies]
+cortexm4 = { path = "../../arch/cortex-m4" }
+capsules = { path = "../../capsules" }
+kernel = { path = "../../kernel" }
+nrf52 = { path = "../../chips/nrf52" }
+nrf52840 = { path = "../../chips/nrf52840" }
+components = { path = "../components" }
+nrf52_components = { path = "../nordic/nrf52_components" }

--- a/boards/nano33ble/Makefile
+++ b/boards/nano33ble/Makefile
@@ -1,0 +1,16 @@
+# Makefile for building the tock kernel for the Arduino Nano 33 BLE board.
+
+TOCK_ARCH=cortex-m4
+TARGET=thumbv7em-none-eabi
+PLATFORM=nano33ble
+
+include ../Makefile.common
+
+ifdef PORT
+  FLAGS += --port $(PORT)
+endif
+
+# Upload the kernel using bossac
+.PHONY: program
+program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+	bossac $(FLAGS) -U -i -e -w $< -R

--- a/boards/nano33ble/README.md
+++ b/boards/nano33ble/README.md
@@ -1,0 +1,114 @@
+Arduino Nano 33 BLE
+===================
+
+<img src="https://store-cdn.arduino.cc/usa/catalog/product/cache/1/image/1040x660/604a3538c15e081937dbfbd20aa60aad/a/b/abx00031_featured.jpg" width="35%">
+
+The [Arduino Nano 33 BLE](https://store.arduino.cc/usa/nano-33-ble) and [Arduino
+Nano 33 BLE Sense](https://store.arduino.cc/usa/nano-33-ble-sense) are compact
+boards based on the Nordic nRF52840 SoC. The "Sense" version includes the
+following sensors:
+
+- 9 axis inertial sensor
+- humidity and temperature sensor
+- barometric sensor
+- microphone
+- gesture, proximity, light color and light intensity sensor
+
+
+## Getting Started
+
+First, follow the [Tock Getting Started guide](../../../doc/Getting_Started.md)
+
+You will need the bossac bootloader tool:
+
+```shell
+$ git clone https://github.com/arduino/BOSSA
+$ cd BOSSA
+$ make bossac
+```
+
+Then you will need to add `BOSSA/bin` to your `$PATH` variable so that your
+system can find the `bossac` program.
+
+## Programming the Kernel
+
+To program the kernel we use the BOSSA tool to communicate with the bootloader
+on the board which then flashes the kernel. This requires that the bootloader be
+active. To force the board into bootloader mode, press the button on the board
+twice in rapid succession. You should see the yellow LED pulse on and off.
+
+At this point you should be able to simply run `make program` in this directory
+to install a fresh kernel.
+
+```
+$ make program
+```
+
+You may need to specify the port like so:
+
+```
+$ make program PORT=<serial port path>
+```
+
+## Programming Applications
+
+This is currently a weakness of the Nano 33 board as flashing applications is
+not as ergonomic as Tock expects. Right now, you should be able to flash a
+single application. For example, to flash the "blink" app, first compile it:
+
+```
+$ git clone https://github.com/tock/libtock-c
+$ cd libtock-c/examples/blink
+$ make
+```
+
+This previous step will create a TAB (`.tab` file) that normally tockloader
+would use to program on the board. However, tockloader is currently not
+supported. As a workaround, we can directly program a single app. To load the
+blink app, first press the button on the board twice in rapid succession to
+enter the bootloader, and then:
+
+```
+$ bossac -i -e -o 0x20000 -w build/cortex-m4/cortex-m4.tbf -R
+```
+
+That tells the BOSSA tool to flash the application in the Tock Binary Format to
+the correct offset (the app will end up at address 0x30000). You may also need
+to pass the `--port` flag.
+
+### Userspace Resource Mapping
+
+This table shows the mappings between resources available in userspace
+and the physical elements on the Nano 33 BLE board.
+
+| Software Resource | Physical Element    |
+|-------------------|---------------------|
+| GPIO[2]           | Pin D2              |
+| GPIO[3]           | Pin D3              |
+| GPIO[4]           | Pin D4              |
+| GPIO[5]           | Pin D5              |
+| GPIO[6]           | Pin D6              |
+| GPIO[7]           | Pin D7              |
+| GPIO[8]           | Pin D8              |
+| GPIO[9]           | Pin D9              |
+| GPIO[10]          | Pin D10             |
+| LED[0]            | Tri-color LED Red   |
+| LED[1]            | Tri-color LED Green |
+| LED[2]            | Tri-color LED Blue  |
+
+## Debugging
+
+The Nano 33 board uses a virtual serial console over USB to send debugging info
+from the kernel and print messages from applications. You can use whatever your
+favorite serial terminal program is to view the output. Tockloader also
+supports reading and writing to a serial console with `tockloader listen`.
+
+### Kernel Panics
+
+If the kernel or an app encounter a `panic!()`, the panic handler specified in
+`io.rs` is called. This causes the kernel to stop. You will notice the yellow
+LED starts blinking in a repeating but slightly irregular pattern. There is also
+a panic print out that provides a fair bit of debugging information. However,
+currently that panic print info is transmitted over `UARTE0`, not the USB port.
+So, to view the panic info, you will need to connect to the two pins on the
+board labeled `TX1` and `RX0` and view the UART information there.

--- a/boards/nano33ble/build.rs
+++ b/boards/nano33ble/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rerun-if-changed=layout.ld");
+    println!("cargo:rerun-if-changed=../kernel_layout.ld");
+}

--- a/boards/nano33ble/layout.ld
+++ b/boards/nano33ble/layout.ld
@@ -1,0 +1,11 @@
+MEMORY
+{
+  rom (rx)  : ORIGIN = 0x00010000, LENGTH = 128K
+  prog (rx) : ORIGIN = 0x00040000, LENGTH = 768K
+  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 256K
+}
+
+MPU_MIN_ALIGN = 8K;
+PAGE_SIZE = 4K;
+
+INCLUDE ../kernel_layout.ld

--- a/boards/nano33ble/src/io.rs
+++ b/boards/nano33ble/src/io.rs
@@ -1,0 +1,67 @@
+use core::fmt::Write;
+use core::panic::PanicInfo;
+
+use cortexm4;
+use kernel::debug;
+use kernel::debug::IoWrite;
+use kernel::hil::led;
+use kernel::hil::uart::{self, Configure};
+use nrf52840::gpio::Pin;
+
+use crate::CHIP;
+use crate::PROCESSES;
+
+struct Writer {
+    initialized: bool,
+}
+
+static mut WRITER: Writer = Writer { initialized: false };
+
+impl Write for Writer {
+    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+impl IoWrite for Writer {
+    fn write(&mut self, buf: &[u8]) {
+        let uart = unsafe { &mut nrf52840::uart::UARTE0 };
+        if !self.initialized {
+            self.initialized = true;
+            uart.configure(uart::Parameters {
+                baud_rate: 115200,
+                stop_bits: uart::StopBits::One,
+                parity: uart::Parity::None,
+                hw_flow_control: false,
+                width: uart::Width::Eight,
+            });
+        }
+        for &c in buf {
+            unsafe {
+                uart.send_byte(c);
+            }
+            while !uart.tx_ready() {}
+        }
+    }
+}
+
+/// Default panic handler for the Nano 33 Board.
+///
+/// We just use the standard default provided by the debug module in the kernel.
+#[cfg(not(test))]
+#[no_mangle]
+#[panic_handler]
+pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+    const LED_KERNEL_PIN: Pin = Pin::P0_13;
+    let led = &mut led::LedLow::new(&mut nrf52840::gpio::PORT[LED_KERNEL_PIN]);
+    let writer = &mut WRITER;
+    debug::panic(
+        &mut [led],
+        writer,
+        pi,
+        &cortexm4::support::nop,
+        &PROCESSES,
+        &CHIP,
+    )
+}

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -1,0 +1,502 @@
+//! Tock kernel for the Arduino Nano 33 BLE.
+//!
+//! It is based on nRF52840 SoC (Cortex M4 core with a BLE + IEEE 802.15.4 transceiver).
+
+#![no_std]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
+#![feature(const_in_array_repeat_expressions)]
+#![deny(missing_docs)]
+
+use kernel::capabilities;
+use kernel::common::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
+use kernel::component::Component;
+use kernel::hil::usb::UsbController;
+use kernel::hil::gpio::ActivationMode::ActiveLow;
+use kernel::hil::gpio::Configure;
+use kernel::hil::gpio::Output;
+use kernel::hil::i2c::I2CMaster;
+use kernel::mpu::MPU;
+use kernel::Chip;
+use nrf52_components::{self, UartChannel, UartPins};
+#[allow(unused_imports)]
+use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
+
+use nrf52840::gpio::Pin;
+
+
+// Three-color LED.
+const LED_RED_PIN: Pin = Pin::P0_24;
+const LED_GREEN_PIN: Pin = Pin::P0_16;
+const LED_BLUE_PIN: Pin = Pin::P0_06;
+
+const LED_KERNEL_PIN: Pin = Pin::P0_13;
+
+const _BUTTON_RST_PIN: Pin = Pin::P0_18;
+
+const GPIO_D2: Pin = Pin::P1_11;
+const GPIO_D3: Pin = Pin::P1_12;
+const GPIO_D4: Pin = Pin::P1_15;
+const GPIO_D5: Pin = Pin::P1_13;
+const GPIO_D6: Pin = Pin::P1_14;
+const GPIO_D7: Pin = Pin::P0_23;
+const GPIO_D8: Pin = Pin::P0_21;
+const GPIO_D9: Pin = Pin::P0_27;
+const GPIO_D10: Pin = Pin::P1_02;
+
+const _UART_TX_PIN: Pin = Pin::P1_03;
+const _UART_RX_PIN: Pin = Pin::P1_10;
+const _UART_CTS_PIN: Option<Pin> = None;
+const _UART_RTS_PIN: Option<Pin> = None;
+
+/// I2C pins for all of the sensors.
+const I2C_SDA_PIN: Pin = Pin::P0_14;
+const I2C_SCL_PIN: Pin = Pin::P0_15;
+
+/// GPIO tied to the VCC of the I2C pullup resistors.
+const I2C_PULLUP_PIN: Pin = Pin::P1_00;
+
+/// Interrupt pin for the APDS9960 sensor.
+//const APDS9960_PIN: Pin = Pin::P0_19;
+
+/// UART Writer for panic!()s.
+pub mod io;
+
+// State for loading and holding applications.
+// How should the kernel respond when a process faults.
+const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+
+// Number of concurrent processes this platform supports.
+const NUM_PROCS: usize = 8;
+
+static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROCS] = [None; NUM_PROCS];
+
+static mut STORAGE_LOCATIONS: [kernel::StorageLocation; 1] = [kernel::StorageLocation {
+    address: 0xC0000,
+    size: 0x40000,
+}];
+
+static mut CHIP: Option<&'static nrf52840::chip::Chip> = None;
+
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
+
+/// Supported drivers by the platform
+pub struct Platform {
+    pconsole: &'static capsules::process_console::ProcessConsole<
+        'static,
+        components::process_console::Capability,
+    >,
+    console: &'static capsules::console::Console<'static>,
+    //proximity: &'static capsules::proximity::ProximitySensor<'static>,
+    gpio: &'static capsules::gpio::GPIO<'static, nrf52840::gpio::GPIOPin<'static>>,
+    led: &'static capsules::led::LED<'static, nrf52840::gpio::GPIOPin<'static>>,
+    button: &'static capsules::button::Button<'static, nrf52840::gpio::GPIOPin<'static>>,
+    rng: &'static capsules::rng::RngDriver<'static>,
+    ipc: kernel::ipc::IPC,
+    alarm: &'static capsules::alarm::AlarmDriver<
+        'static,
+        capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
+    >,
+    usb: &'static capsules::usb::usb_ctap::CtapUsbSyscallDriver<
+        'static,
+        'static,
+        nrf52840::usbd::Usbd<'static>,
+    >,
+    nvmc: &'static nrf52840::nvmc::SyscallDriver
+}
+
+impl kernel::Platform for Platform {
+    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    where
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
+    {
+        match driver_num {
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            //capsules::proximity::DRIVER_NUM => f(Some(self.proximity)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::rng::DRIVER_NUM => f(Some(self.rng)),
+            capsules::button::DRIVER_NUM => f(Some(self.button)),
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
+            nrf52840::nvmc::DRIVER_NUM => f(Some(self.nvmc)),
+            capsules::usb::usb_ctap::DRIVER_NUM => f(Some(self.usb)),
+            _ => f(None),
+        }
+    }
+
+    fn filter_syscall(
+        &self,
+        process: &dyn kernel::procs::ProcessType,
+        syscall: &kernel::syscall::Syscall,
+    ) -> Result<(), kernel::ReturnCode> {
+        use kernel::syscall::Syscall;
+        match *syscall {
+            Syscall::COMMAND {
+                driver_number: nrf52840::nvmc::DRIVER_NUM,
+                subdriver_number: cmd,
+                arg0: ptr,
+                arg1: len,
+            } if (cmd == 2 || cmd == 3) && !process.fits_in_storage_location(ptr, len) => {
+                Err(kernel::ReturnCode::EINVAL)
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+/// Entry point in the vector table called on hard reset.
+#[no_mangle]
+pub unsafe fn reset_handler() {
+    // Loads relocations and clears BSS
+    nrf52840::init();
+
+    let board_kernel = static_init!(
+        kernel::Kernel,
+        kernel::Kernel::new_with_storage(&PROCESSES, &STORAGE_LOCATIONS));
+
+    //--------------------------------------------------------------------------
+    // CAPABILITIES
+    //--------------------------------------------------------------------------
+
+    // Create capabilities that the board needs to call certain protected kernel
+    // functions.
+    let process_management_capability =
+        create_capability!(capabilities::ProcessManagementCapability);
+    let main_loop_capability = create_capability!(capabilities::MainLoopCapability);
+    let memory_allocation_capability = create_capability!(capabilities::MemoryAllocationCapability);
+
+    //--------------------------------------------------------------------------
+    // DEBUG GPIO
+    //--------------------------------------------------------------------------
+
+    // Configure kernel debug GPIOs as early as possible. These are used by the
+    // `debug_gpio!(0, toggle)` macro. We configure these early so that the
+    // macro is available during most of the setup code and kernel execution.
+    kernel::debug::assign_gpios(Some(&nrf52840::gpio::PORT[LED_KERNEL_PIN]), None, None);
+
+    //--------------------------------------------------------------------------
+    // BUTTON
+    //--------------------------------------------------------------------------
+
+
+    // The button has been set by default on PIN D2. If you'd like to change it,
+    // you can modify the PORT with the desired PIN and comment it below at the GPIO initialization
+
+    let button = components::button::ButtonComponent::new(
+        board_kernel,
+        components::button_component_helper!(
+            nrf52840::gpio::GPIOPin,
+            (
+                &nrf52840::gpio::PORT[GPIO_D2],
+                kernel::hil::gpio::ActivationMode::ActiveHigh,
+                kernel::hil::gpio::FloatingState::PullNone
+            )
+        ),
+    )
+    .finalize(components::button_component_buf!(nrf52840::gpio::GPIOPin));
+
+
+    //--------------------------------------------------------------------------
+    // GPIO
+    //--------------------------------------------------------------------------
+
+
+    let gpio = components::gpio::GpioComponent::new(
+        board_kernel,
+        components::gpio_component_helper!(
+            nrf52840::gpio::GPIOPin,
+            // PIN D2 has been hooked up to a button, as shown above
+            //2 => &nrf52840::gpio::PORT[GPIO_D2],
+            3 => &nrf52840::gpio::PORT[GPIO_D3],
+            4 => &nrf52840::gpio::PORT[GPIO_D4],
+            5 => &nrf52840::gpio::PORT[GPIO_D5],
+            6 => &nrf52840::gpio::PORT[GPIO_D6],
+            7 => &nrf52840::gpio::PORT[GPIO_D7],
+            8 => &nrf52840::gpio::PORT[GPIO_D8],
+            9 => &nrf52840::gpio::PORT[GPIO_D9],
+            10 => &nrf52840::gpio::PORT[GPIO_D10]
+        ),
+    )
+    .finalize(components::gpio_component_buf!(nrf52840::gpio::GPIOPin));
+
+    //--------------------------------------------------------------------------
+    // LEDs
+    //--------------------------------------------------------------------------
+
+    let led = components::led::LedsComponent::new(components::led_component_helper!(
+        nrf52840::gpio::GPIOPin,
+        (&nrf52840::gpio::PORT[LED_RED_PIN], ActiveLow),
+        (&nrf52840::gpio::PORT[LED_GREEN_PIN], ActiveLow),
+        (&nrf52840::gpio::PORT[LED_BLUE_PIN], ActiveLow)
+    ))
+    .finalize(components::led_component_buf!(nrf52840::gpio::GPIOPin));
+
+    nrf52_components::startup::NrfStartupComponent::new(
+        false,
+        _BUTTON_RST_PIN,
+        nrf52840::uicr::Regulator0Output::V3_0,
+    )
+    .finalize(());
+
+    //--------------------------------------------------------------------------
+    // Deferred Call (Dynamic) Setup
+    //--------------------------------------------------------------------------
+
+    let dynamic_deferred_call_clients =
+        static_init!([DynamicDeferredCallClientState; 2], Default::default());
+    let dynamic_deferred_caller = static_init!(
+        DynamicDeferredCall,
+        DynamicDeferredCall::new(dynamic_deferred_call_clients)
+    );
+    DynamicDeferredCall::set_global_instance(dynamic_deferred_caller);
+
+    //--------------------------------------------------------------------------
+    // ALARM & TIMER
+    //--------------------------------------------------------------------------
+
+    let rtc = &nrf52840::rtc::RTC;
+    rtc.start();
+
+    let mux_alarm = components::alarm::AlarmMuxComponent::new(rtc)
+        .finalize(components::alarm_mux_component_helper!(nrf52840::rtc::Rtc));
+    let alarm = components::alarm::AlarmDriverComponent::new(board_kernel, mux_alarm)
+        .finalize(components::alarm_component_helper!(nrf52840::rtc::Rtc));
+
+    //--------------------------------------------------------------------------
+    // UART & CONSOLE & DEBUG
+    //--------------------------------------------------------------------------
+
+    // Setup the CDC-ACM over USB driver that we will use for UART.
+    // We use the Arduino Vendor ID and Product ID since the device is the same.
+
+    // Create the strings we include in the USB descriptor. We use the hardcoded
+    // DEVICEADDR register on the nRF52 to set the serial number.
+    let serial_number_buf = static_init!([u8; 17], [0; 17]);
+    let serial_number_string: &'static str =
+        nrf52840::ficr::FICR_INSTANCE.address_str(serial_number_buf);
+    let strings = static_init!(
+        [&str; 3],
+        [
+            "Arduino",              // Manufacturer
+            "Nano 33 BLE - TockOS", // Product
+            serial_number_string,   // Serial number
+        ]
+    );
+
+    let uart_channel = UartChannel::Pins(UartPins::new(_UART_RTS_PIN, _UART_TX_PIN, _UART_CTS_PIN, _UART_RX_PIN));
+    let channel = nrf52_components::UartChannelComponent::new(uart_channel, mux_alarm).finalize(());
+
+    // Create a shared UART channel for the console and for kernel debug.
+    let uart_mux =
+    components::console::UartMuxComponent::new(channel, 115200, dynamic_deferred_caller)
+        .finalize(());
+
+    let pconsole =
+    components::process_console::ProcessConsoleComponent::new(board_kernel, uart_mux)
+        .finalize(());
+
+    // Setup the console.
+    let console = components::console::ConsoleComponent::new(board_kernel, uart_mux).finalize(());
+    // Create the debugger object that handles calls to `debug!()`.
+    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+
+
+    //--------------------------------------------------------------------------
+    // RANDOM NUMBERS
+    //--------------------------------------------------------------------------
+
+    let rng = components::rng::RngComponent::new(board_kernel, &nrf52840::trng::TRNG).finalize(());
+
+    //--------------------------------------------------------------------------
+    // SENSORS
+    //--------------------------------------------------------------------------
+
+    let sensors_i2c_bus = static_init!(
+        capsules::virtual_i2c::MuxI2C<'static>,
+        capsules::virtual_i2c::MuxI2C::new(&nrf52840::i2c::TWIM0, None, dynamic_deferred_caller)
+    );
+    nrf52840::i2c::TWIM0.configure(
+        nrf52840::pinmux::Pinmux::new(I2C_SCL_PIN as u32),
+        nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN as u32),
+    );
+    nrf52840::i2c::TWIM0.set_master_client(sensors_i2c_bus);
+
+    &nrf52840::gpio::PORT[I2C_PULLUP_PIN].make_output();
+    &nrf52840::gpio::PORT[I2C_PULLUP_PIN].set();
+
+    // Disabled the gesture sensor since we do not need it in this context and the current tock repo 
+    // that OpenSK runs on does not contain it
+
+    /*
+    let apds9960_i2c = static_init!(
+        capsules::virtual_i2c::I2CDevice,
+        capsules::virtual_i2c::I2CDevice::new(sensors_i2c_bus, 0x39 << 1)
+    );
+
+    let apds9960 = static_init!(
+        capsules::apds9960::APDS9960<'static>,
+        capsules::apds9960::APDS9960::new(
+            apds9960_i2c,
+            &nrf52840::gpio::PORT[APDS9960_PIN],
+            &mut capsules::apds9960::BUFFER
+        )
+    );
+    apds9960_i2c.set_client(apds9960);
+    nrf52840::gpio::PORT[APDS9960_PIN].set_client(apds9960);
+    */
+
+
+    // Disabled the proximity sensor for the same reasons as stated above (apds9960)
+
+    // let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
+    /*
+    let proximity = static_init!(
+        capsules::proximity::ProximitySensor<'static>,
+        capsules::proximity::ProximitySensor::new(apds9960, board_kernel.create_grant(&grant_cap))
+    );
+    */
+
+   // kernel::hil::sensors::ProximityDriver::set_client(apds9960, proximity);
+
+    let nvmc = static_init!(
+        nrf52840::nvmc::SyscallDriver,
+        nrf52840::nvmc::SyscallDriver::new(
+            &nrf52840::nvmc::NVMC,
+            board_kernel.create_grant(&memory_allocation_capability),
+        )
+    );
+
+    //--------------------------------------------------------------------------
+    // USB
+    //------------------------------------------------------------------------
+
+    let usb:
+        &'static capsules::usb::usb_ctap::CtapUsbSyscallDriver<
+            'static,
+            'static,
+            nrf52840::usbd::Usbd<'static>,
+    > = {
+        let usb_ctap = static_init!(
+            capsules::usb::usbc_ctap_hid::ClientCtapHID<
+                'static,
+                'static,
+                nrf52840::usbd::Usbd<'static>,
+            >,
+            capsules::usb::usbc_ctap_hid::ClientCtapHID::new(
+                &nrf52840::usbd::USBD,
+                capsules::usb::usbc_client::MAX_CTRL_PACKET_SIZE_NRF52840,
+                0x2341,
+                0x005a,
+                strings,
+            )
+        );
+        nrf52840::usbd::USBD.set_client(usb_ctap);
+
+        // Enable power events to be sent to USB controller
+        nrf52840::power::POWER.set_usb_client(&nrf52840::usbd::USBD);
+        nrf52840::power::POWER.enable_interrupts();
+
+        // Configure the USB userspace driver
+        let usb_driver = static_init!(
+            capsules::usb::usb_ctap::CtapUsbSyscallDriver<
+                'static,
+                'static,
+                nrf52840::usbd::Usbd<'static>,
+            >,
+            capsules::usb::usb_ctap::CtapUsbSyscallDriver::new(
+                usb_ctap,
+                board_kernel.create_grant(&memory_allocation_capability)
+            )
+        );
+        usb_ctap.set_client(usb_driver);
+        usb_driver as &'static _
+    };
+
+    //--------------------------------------------------------------------------
+    // FINAL SETUP AND BOARD BOOT
+    //--------------------------------------------------------------------------
+
+    // Start all of the clocks. Low power operation will require a better
+    // approach than this.
+    nrf52_components::NrfClockComponent::new().finalize(());
+
+    let platform = Platform {
+        button: button,
+        pconsole: pconsole,
+        console: console,
+        //proximity: proximity,
+        led: led,
+        gpio: gpio,
+        rng: rng,
+        alarm: alarm,
+        usb: usb,
+        nvmc:nvmc,
+        ipc: kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability),
+    };
+
+    let chip = static_init!(nrf52840::chip::Chip, nrf52840::chip::new());
+    CHIP = Some(chip);
+
+    // Need to disable the MPU because the bootloader seems to set it up.
+    chip.mpu().clear_mpu();
+
+    // Configure the USB stack to enable a serial port over CDC-ACM.
+    //cdc.enable();
+    //cdc.attach();
+
+    platform.pconsole.start();
+
+    debug!("Initialization complete. Entering main loop.");
+
+    //--------------------------------------------------------------------------
+    // PROCESSES AND MAIN LOOP
+    //--------------------------------------------------------------------------
+
+    /// These symbols are defined in the linker script.
+    extern "C" {
+        /// Beginning of the ROM region containing app images.
+        static _sapps: u8;
+        /// End of the ROM region containing app images.
+        static _eapps: u8;
+        /// Beginning of the RAM region for app memory.
+        static mut _sappmem: u8;
+        /// End of the RAM region for app memory.
+        static _eappmem: u8;
+    }
+
+    kernel::procs::load_processes(
+        board_kernel,
+        chip,
+        core::slice::from_raw_parts(
+            &_sapps as *const u8,
+            &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
+        ),
+        core::slice::from_raw_parts_mut(
+            &mut _sappmem as *mut u8,
+            &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
+        ),
+        &mut PROCESSES,
+        FAULT_RESPONSE,
+        &process_management_capability,
+    )
+    .unwrap_or_else(|err| {
+        debug!("Error loading processes!");
+        debug!("{:?}", err);
+    });
+
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+        .finalize(components::rr_component_helper!(NUM_PROCS));
+    board_kernel.kernel_loop(
+        &platform,
+        chip,
+        Some(&platform.ipc),
+        scheduler,
+        &main_loop_capability,
+    );
+}

--- a/deploy.py
+++ b/deploy.py
@@ -26,7 +26,6 @@ import os
 import shutil
 import subprocess
 import sys
-
 import colorama
 from six.moves import input
 import tockloader
@@ -35,8 +34,8 @@ from tockloader import tbfh
 from tockloader import tockloader as loader
 from tockloader.exceptions import TockLoaderException
 
-PROGRAMMERS = frozenset(("jlink", "openocd", "pyocd",
-                        "nordicdfu", "none", "bossac"))
+PROGRAMMERS = frozenset(
+    ("jlink", "openocd", "pyocd", "nordicdfu", "none", "bossac"))
 
 # This structure allows us to support out-of-tree boards as well as (in the
 # future) more achitectures.
@@ -689,41 +688,37 @@ class OpenSKInstaller:
 
     if self.args.programmer == "bossac":
       props = SUPPORTED_BOARDS[self.args.board]
-            # Call the Makefile in order to build and flash Tock OS using bossac
+      # Call the Makefile in order to build and flash Tock OS using bossac
       if self.args.tockos:
         # The Arduino Nano requires a double tap on the reset button
         # in order to enter bootloader mode
         # We must wait for the user to confirm that
         # the board is ready to load something on it
-        info(
-            """Double tap the reset button on your Arduino Nano board
-            in order to begin the flashing process"""
-                )
+        info("""Double tap the reset button on your Arduino Nano board
+            in order to begin the flashing process""")
         info("Press [ENTER] when ready.")
         _ = input()
         self.checked_command(["make", "program"], cwd=props.path)
 
       # Install the app using bossac
       if self.args.application:
-        info(
-            """Double tap the reset button on your Arduino Nano board
-            in order to load the application onto the board"""
-            )
+        info("""Double tap the reset button on your Arduino Nano board
+            in order to load the application onto the board""")
         info("Press [ENTER] when ready.")
         _ = input()
 
         self.checked_command(
-          [
-          "bossac",
-          "-i",
-          "-e",
-          "-o",
-          "0x30000",
-          "-w",
-          "{}.tbf".format(props.arch),
-          "-R",
-          ],
-          cwd="target/tab/",
+            [
+                "bossac",
+                "-i",
+                "-e",
+                "-o",
+                "0x30000",
+                "-w",
+                "{}.tbf".format(props.arch),
+                "-R",
+            ],
+            cwd="target/tab/",
         )
 
     if self.args.programmer in ("pyocd", "nordicdfu", "none"):

--- a/deploy.py
+++ b/deploy.py
@@ -35,7 +35,8 @@ from tockloader import tbfh
 from tockloader import tockloader as loader
 from tockloader.exceptions import TockLoaderException
 
-PROGRAMMERS = frozenset(("jlink", "openocd", "pyocd", "nordicdfu", "none", "bossac"))
+PROGRAMMERS = frozenset(("jlink", "openocd", "pyocd",
+                        "nordicdfu", "none", "bossac"))
 
 # This structure allows us to support out-of-tree boards as well as (in the
 # future) more achitectures.
@@ -84,7 +85,7 @@ OpenSKBoard = collections.namedtuple(
     ])
 
 SUPPORTED_BOARDS = {
-    "nano33ble": 
+    "nano33ble":
         OpenSKBoard(
             path="third_party/tock/boards/nano33ble",
             arch="thumbv7em-none-eabi",
@@ -687,39 +688,43 @@ class OpenSKInstaller:
       return 0
 
     if self.args.programmer == "bossac":
-            props = SUPPORTED_BOARDS[self.args.board]
+      props = SUPPORTED_BOARDS[self.args.board]
             # Call the Makefile in order to build and flash Tock OS using bossac
-            if self.args.tockos:
-                # The Arduino Nano requires a double tap on the reset button in order to enter bootloader mode
-                # We must wait for the user to confirm that the board is ready to load something on it
-                info(
-                    "Double tap the reset button on your Arduino Nano board in order to begin the flashing process"
+      if self.args.tockos:
+        # The Arduino Nano requires a double tap on the reset button
+        # in order to enter bootloader mode
+        # We must wait for the user to confirm that
+        # the board is ready to load something on it
+        info(
+            """Double tap the reset button on your Arduino Nano board
+            in order to begin the flashing process"""
                 )
-                info("Press [ENTER] when ready.")
-                _ = input()
-                self.checked_command(["make", "program"], cwd=props.path)
+        info("Press [ENTER] when ready.")
+        _ = input()
+        self.checked_command(["make", "program"], cwd=props.path)
 
-            # Install the app using bossac
-            if self.args.application:
-                info(
-                    "Double tap the reset button on your Arduino Nano board in order to load the application onto the board"
-                )
-                info("Press [ENTER] when ready.")
-                _ = input()
+      # Install the app using bossac
+      if self.args.application:
+        info(
+            """Double tap the reset button on your Arduino Nano board
+            in order to load the application onto the board"""
+            )
+        info("Press [ENTER] when ready.")
+        _ = input()
 
-                self.checked_command(
-                    [
-                        "bossac",
-                        "-i",
-                        "-e",
-                        "-o",
-                        "0x30000",
-                        "-w",
-                        "{}.tbf".format(props.arch),
-                        "-R",
-                    ],
-                    cwd="target/tab/",
-                )
+        self.checked_command(
+          [
+          "bossac",
+          "-i",
+          "-e",
+          "-o",
+          "0x30000",
+          "-w",
+          "{}.tbf".format(props.arch),
+          "-R",
+          ],
+          cwd="target/tab/",
+        )
 
     if self.args.programmer in ("pyocd", "nordicdfu", "none"):
       dest_file = "target/{}_merged.hex".format(self.args.board)


### PR DESCRIPTION
Hello guys! I've recently managed to make the OpenSK project work on the nano33ble and I am interested in adding it to the OpenSK repo. I've got a question, though. I've added the necessary linker file + additions to the main.rs file of the board (in order to support USB HID and a button) to the boards/nano33ble directory, but I am not sure how to "transfer" it to the Tock patch that OpenSK uses. For example, I would like to replace the third_party/tock/boards/nano33ble directory that OpenSK currently uses.

Additional tools needed in order to install OpenSK and TockOS on the board: **bossac**. Details on how to get it up and running are in the board's README file.

If there is something I'm missing or any adjustments are needed, please let me know!
