### PR TITLE
Ensure CTAP1 uses the storage to access attestation material

### DIFF
--- a/src/ctap/ctap1.rs
+++ b/src/ctap/ctap1.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use super::hid::ChannelID;
-use super::key_material::{ATTESTATION_CERTIFICATE, ATTESTATION_PRIVATE_KEY};
 use super::status_code::Ctap2StatusCode;
 use super::CtapState;
 use alloc::vec::Vec;
@@ -295,14 +294,22 @@ impl Ctap1Command {
             return Err(Ctap1StatusCode::SW_VENDOR_KEY_HANDLE_TOO_LONG);
         }
 
-        let mut response =
-            Vec::with_capacity(105 + key_handle.len() + ATTESTATION_CERTIFICATE.len());
+        let certificate = match ctap_state.persistent_store.attestation_certificate() {
+            Ok(Some(value)) => value,
+            _ => return Err(Ctap1StatusCode::SW_INS_NOT_SUPPORTED),
+        };
+        let private_key = match ctap_state.persistent_store.attestation_private_key() {
+            Ok(Some(value)) => value,
+            _ => return Err(Ctap1StatusCode::SW_INS_NOT_SUPPORTED),
+        };
+
+        let mut response = Vec::with_capacity(105 + key_handle.len() + certificate.len());
         response.push(Ctap1Command::LEGACY_BYTE);
         let user_pk = pk.to_uncompressed();
         response.extend_from_slice(&user_pk);
         response.push(key_handle.len() as u8);
         response.extend(key_handle.clone());
-        response.extend_from_slice(&ATTESTATION_CERTIFICATE);
+        response.extend_from_slice(&certificate);
 
         // The first byte is reserved.
         let mut signature_data = Vec::with_capacity(66 + key_handle.len());
