### PR TITLE
fail on UP=true in make

### DIFF
--- a/src/ctap/data_formats.rs
+++ b/src/ctap/data_formats.rs
@@ -361,10 +361,8 @@ impl TryFrom<cbor::Value> for MakeCredentialOptions {
             Some(options_entry) => extract_bool(options_entry)?,
             None => false,
         };
-        if let Some(options_entry) = up {
-            if !extract_bool(options_entry)? {
-                return Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION);
-            }
+        if up.is_some() {
+            return Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION);
         }
         let uv = match uv {
             Some(options_entry) => extract_bool(options_entry)?,


### PR DESCRIPTION
Blocks #196 . While still being discussed in the specification, we probably want the behaviour that works with certification. We can always revert back if it turns out to work with the old implementation.

- [x] Tests pass