### PR TITLE
Updates status codes for RD02 of CTAP 2.1

### DIFF
--- a/src/ctap/hid/mod.rs
+++ b/src/ctap/hid/mod.rs
@@ -219,7 +219,7 @@ impl CtapHid {
                                 cid,
                                 cmd: CtapHid::COMMAND_CBOR,
                                 payload: vec![
-                                    Ctap2StatusCode::CTAP2_ERR_VENDOR_RESPONSE_TOO_LONG as u8,
+                                    Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR as u8,
                                 ],
                             })
                             .unwrap()

--- a/src/ctap/status_code.rs
+++ b/src/ctap/status_code.rs
@@ -31,11 +31,10 @@ pub enum Ctap2StatusCode {
     CTAP2_ERR_INVALID_CBOR = 0x12,
     CTAP2_ERR_MISSING_PARAMETER = 0x14,
     CTAP2_ERR_LIMIT_EXCEEDED = 0x15,
-    CTAP2_ERR_UNSUPPORTED_EXTENSION = 0x16,
     #[cfg(feature = "with_ctap2_1")]
     CTAP2_ERR_FP_DATABASE_FULL = 0x17,
     #[cfg(feature = "with_ctap2_1")]
-    CTAP2_ERR_PC_STORAGE_FULL = 0x18,
+    CTAP2_ERR_LARGE_BLOB_STORAGE_FULL = 0x18,
     CTAP2_ERR_CREDENTIAL_EXCLUDED = 0x19,
     CTAP2_ERR_PROCESSING = 0x21,
     CTAP2_ERR_INVALID_CREDENTIAL = 0x22,
@@ -57,7 +56,7 @@ pub enum Ctap2StatusCode {
     CTAP2_ERR_PIN_AUTH_INVALID = 0x33,
     CTAP2_ERR_PIN_AUTH_BLOCKED = 0x34,
     CTAP2_ERR_PIN_NOT_SET = 0x35,
-    CTAP2_ERR_PIN_REQUIRED = 0x36,
+    CTAP2_ERR_PUAT_REQUIRED = 0x36,
     CTAP2_ERR_PIN_POLICY_VIOLATION = 0x37,
     CTAP2_ERR_PIN_TOKEN_EXPIRED = 0x38,
     CTAP2_ERR_REQUEST_TOO_LARGE = 0x39,
@@ -68,14 +67,15 @@ pub enum Ctap2StatusCode {
     CTAP2_ERR_INTEGRITY_FAILURE = 0x3D,
     #[cfg(feature = "with_ctap2_1")]
     CTAP2_ERR_INVALID_SUBCOMMAND = 0x3E,
+    #[cfg(feature = "with_ctap2_1")]
+    CTAP2_ERR_UV_INVALID = 0x3F,
+    #[cfg(feature = "with_ctap2_1")]
+    CTAP2_ERR_UNAUTHORIZED_PERMISSION = 0x40,
     CTAP1_ERR_OTHER = 0x7F,
-    CTAP2_ERR_SPEC_LAST = 0xDF,
-    CTAP2_ERR_EXTENSION_FIRST = 0xE0,
-    CTAP2_ERR_EXTENSION_LAST = 0xEF,
-    // CTAP2_ERR_VENDOR_FIRST = 0xF0,
-    CTAP2_ERR_VENDOR_RESPONSE_TOO_LONG = 0xF0,
-    CTAP2_ERR_VENDOR_RESPONSE_CANNOT_WRITE_CBOR = 0xF1,
-
+    _CTAP2_ERR_SPEC_LAST = 0xDF,
+    _CTAP2_ERR_EXTENSION_FIRST = 0xE0,
+    _CTAP2_ERR_EXTENSION_LAST = 0xEF,
+    _CTAP2_ERR_VENDOR_FIRST = 0xF0,
     /// An internal invariant is broken.
     ///
     /// This type of error is unexpected and the current state is undefined.
@@ -85,6 +85,5 @@ pub enum Ctap2StatusCode {
     ///
     /// It may be possible that some of those errors are actually internal errors.
     CTAP2_ERR_VENDOR_HARDWARE_FAILURE = 0xF3,
-
-    CTAP2_ERR_VENDOR_LAST = 0xFF,
+    _CTAP2_ERR_VENDOR_LAST = 0xFF,
 }

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -577,7 +577,7 @@ fn serialize_credential(credential: PublicKeyCredentialSource) -> Result<Vec<u8>
     if cbor::write(credential.into(), &mut data) {
         Ok(data)
     } else {
-        Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_RESPONSE_CANNOT_WRITE_CBOR)
+        Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)
     }
 }
 
@@ -600,7 +600,7 @@ fn _serialize_min_pin_length_rp_ids(rp_ids: Vec<String>) -> Result<Vec<u8>, Ctap
     if cbor::write(cbor_array_vec!(rp_ids), &mut data) {
         Ok(data)
     } else {
-        Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_RESPONSE_CANNOT_WRITE_CBOR)
+        Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)
     }
 }
 


### PR DESCRIPTION
Continues #106 . Updates status codes, unifies existing vendor specific error codes. Same style as #244 .

- [x] Tests pass
