### PR TITLE
Fix broken crypto_test workflow.

### DIFF
--- a/.github/workflows/crypto_test.yml
+++ b/.github/workflows/crypto_test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up OpenSK
         run: ./setup.sh
 
-      - run: echo "::set-env name=RUSTFLAGS::-C target-feature=+aes"
+      - run: echo "RUSTFLAGS=-C target-feature=+aes" >> $GITHUB_ENV
 
       - name: Unit testing of crypto library (release mode)
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
The use of `::set-env` command in workflows is not being depreacted.
Moving to the new way of setting environment variables.

Fixes #214

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR