### PR TITLE
implicitly generate HMAC-secret

### DIFF
--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -238,15 +238,14 @@ where
         let mut iv = [0; 16];
         iv.copy_from_slice(&self.rng.gen_uniform_u8x32()[..16]);
 
-        let block_len = 4;
-        let mut blocks = vec![[0u8; 16]; block_len];
+        let mut blocks = [[0u8; 16]; 4];
         blocks[0].copy_from_slice(&sk_bytes[..16]);
         blocks[1].copy_from_slice(&sk_bytes[16..]);
         blocks[2].copy_from_slice(&application[..16]);
         blocks[3].copy_from_slice(&application[16..]);
         cbc_encrypt(&aes_enc_key, iv, &mut blocks);
 
-        let mut encrypted_id = Vec::with_capacity(16 * (block_len + 3));
+        let mut encrypted_id = Vec::with_capacity(0x70);
         encrypted_id.extend(&iv);
         for b in &blocks {
             encrypted_id.extend(b);
@@ -280,9 +279,8 @@ where
         let aes_dec_key = crypto::aes256::DecryptionKey::new(&aes_enc_key);
         let mut iv = [0; 16];
         iv.copy_from_slice(&credential_id[..16]);
-        let block_len = 4;
-        let mut blocks = vec![[0u8; 16]; block_len];
-        for i in 0..block_len {
+        let mut blocks = [[0u8; 16]; 4];
+        for i in 0..4 {
             blocks[i].copy_from_slice(&credential_id[16 * (i + 1)..16 * (i + 2)]);
         }
 
@@ -608,7 +606,7 @@ where
         let mut private_key_bytes = [0u8; 32];
         private_key.to_bytes(&mut private_key_bytes);
         let key = self.persistent_store.cred_random_secret(has_uv)?;
-        Ok(hmac_256::<Sha256>(&key, &private_key_bytes[..]))
+        Ok(hmac_256::<Sha256>(&key, &private_key_bytes))
     }
 
     // Processes the input of a get_assertion operation for a given credential

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -607,10 +607,8 @@ where
     ) -> Result<[u8; 32], Ctap2StatusCode> {
         let mut private_key_bytes = [0u8; 32];
         private_key.to_bytes(&mut private_key_bytes);
-        let salt = crypto::sha256::Sha256::hash(&private_key_bytes);
-        // TODO(kaczmarczyck) KDF? hash salt together with rp_id_hash?
         let key = self.persistent_store.cred_random_secret(has_uv)?;
-        Ok(hmac_256::<Sha256>(&key, &salt[..]))
+        Ok(hmac_256::<Sha256>(&key, &private_key_bytes[..]))
     }
 
     // Processes the input of a get_assertion operation for a given credential

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -1011,7 +1011,7 @@ mod test {
         let mut rng = ThreadRng256 {};
         let mut persistent_store = PersistentStore::new(&mut rng);
 
-        // Master keys stay the same between calls.
+        // Master keys stay the same within the same CTAP reset cycle.
         let master_keys_1 = persistent_store.master_keys().unwrap();
         let master_keys_2 = persistent_store.master_keys().unwrap();
         assert_eq!(master_keys_2.encryption, master_keys_1.encryption);
@@ -1032,7 +1032,7 @@ mod test {
         let mut rng = ThreadRng256 {};
         let mut persistent_store = PersistentStore::new(&mut rng);
 
-        // Master keys stay the same between calls.
+        // CredRandom secrets stay the same within the same CTAP reset cycle.
         let cred_random_with_uv_1 = persistent_store.cred_random_secret(true).unwrap();
         let cred_random_without_uv_1 = persistent_store.cred_random_secret(false).unwrap();
         let cred_random_with_uv_2 = persistent_store.cred_random_secret(true).unwrap();
@@ -1040,7 +1040,7 @@ mod test {
         assert_eq!(cred_random_with_uv_1, cred_random_with_uv_2);
         assert_eq!(cred_random_without_uv_1, cred_random_without_uv_2);
 
-        // Master keys change after reset. This test may fail if the random generator produces the
+        // CredRandom secrets change after reset. This test may fail if the random generator produces the
         // same keys.
         persistent_store.reset(&mut rng).unwrap();
         let cred_random_with_uv_3 = persistent_store.cred_random_secret(true).unwrap();


### PR DESCRIPTION
This PR implements the new version of the HMAC-secret extension. It does so by reverting the extension of key handles in #218, now implicitly creating `cred_random` values deterministically from the credential and 2 new device secrets.

Part of #106 , but backwards compatible to the 2.0 version.

@jmichelp for checking the idea
@ia0 for storage
optional FYI @gendx for crypto (i.e. `generate_cred_random`)

- [x] Tests pass