### PR TITLE
Do not crash with dirty init

### DIFF
--- a/libraries/persistent_store/fuzz/src/store.rs
+++ b/libraries/persistent_store/fuzz/src/store.rs
@@ -133,7 +133,7 @@ impl<'a> Fuzzer<'a> {
             page_size: 1 << self.entropy.read_range(5, 12),
             max_word_writes: 2,
             max_page_erases: self.entropy.read_range(0, 50000),
-            strict_write: true,
+            strict_mode: true,
         };
         let num_pages = self.entropy.read_range(3, 64);
         self.record(StatKey::PageSize, options.page_size);
@@ -156,7 +156,7 @@ impl<'a> Fuzzer<'a> {
             if self.debug {
                 println!("Start with dirty storage.");
             }
-            options.strict_write = false;
+            options.strict_mode = false;
             let storage = BufferStorage::new(storage, options);
             StoreDriver::Off(StoreDriverOff::new_dirty(storage))
         } else if self.entropy.read_bit() {

--- a/libraries/persistent_store/src/store.rs
+++ b/libraries/persistent_store/src/store.rs
@@ -1257,7 +1257,7 @@ mod tests {
                 page_size: self.page_size,
                 max_word_writes: self.max_word_writes,
                 max_page_erases: self.max_page_erases,
-                strict_write: true,
+                strict_mode: true,
             };
             StoreDriverOff::new(options, self.num_pages)
         }


### PR DESCRIPTION
Also rename `strict_write` to `strict_mode` to enhance that it enables additional checks.

The dirty init already used to set `strict_write` to false.