### PR TITLE
Fix lang items

### DIFF
--- a/third_party/lang-items/Cargo.toml
+++ b/third_party/lang-items/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 libtock_core = { path = "../../third_party/libtock-rs/core", default-features = false, features = ["alloc_init", "custom_panic_handler", "custom_alloc_error_handler"] }
 libtock_drivers = { path = "../libtock-drivers" }
-linked_list_allocator = { version = "=0.8.1", default-features = false }
+linked_list_allocator = { version = "0.8.7", default-features = false, features = ["const_mut_refs"] }
 
 [features]
 debug_allocations = []

--- a/third_party/lang-items/Cargo.toml
+++ b/third_party/lang-items/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 libtock_core = { path = "../../third_party/libtock-rs/core", default-features = false, features = ["alloc_init", "custom_panic_handler", "custom_alloc_error_handler"] }
 libtock_drivers = { path = "../libtock-drivers" }
-linked_list_allocator = { version = "0.8.1", default-features = false }
+linked_list_allocator = { version = "=0.8.1", default-features = false }
 
 [features]
 debug_allocations = []


### PR DESCRIPTION
`linked-list-allocator` released version 0.8.7 today which adds a feature that we need to preserve previous behavior. See https://github.com/phil-opp/linked-list-allocator/blob/master/Changelog.md#087--2020-12-10
