### PR TITLE
Adds user data to stored credentials

### DIFF
--- a/src/ctap/pin_protocol_v1.rs
+++ b/src/ctap/pin_protocol_v1.rs
@@ -631,6 +631,22 @@ impl PinProtocolV1 {
         }
         Ok(())
     }
+
+    #[cfg(test)]
+    pub fn new_test(
+        key_agreement_key: crypto::ecdh::SecKey,
+        pin_uv_auth_token: [u8; 32],
+    ) -> PinProtocolV1 {
+        PinProtocolV1 {
+            key_agreement_key,
+            pin_uv_auth_token,
+            consecutive_pin_mismatches: 0,
+            #[cfg(feature = "with_ctap2_1")]
+            permissions: 0xFF,
+            #[cfg(feature = "with_ctap2_1")]
+            permissions_rp_id: None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -719,10 +719,12 @@ mod test {
             private_key,
             rp_id: String::from(rp_id),
             user_handle,
-            other_ui: None,
+            user_display_name: None,
             cred_random: None,
             cred_protect_policy: None,
             creation_order: 0,
+            user_name: None,
+            user_icon: None,
         }
     }
 
@@ -896,12 +898,14 @@ mod test {
             private_key,
             rp_id: String::from("example.com"),
             user_handle: vec![0x00],
-            other_ui: None,
+            user_display_name: None,
             cred_random: None,
             cred_protect_policy: Some(
                 CredentialProtectionPolicy::UserVerificationOptionalWithCredentialIdList,
             ),
             creation_order: 0,
+            user_name: None,
+            user_icon: None,
         };
         assert!(persistent_store.store_credential(credential).is_ok());
 
@@ -940,10 +944,12 @@ mod test {
             private_key: key0,
             rp_id: String::from("example.com"),
             user_handle: vec![0x00],
-            other_ui: None,
+            user_display_name: None,
             cred_random: None,
             cred_protect_policy: None,
             creation_order: 0,
+            user_name: None,
+            user_icon: None,
         };
         assert_eq!(found_credential, Some(expected_credential));
     }
@@ -960,10 +966,12 @@ mod test {
             private_key,
             rp_id: String::from("example.com"),
             user_handle: vec![0x00],
-            other_ui: None,
+            user_display_name: None,
             cred_random: None,
             cred_protect_policy: Some(CredentialProtectionPolicy::UserVerificationRequired),
             creation_order: 0,
+            user_name: None,
+            user_icon: None,
         };
         assert!(persistent_store.store_credential(credential).is_ok());
 
@@ -1138,10 +1146,12 @@ mod test {
             private_key,
             rp_id: String::from("example.com"),
             user_handle: vec![0x00],
-            other_ui: None,
+            user_display_name: None,
             cred_random: None,
             cred_protect_policy: None,
             creation_order: 0,
+            user_name: None,
+            user_icon: None,
         };
         let serialized = serialize_credential(credential.clone()).unwrap();
         let reconstructed = deserialize_credential(&serialized).unwrap();


### PR DESCRIPTION
Blocks #196 . And hopefully fixes it this time.

Returning user data is mandatory, so we added it to the store. We deviate from `WebAuthn`'s `CredentialSource` now, so I renamed `OtherUi` to what we actually used it for, the `DisplayName` in user. This should still be backwards compatible with the store, just adding @ia0 for checking.

- [x] Tests pass