@@ -312,7 +319,7 @@ impl Ctap1Command {
         signature_data.extend(key_handle);
         signature_data.extend_from_slice(&user_pk);
 
-        let attestation_key = crypto::ecdsa::SecKey::from_bytes(ATTESTATION_PRIVATE_KEY).unwrap();
+        let attestation_key = crypto::ecdsa::SecKey::from_bytes(private_key).unwrap();
         let signature = attestation_key.sign_rfc6979::<crypto::sha256::Sha256>(&signature_data);
 
         response.extend(signature.to_asn1_der());
@@ -373,7 +380,7 @@ impl Ctap1Command {
 
 #[cfg(test)]
 mod test {
-    use super::super::{CREDENTIAL_ID_BASE_SIZE, USE_SIGNATURE_COUNTER};
+    use super::super::{key_material, CREDENTIAL_ID_BASE_SIZE, USE_SIGNATURE_COUNTER};
     use super::*;
     use crypto::rng256::ThreadRng256;
     use crypto::Hash256;
@@ -434,8 +441,25 @@ mod test {
         ctap_state.u2f_up_state.consume_up(START_CLOCK_VALUE);
         ctap_state.u2f_up_state.grant_up(START_CLOCK_VALUE);
         let response =
-            Ctap1Command::process_command(&message, &mut ctap_state, START_CLOCK_VALUE).unwrap();
+            Ctap1Command::process_command(&message, &mut ctap_state, START_CLOCK_VALUE);
+        // Certificate and private key are missing
+        assert_eq!(response, Err(Ctap1StatusCode::SW_INS_NOT_SUPPORTED));
 
+        let fake_key = [0x41u8; key_material::ATTESTATION_PRIVATE_KEY_LENGTH];
+        assert!(ctap_state.persistent_store.set_attestation_private_key(&fake_key).is_ok());
+        ctap_state.u2f_up_state.consume_up(START_CLOCK_VALUE);
+        ctap_state.u2f_up_state.grant_up(START_CLOCK_VALUE);
+        let response =
+            Ctap1Command::process_command(&message, &mut ctap_state, START_CLOCK_VALUE);
+        // Certificate is still missing
+        assert_eq!(response, Err(Ctap1StatusCode::SW_INS_NOT_SUPPORTED));
+
+        let fake_cert = [0x99u8; 100]; // Arbitrary length
+        assert!(ctap_state.persistent_store.set_attestation_certificate(&fake_cert[..]).is_ok());
+        ctap_state.u2f_up_state.consume_up(START_CLOCK_VALUE);
+        ctap_state.u2f_up_state.grant_up(START_CLOCK_VALUE);
+        let response =
+            Ctap1Command::process_command(&message, &mut ctap_state, START_CLOCK_VALUE).unwrap();
         assert_eq!(response[0], Ctap1Command::LEGACY_BYTE);
         assert_eq!(response[66], CREDENTIAL_ID_BASE_SIZE as u8);
         assert!(ctap_state
@@ -447,8 +471,8 @@ mod test {
             .is_some());
         const CERT_START: usize = 67 + CREDENTIAL_ID_BASE_SIZE;
         assert_eq!(
-            &response[CERT_START..CERT_START + ATTESTATION_CERTIFICATE.len()],
-            &ATTESTATION_CERTIFICATE[..]
+            &response[CERT_START..CERT_START + fake_cert.len()],
+            &fake_cert[..]
         );
     }
 

--- a/src/ctap/ctap1.rs
+++ b/src/ctap/ctap1.rs
@@ -440,22 +440,26 @@ mod test {
         let message = create_register_message(&application);
         ctap_state.u2f_up_state.consume_up(START_CLOCK_VALUE);
         ctap_state.u2f_up_state.grant_up(START_CLOCK_VALUE);
-        let response =
-            Ctap1Command::process_command(&message, &mut ctap_state, START_CLOCK_VALUE);
+        let response = Ctap1Command::process_command(&message, &mut ctap_state, START_CLOCK_VALUE);
         // Certificate and private key are missing
         assert_eq!(response, Err(Ctap1StatusCode::SW_INS_NOT_SUPPORTED));
 
         let fake_key = [0x41u8; key_material::ATTESTATION_PRIVATE_KEY_LENGTH];
-        assert!(ctap_state.persistent_store.set_attestation_private_key(&fake_key).is_ok());
+        assert!(ctap_state
+            .persistent_store
+            .set_attestation_private_key(&fake_key)
+            .is_ok());
         ctap_state.u2f_up_state.consume_up(START_CLOCK_VALUE);
         ctap_state.u2f_up_state.grant_up(START_CLOCK_VALUE);
-        let response =
-            Ctap1Command::process_command(&message, &mut ctap_state, START_CLOCK_VALUE);
+        let response = Ctap1Command::process_command(&message, &mut ctap_state, START_CLOCK_VALUE);
         // Certificate is still missing
         assert_eq!(response, Err(Ctap1StatusCode::SW_INS_NOT_SUPPORTED));
 
         let fake_cert = [0x99u8; 100]; // Arbitrary length
-        assert!(ctap_state.persistent_store.set_attestation_certificate(&fake_cert[..]).is_ok());
+        assert!(ctap_state
+            .persistent_store
+            .set_attestation_certificate(&fake_cert[..])
+            .is_ok());
         ctap_state.u2f_up_state.consume_up(START_CLOCK_VALUE);
         ctap_state.u2f_up_state.grant_up(START_CLOCK_VALUE);
         let response =

--- a/src/ctap/key_material.rs
+++ b/src/ctap/key_material.rs
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub const AAGUID: &[u8; 16] = include_bytes!(concat!(env!("OUT_DIR"), "/opensk_aaguid.bin"));
+pub const ATTESTATION_PRIVATE_KEY_LENGTH: usize = 32;
+pub const AAGUID_LENGTH: usize = 16;
+
+pub const AAGUID: &[u8; AAGUID_LENGTH] = include_bytes!(concat!(env!("OUT_DIR"), "/opensk_aaguid.bin"));
 
 pub const ATTESTATION_CERTIFICATE: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/opensk_cert.bin"));
 
-pub const ATTESTATION_PRIVATE_KEY: &[u8; 32] =
+pub const ATTESTATION_PRIVATE_KEY: &[u8; ATTESTATION_PRIVATE_KEY_LENGTH] =
     include_bytes!(concat!(env!("OUT_DIR"), "/opensk_pkey.bin"));

--- a/src/ctap/key_material.rs
+++ b/src/ctap/key_material.rs
@@ -15,7 +15,8 @@
 pub const ATTESTATION_PRIVATE_KEY_LENGTH: usize = 32;
 pub const AAGUID_LENGTH: usize = 16;
 
-pub const AAGUID: &[u8; AAGUID_LENGTH] = include_bytes!(concat!(env!("OUT_DIR"), "/opensk_aaguid.bin"));
+pub const AAGUID: &[u8; AAGUID_LENGTH] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/opensk_aaguid.bin"));
 
 pub const ATTESTATION_CERTIFICATE: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/opensk_cert.bin"));

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -552,11 +552,11 @@ impl PersistentStore {
         let entry = StoreEntry {
             tag: ATTESTATION_PRIVATE_KEY,
             data: attestation_private_key,
-            sensitive: false,
+            sensitive: true,
         };
         match self.store.find_one(&Key::AttestationPrivateKey) {
             None => self.store.insert(entry)?,
-            Some((index, _)) => self.store.replace(index, entry)?,
+            _ => return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR),
         }
         Ok(())
     }
@@ -580,7 +580,7 @@ impl PersistentStore {
         };
         match self.store.find_one(&Key::AttestationCertificate) {
             None => self.store.insert(entry)?,
-            Some((index, _)) => self.store.replace(index, entry)?,
+            _ => return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR),
         }
         Ok(())
     }

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -230,8 +230,8 @@ impl PersistentStore {
                 .unwrap();
         }
         // TODO(jmichel): remove this when vendor command is in place
-        #[cfg(not(any(test, feature = "ram_storage")))]
-        self.load_attestation_from_firmware();
+        #[cfg(not(test))]
+        self.load_attestation_data_from_firmware();
 
         if self.store.find_one(&Key::Aaguid).is_none() {
             self.set_aaguid(key_material::AAGUID).unwrap();
@@ -239,8 +239,8 @@ impl PersistentStore {
     }
 
     // TODO(jmichel): remove this function when vendor command is in place.
-    #[cfg(not(any(test, feature = "ram_storage")))]
-    fn load_attestation_from_firmware(&mut self) {
+    #[cfg(not(test))]
+    fn load_attestation_data_from_firmware(&mut self) {
         // The following 2 entries are meant to be written by vendor-specific commands.
         if self.store.find_one(&Key::AttestationPrivateKey).is_none() {
             self.set_attestation_private_key(key_material::ATTESTATION_PRIVATE_KEY)


### PR DESCRIPTION
Part of the changes needed for #195 

This also prepares removing the crypto material from the firmware by:
* defining `attestation_private_key` as sensitive in the storage
* ensuring that the certificate and the private key are one-time programmable


- [x] Tests pass
- [ ] Appropriate changes to README are included in PR