### PR TITLE
Remove CTAP 2.1 flag

### DIFF
--- a/.github/workflows/cargo_check.yml
+++ b/.github/workflows/cargo_check.yml
@@ -42,12 +42,6 @@ jobs:
           command: check
           args: --target thumbv7em-none-eabi --release --features with_ctap1
 
-      - name: Check OpenSK with_ctap2_1
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --target thumbv7em-none-eabi --release --features with_ctap2_1
-
       - name: Check OpenSK debug_ctap
         uses: actions-rs/cargo@v1
         with:
@@ -78,17 +72,11 @@ jobs:
           command: check
           args: --target thumbv7em-none-eabi --release --features debug_ctap,with_ctap1
 
-      - name: Check OpenSK debug_ctap,with_ctap2_1
+      - name: Check OpenSK debug_ctap,with_ctap1,panic_console,debug_allocations,verbose
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --target thumbv7em-none-eabi --release --features debug_ctap,with_ctap2_1
-
-      - name: Check OpenSK debug_ctap,with_ctap1,with_ctap2_1,panic_console,debug_allocations,verbose
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --target thumbv7em-none-eabi --release --features debug_ctap,with_ctap1,with_ctap2_1,panic_console,debug_allocations,verbose
+          args: --target thumbv7em-none-eabi --release --features debug_ctap,with_ctap1,,panic_console,debug_allocations,verbose
 
       - name: Check examples
         uses: actions-rs/cargo@v1

--- a/.github/workflows/opensk_test.yml
+++ b/.github/workflows/opensk_test.yml
@@ -51,27 +51,3 @@ jobs:
           command: test
           args: --features std,with_ctap1
 
-      - name: Unit testing of CTAP2 (release mode + CTAP2.1)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --features std,with_ctap2_1
-
-      - name: Unit testing of CTAP2 (debug mode + CTAP2.1)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features std,with_ctap2_1
-
-      - name: Unit testing of CTAP2 (release mode + CTAP1 + CTAP2.1)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --features std,with_ctap1,with_ctap2_1
-
-      - name: Unit testing of CTAP2 (debug mode + CTAP1 + CTAP2.1)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features std,with_ctap1,with_ctap2_1
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ panic_console = ["lang_items/panic_console"]
 std = ["cbor/std", "crypto/std", "crypto/derive_debug", "lang_items/std", "persistent_store/std"]
 verbose = ["debug_ctap", "libtock_drivers/verbose_usb"]
 with_ctap1 = ["crypto/with_ctap1"]
-with_ctap2_1 = []
 with_nfc = ["libtock_drivers/with_nfc"]
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -24,15 +24,14 @@ few limitations:
 
 ### FIDO2
 
-Although we tested and implemented our firmware based on the published
+The stable branch implements the published
 [CTAP2.0 specifications](https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html),
-our implementation was not reviewed nor officially tested and doesn't claim to
-be FIDO Certified.
-We started adding features of the upcoming next version of the
-[CTAP2.1 specifications](https://fidoalliance.org/specs/fido2/fido-client-to-authenticator-protocol-v2.1-rd-20191217.html).
-The development is currently between 2.0 and 2.1, with updates hidden behind
-a feature flag.
-Please add the flag `--ctap2.1` to the deploy command to include them.
+but our implementation was not reviewed nor officially tested and doesn't claim
+to be FIDO Certified. It already contains some preview features of 2.1, that you
+can try by adding the flag `--ctap2.1` to the deploy command.
+The develop branch offers only the
+[CTAP2.1 specifications](https://fidoalliance.org/specs/fido-v2.1-rd-20201208/fido-client-to-authenticator-protocol-v2.1-rd-20201208.html).
+The new features of 2.1 are currently work in progress.
 
 ### Cryptography
 

--- a/deploy.py
+++ b/deploy.py
@@ -882,14 +882,6 @@ if __name__ == "__main__":
             "support for U2F/CTAP1 protocol."),
   )
   main_parser.add_argument(
-      "--ctap2.1",
-      action="append_const",
-      const="with_ctap2_1",
-      dest="features",
-      help=("Compiles the OpenSK application with backward compatible "
-            "support for CTAP2.1 protocol."),
-  )
-  main_parser.add_argument(
       "--nfc",
       action="append_const",
       const="with_nfc",

--- a/deploy.py
+++ b/deploy.py
@@ -947,7 +947,16 @@ if __name__ == "__main__":
       dest="application",
       action="store_const",
       const="store_latency",
-      help=("Compiles and installs the store_latency example."))
+      help=("Compiles and installs the store_latency example which print "
+            "latency statistics of the persistent store library."))
+  apps_group.add_argument(
+      "--erase_storage",
+      dest="application",
+      action="store_const",
+      const="erase_storage",
+      help=("Compiles and installs the erase_storage example which erases "
+            "the storage. During operation the dongle red light is on. Once "
+            "the operation is completed the dongle green light is on."))
   apps_group.add_argument(
       "--panic_test",
       dest="application",

--- a/examples/erase_storage.rs
+++ b/examples/erase_storage.rs
@@ -1,0 +1,53 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![no_std]
+
+extern crate lang_items;
+
+use core::fmt::Write;
+use ctap2::embedded_flash::new_storage;
+use libtock_drivers::console::Console;
+use libtock_drivers::led;
+use libtock_drivers::result::FlexUnwrap;
+use persistent_store::{Storage, StorageIndex};
+
+fn is_page_erased(storage: &dyn Storage, page: usize) -> bool {
+    let index = StorageIndex { page, byte: 0 };
+    let length = storage.page_size();
+    storage
+        .read_slice(index, length)
+        .unwrap()
+        .iter()
+        .all(|&x| x == 0xff)
+}
+
+fn main() {
+    led::get(1).flex_unwrap().on().flex_unwrap(); // red on dongle
+    const NUM_PAGES: usize = 20; // should be at least ctap::storage::NUM_PAGES
+    let mut storage = new_storage(NUM_PAGES);
+    writeln!(Console::new(), "Erase {} pages of storage:", NUM_PAGES).unwrap();
+    for page in 0..NUM_PAGES {
+        write!(Console::new(), "- Page {} ", page).unwrap();
+        if is_page_erased(&storage, page) {
+            writeln!(Console::new(), "skipped (was already erased).").unwrap();
+        } else {
+            storage.erase_page(page).unwrap();
+            writeln!(Console::new(), "erased.").unwrap();
+        }
+    }
+    writeln!(Console::new(), "Done.").unwrap();
+    led::get(1).flex_unwrap().off().flex_unwrap();
+    led::get(0).flex_unwrap().on().flex_unwrap(); // green on dongle
+}

--- a/run_desktop_tests.sh
+++ b/run_desktop_tests.sh
@@ -44,7 +44,6 @@ cargo test --manifest-path tools/heapviz/Cargo.toml
 echo "Checking that CTAP2 builds properly..."
 cargo check --release --target=thumbv7em-none-eabi
 cargo check --release --target=thumbv7em-none-eabi --features with_ctap1
-cargo check --release --target=thumbv7em-none-eabi --features with_ctap2_1
 cargo check --release --target=thumbv7em-none-eabi --features debug_ctap
 cargo check --release --target=thumbv7em-none-eabi --features panic_console
 cargo check --release --target=thumbv7em-none-eabi --features debug_allocations
@@ -116,16 +115,4 @@ then
 
   echo "Running unit tests on the desktop (debug mode + CTAP1)..."
   cargo test --features std,with_ctap1
-
-  echo "Running unit tests on the desktop (release mode + CTAP2.1)..."
-  cargo test --release --features std,with_ctap2_1
-
-  echo "Running unit tests on the desktop (debug mode + CTAP2.1)..."
-  cargo test --features std,with_ctap2_1
-
-  echo "Running unit tests on the desktop (release mode + CTAP1 + CTAP2.1)..."
-  cargo test --release --features std,with_ctap1,with_ctap2_1
-
-  echo "Running unit tests on the desktop (debug mode + CTAP1 + CTAP2.1)..."
-  cargo test --features std,with_ctap1,with_ctap2_1
 fi

--- a/src/ctap/command.rs
+++ b/src/ctap/command.rs
@@ -41,7 +41,6 @@ pub enum Command {
     AuthenticatorClientPin(AuthenticatorClientPinParameters),
     AuthenticatorReset,
     AuthenticatorGetNextAssertion,
-    #[cfg(feature = "with_ctap2_1")]
     AuthenticatorSelection,
     // TODO(kaczmarczyck) implement FIDO 2.1 commands (see below consts)
     // Vendor specific commands
@@ -111,7 +110,6 @@ impl Command {
                 // Parameters are ignored.
                 Ok(Command::AuthenticatorGetNextAssertion)
             }
-            #[cfg(feature = "with_ctap2_1")]
             Command::AUTHENTICATOR_SELECTION => {
                 // Parameters are ignored.
                 Ok(Command::AuthenticatorSelection)
@@ -292,13 +290,9 @@ pub struct AuthenticatorClientPinParameters {
     pub pin_auth: Option<Vec<u8>>,
     pub new_pin_enc: Option<Vec<u8>>,
     pub pin_hash_enc: Option<Vec<u8>>,
-    #[cfg(feature = "with_ctap2_1")]
     pub min_pin_length: Option<u8>,
-    #[cfg(feature = "with_ctap2_1")]
     pub min_pin_length_rp_ids: Option<Vec<String>>,
-    #[cfg(feature = "with_ctap2_1")]
     pub permissions: Option<u8>,
-    #[cfg(feature = "with_ctap2_1")]
     pub permissions_rp_id: Option<String>,
 }
 
@@ -306,18 +300,6 @@ impl TryFrom<cbor::Value> for AuthenticatorClientPinParameters {
     type Error = Ctap2StatusCode;
 
     fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
-        #[cfg(not(feature = "with_ctap2_1"))]
-        destructure_cbor_map! {
-            let {
-                1 => pin_protocol,
-                2 => sub_command,
-                3 => key_agreement,
-                4 => pin_auth,
-                5 => new_pin_enc,
-                6 => pin_hash_enc,
-            } = extract_map(cbor_value)?;
-        }
-        #[cfg(feature = "with_ctap2_1")]
         destructure_cbor_map! {
             let {
                 1 => pin_protocol,
@@ -339,14 +321,12 @@ impl TryFrom<cbor::Value> for AuthenticatorClientPinParameters {
         let pin_auth = pin_auth.map(extract_byte_string).transpose()?;
         let new_pin_enc = new_pin_enc.map(extract_byte_string).transpose()?;
         let pin_hash_enc = pin_hash_enc.map(extract_byte_string).transpose()?;
-        #[cfg(feature = "with_ctap2_1")]
         let min_pin_length = min_pin_length
             .map(extract_unsigned)
             .transpose()?
             .map(u8::try_from)
             .transpose()
             .map_err(|_| Ctap2StatusCode::CTAP2_ERR_PIN_POLICY_VIOLATION)?;
-        #[cfg(feature = "with_ctap2_1")]
         let min_pin_length_rp_ids = match min_pin_length_rp_ids {
             Some(entry) => Some(
                 extract_array(entry)?
@@ -356,14 +336,12 @@ impl TryFrom<cbor::Value> for AuthenticatorClientPinParameters {
             ),
             None => None,
         };
-        #[cfg(feature = "with_ctap2_1")]
         // We expect a bit field of 8 bits, and drop everything else.
         // This means we ignore extensions in future versions.
         let permissions = permissions
             .map(extract_unsigned)
             .transpose()?
             .map(|p| p as u8);
-        #[cfg(feature = "with_ctap2_1")]
         let permissions_rp_id = permissions_rp_id.map(extract_text_string).transpose()?;
 
         Ok(AuthenticatorClientPinParameters {
@@ -373,13 +351,9 @@ impl TryFrom<cbor::Value> for AuthenticatorClientPinParameters {
             pin_auth,
             new_pin_enc,
             pin_hash_enc,
-            #[cfg(feature = "with_ctap2_1")]
             min_pin_length,
-            #[cfg(feature = "with_ctap2_1")]
             min_pin_length_rp_ids,
-            #[cfg(feature = "with_ctap2_1")]
             permissions,
-            #[cfg(feature = "with_ctap2_1")]
             permissions_rp_id,
         })
     }
@@ -560,18 +534,6 @@ mod test {
 
     #[test]
     fn test_from_cbor_client_pin_parameters() {
-        // TODO(kaczmarczyck) inline the #cfg when #128 is resolved:
-        // https://github.com/google/OpenSK/issues/128
-        #[cfg(not(feature = "with_ctap2_1"))]
-        let cbor_value = cbor_map! {
-            1 => 1,
-            2 => ClientPinSubCommand::GetPinRetries,
-            3 => cbor_map!{},
-            4 => vec! [0xBB],
-            5 => vec! [0xCC],
-            6 => vec! [0xDD],
-        };
-        #[cfg(feature = "with_ctap2_1")]
         let cbor_value = cbor_map! {
             1 => 1,
             2 => ClientPinSubCommand::GetPinRetries,
@@ -594,13 +556,9 @@ mod test {
             pin_auth: Some(vec![0xBB]),
             new_pin_enc: Some(vec![0xCC]),
             pin_hash_enc: Some(vec![0xDD]),
-            #[cfg(feature = "with_ctap2_1")]
             min_pin_length: Some(4),
-            #[cfg(feature = "with_ctap2_1")]
             min_pin_length_rp_ids: Some(vec!["example.com".to_string()]),
-            #[cfg(feature = "with_ctap2_1")]
             permissions: Some(0x03),
-            #[cfg(feature = "with_ctap2_1")]
             permissions_rp_id: Some("example.com".to_string()),
         };
 
@@ -632,7 +590,6 @@ mod test {
         assert_eq!(command, Ok(Command::AuthenticatorGetNextAssertion));
     }
 
-    #[cfg(feature = "with_ctap2_1")]
     #[test]
     fn test_deserialize_selection() {
         let cbor_bytes = [Command::AUTHENTICATOR_SELECTION];

--- a/src/ctap/data_formats.rs
+++ b/src/ctap/data_formats.rs
@@ -704,13 +704,9 @@ pub enum ClientPinSubCommand {
     SetPin = 0x03,
     ChangePin = 0x04,
     GetPinToken = 0x05,
-    #[cfg(feature = "with_ctap2_1")]
     GetPinUvAuthTokenUsingUvWithPermissions = 0x06,
-    #[cfg(feature = "with_ctap2_1")]
     GetUvRetries = 0x07,
-    #[cfg(feature = "with_ctap2_1")]
     SetMinPinLength = 0x08,
-    #[cfg(feature = "with_ctap2_1")]
     GetPinUvAuthTokenUsingPinWithPermissions = 0x09,
 }
 
@@ -731,18 +727,11 @@ impl TryFrom<cbor::Value> for ClientPinSubCommand {
             0x03 => Ok(ClientPinSubCommand::SetPin),
             0x04 => Ok(ClientPinSubCommand::ChangePin),
             0x05 => Ok(ClientPinSubCommand::GetPinToken),
-            #[cfg(feature = "with_ctap2_1")]
             0x06 => Ok(ClientPinSubCommand::GetPinUvAuthTokenUsingUvWithPermissions),
-            #[cfg(feature = "with_ctap2_1")]
             0x07 => Ok(ClientPinSubCommand::GetUvRetries),
-            #[cfg(feature = "with_ctap2_1")]
             0x08 => Ok(ClientPinSubCommand::SetMinPinLength),
-            #[cfg(feature = "with_ctap2_1")]
             0x09 => Ok(ClientPinSubCommand::GetPinUvAuthTokenUsingPinWithPermissions),
-            #[cfg(feature = "with_ctap2_1")]
             _ => Err(Ctap2StatusCode::CTAP2_ERR_INVALID_SUBCOMMAND),
-            #[cfg(not(feature = "with_ctap2_1"))]
-            _ => Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER),
         }
     }
 }

--- a/src/ctap/hid/mod.rs
+++ b/src/ctap/hid/mod.rs
@@ -219,7 +219,7 @@ impl CtapHid {
                                 cid,
                                 cmd: CtapHid::COMMAND_CBOR,
                                 payload: vec![
-                                    Ctap2StatusCode::CTAP2_ERR_VENDOR_RESPONSE_TOO_LONG as u8,
+                                    Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR as u8,
                                 ],
                             })
                             .unwrap()

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -25,23 +25,19 @@ pub mod status_code;
 mod storage;
 mod timed_permission;
 
-#[cfg(feature = "with_ctap2_1")]
-use self::command::MAX_CREDENTIAL_COUNT_IN_LIST;
 use self::command::{
     AuthenticatorClientPinParameters, AuthenticatorGetAssertionParameters,
     AuthenticatorMakeCredentialParameters, AuthenticatorVendorConfigureParameters, Command,
+    MAX_CREDENTIAL_COUNT_IN_LIST,
 };
-#[cfg(feature = "with_ctap2_1")]
-use self::data_formats::AuthenticatorTransport;
 use self::data_formats::{
-    CredentialProtectionPolicy, GetAssertionHmacSecretInput, PackedAttestationStatement,
-    PublicKeyCredentialDescriptor, PublicKeyCredentialParameter, PublicKeyCredentialSource,
-    PublicKeyCredentialType, PublicKeyCredentialUserEntity, SignatureAlgorithm,
+    AuthenticatorTransport, CredentialProtectionPolicy, GetAssertionHmacSecretInput,
+    PackedAttestationStatement, PublicKeyCredentialDescriptor, PublicKeyCredentialParameter,
+    PublicKeyCredentialSource, PublicKeyCredentialType, PublicKeyCredentialUserEntity,
+    SignatureAlgorithm,
 };
 use self::hid::ChannelID;
-#[cfg(feature = "with_ctap2_1")]
-use self::pin_protocol_v1::PinPermission;
-use self::pin_protocol_v1::PinProtocolV1;
+use self::pin_protocol_v1::{PinPermission, PinProtocolV1};
 use self::response::{
     AuthenticatorGetAssertionResponse, AuthenticatorGetInfoResponse,
     AuthenticatorMakeCredentialResponse, AuthenticatorVendorResponse, ResponseData,
@@ -108,7 +104,6 @@ pub const FIDO2_VERSION_STRING: &str = "FIDO_2_0";
 #[cfg(feature = "with_ctap1")]
 pub const U2F_VERSION_STRING: &str = "U2F_V2";
 // TODO(#106) change to final string when ready
-#[cfg(feature = "with_ctap2_1")]
 pub const FIDO2_1_VERSION_STRING: &str = "FIDO_2_1_PRE";
 
 // We currently only support one algorithm for signatures: ES256.
@@ -339,7 +334,6 @@ where
                     // GetInfo does not reset stateful commands.
                     (Command::AuthenticatorGetInfo, _) => (),
                     // AuthenticatorSelection does not reset stateful commands.
-                    #[cfg(feature = "with_ctap2_1")]
                     (Command::AuthenticatorSelection, _) => (),
                     (_, _) => {
                         self.stateful_command_type = None;
@@ -356,7 +350,6 @@ where
                     Command::AuthenticatorGetInfo => self.process_get_info(),
                     Command::AuthenticatorClientPin(params) => self.process_client_pin(params),
                     Command::AuthenticatorReset => self.process_reset(cid, now),
-                    #[cfg(feature = "with_ctap2_1")]
                     Command::AuthenticatorSelection => self.process_selection(cid),
                     // TODO(kaczmarczyck) implement FIDO 2.1 commands
                     // Vendor specific commands
@@ -484,12 +477,9 @@ where
                 {
                     return Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID);
                 }
-                #[cfg(feature = "with_ctap2_1")]
-                {
-                    self.pin_protocol_v1
-                        .has_permission(PinPermission::MakeCredential)?;
-                    self.pin_protocol_v1.has_permission_for_rp_id(&rp_id)?;
-                }
+                self.pin_protocol_v1
+                    .has_permission(PinPermission::MakeCredential)?;
+                self.pin_protocol_v1.has_permission_for_rp_id(&rp_id)?;
                 UP_FLAG | UV_FLAG | AT_FLAG | ed_flag
             }
             None => {
@@ -738,12 +728,9 @@ where
                 {
                     return Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID);
                 }
-                #[cfg(feature = "with_ctap2_1")]
-                {
-                    self.pin_protocol_v1
-                        .has_permission(PinPermission::GetAssertion)?;
-                    self.pin_protocol_v1.has_permission_for_rp_id(&rp_id)?;
-                }
+                self.pin_protocol_v1
+                    .has_permission(PinPermission::GetAssertion)?;
+                self.pin_protocol_v1.has_permission_for_rp_id(&rp_id)?;
                 UV_FLAG
             }
             None => {
@@ -851,7 +838,6 @@ where
                     #[cfg(feature = "with_ctap1")]
                     String::from(U2F_VERSION_STRING),
                     String::from(FIDO2_VERSION_STRING),
-                    #[cfg(feature = "with_ctap2_1")]
                     String::from(FIDO2_1_VERSION_STRING),
                 ],
                 extensions: Some(vec![String::from("hmac-secret")]),
@@ -861,19 +847,13 @@ where
                 pin_protocols: Some(vec![
                     CtapState::<R, CheckUserPresence>::PIN_PROTOCOL_VERSION,
                 ]),
-                #[cfg(feature = "with_ctap2_1")]
                 max_credential_count_in_list: MAX_CREDENTIAL_COUNT_IN_LIST.map(|c| c as u64),
                 // #TODO(106) update with version 2.1 of HMAC-secret
-                #[cfg(feature = "with_ctap2_1")]
                 max_credential_id_length: Some(CREDENTIAL_ID_SIZE as u64),
-                #[cfg(feature = "with_ctap2_1")]
                 transports: Some(vec![AuthenticatorTransport::Usb]),
-                #[cfg(feature = "with_ctap2_1")]
                 algorithms: Some(vec![ES256_CRED_PARAM]),
                 default_cred_protect: DEFAULT_CRED_PROTECT,
-                #[cfg(feature = "with_ctap2_1")]
                 min_pin_length: self.persistent_store.min_pin_length()?,
-                #[cfg(feature = "with_ctap2_1")]
                 firmware_version: None,
             },
         ))
@@ -916,7 +896,6 @@ where
         Ok(ResponseData::AuthenticatorReset)
     }
 
-    #[cfg(feature = "with_ctap2_1")]
     fn process_selection(&self, cid: ChannelID) -> Result<ResponseData, Ctap2StatusCode> {
         (self.check_user_presence)(cid)?;
         Ok(ResponseData::AuthenticatorSelection)
@@ -1036,42 +1015,31 @@ mod test {
         let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
         let info_reponse = ctap_state.process_command(&[0x04], DUMMY_CHANNEL_ID, DUMMY_CLOCK_VALUE);
 
-        #[cfg(feature = "with_ctap2_1")]
         let mut expected_response = vec![0x00, 0xAA, 0x01];
-        #[cfg(not(feature = "with_ctap2_1"))]
-        let mut expected_response = vec![0x00, 0xA6, 0x01];
         // The difference here is a longer array of supported versions.
         let mut version_count = 0;
-        // CTAP 2 is always supported
-        version_count += 1;
+        // CTAP 2.0 and 2.1 are always supported
+        version_count += 2;
         #[cfg(feature = "with_ctap1")]
-        {
-            version_count += 1;
-        }
-        #[cfg(feature = "with_ctap2_1")]
         {
             version_count += 1;
         }
         expected_response.push(0x80 + version_count);
         #[cfg(feature = "with_ctap1")]
         expected_response.extend(&[0x66, 0x55, 0x32, 0x46, 0x5F, 0x56, 0x32]);
-        expected_response.extend(&[0x68, 0x46, 0x49, 0x44, 0x4F, 0x5F, 0x32, 0x5F, 0x30]);
-        #[cfg(feature = "with_ctap2_1")]
-        expected_response.extend(&[
-            0x6C, 0x46, 0x49, 0x44, 0x4F, 0x5F, 0x32, 0x5F, 0x31, 0x5F, 0x50, 0x52, 0x45,
-        ]);
-        expected_response.extend(&[
-            0x02, 0x81, 0x6B, 0x68, 0x6D, 0x61, 0x63, 0x2D, 0x73, 0x65, 0x63, 0x72, 0x65, 0x74,
-            0x03, 0x50,
-        ]);
-        expected_response.extend(&ctap_state.persistent_store.aaguid().unwrap());
-        expected_response.extend(&[
-            0x04, 0xA3, 0x62, 0x72, 0x6B, 0xF5, 0x62, 0x75, 0x70, 0xF5, 0x69, 0x63, 0x6C, 0x69,
-            0x65, 0x6E, 0x74, 0x50, 0x69, 0x6E, 0xF4, 0x05, 0x19, 0x04, 0x00, 0x06, 0x81, 0x01,
-        ]);
-        #[cfg(feature = "with_ctap2_1")]
         expected_response.extend(
             [
+                0x68, 0x46, 0x49, 0x44, 0x4F, 0x5F, 0x32, 0x5F, 0x30, 0x6C, 0x46, 0x49, 0x44, 0x4F,
+                0x5F, 0x32, 0x5F, 0x31, 0x5F, 0x50, 0x52, 0x45, 0x02, 0x81, 0x6B, 0x68, 0x6D, 0x61,
+                0x63, 0x2D, 0x73, 0x65, 0x63, 0x72, 0x65, 0x74, 0x03, 0x50,
+            ]
+            .iter(),
+        );
+        expected_response.extend(&ctap_state.persistent_store.aaguid().unwrap());
+        expected_response.extend(
+            [
+                0x04, 0xA3, 0x62, 0x72, 0x6B, 0xF5, 0x62, 0x75, 0x70, 0xF5, 0x69, 0x63, 0x6C, 0x69,
+                0x65, 0x6E, 0x74, 0x50, 0x69, 0x6E, 0xF4, 0x05, 0x19, 0x04, 0x00, 0x06, 0x81, 0x01,
                 0x08, 0x18, 0x70, 0x09, 0x81, 0x63, 0x75, 0x73, 0x62, 0x0A, 0x81, 0xA2, 0x63, 0x61,
                 0x6C, 0x67, 0x26, 0x64, 0x74, 0x79, 0x70, 0x65, 0x6A, 0x70, 0x75, 0x62, 0x6C, 0x69,
                 0x63, 0x2D, 0x6B, 0x65, 0x79, 0x0D, 0x04,

--- a/src/ctap/status_code.rs
+++ b/src/ctap/status_code.rs
@@ -31,11 +31,10 @@ pub enum Ctap2StatusCode {
     CTAP2_ERR_INVALID_CBOR = 0x12,
     CTAP2_ERR_MISSING_PARAMETER = 0x14,
     CTAP2_ERR_LIMIT_EXCEEDED = 0x15,
-    CTAP2_ERR_UNSUPPORTED_EXTENSION = 0x16,
     #[cfg(feature = "with_ctap2_1")]
     CTAP2_ERR_FP_DATABASE_FULL = 0x17,
     #[cfg(feature = "with_ctap2_1")]
-    CTAP2_ERR_PC_STORAGE_FULL = 0x18,
+    CTAP2_ERR_LARGE_BLOB_STORAGE_FULL = 0x18,
     CTAP2_ERR_CREDENTIAL_EXCLUDED = 0x19,
     CTAP2_ERR_PROCESSING = 0x21,
     CTAP2_ERR_INVALID_CREDENTIAL = 0x22,
@@ -57,7 +56,7 @@ pub enum Ctap2StatusCode {
     CTAP2_ERR_PIN_AUTH_INVALID = 0x33,
     CTAP2_ERR_PIN_AUTH_BLOCKED = 0x34,
     CTAP2_ERR_PIN_NOT_SET = 0x35,
-    CTAP2_ERR_PIN_REQUIRED = 0x36,
+    CTAP2_ERR_PUAT_REQUIRED = 0x36,
     CTAP2_ERR_PIN_POLICY_VIOLATION = 0x37,
     CTAP2_ERR_PIN_TOKEN_EXPIRED = 0x38,
     CTAP2_ERR_REQUEST_TOO_LARGE = 0x39,
@@ -68,14 +67,15 @@ pub enum Ctap2StatusCode {
     CTAP2_ERR_INTEGRITY_FAILURE = 0x3D,
     #[cfg(feature = "with_ctap2_1")]
     CTAP2_ERR_INVALID_SUBCOMMAND = 0x3E,
+    #[cfg(feature = "with_ctap2_1")]
+    CTAP2_ERR_UV_INVALID = 0x3F,
+    #[cfg(feature = "with_ctap2_1")]
+    CTAP2_ERR_UNAUTHORIZED_PERMISSION = 0x40,
     CTAP1_ERR_OTHER = 0x7F,
-    CTAP2_ERR_SPEC_LAST = 0xDF,
-    CTAP2_ERR_EXTENSION_FIRST = 0xE0,
-    CTAP2_ERR_EXTENSION_LAST = 0xEF,
-    // CTAP2_ERR_VENDOR_FIRST = 0xF0,
-    CTAP2_ERR_VENDOR_RESPONSE_TOO_LONG = 0xF0,
-    CTAP2_ERR_VENDOR_RESPONSE_CANNOT_WRITE_CBOR = 0xF1,
-
+    _CTAP2_ERR_SPEC_LAST = 0xDF,
+    _CTAP2_ERR_EXTENSION_FIRST = 0xE0,
+    _CTAP2_ERR_EXTENSION_LAST = 0xEF,
+    _CTAP2_ERR_VENDOR_FIRST = 0xF0,
     /// An internal invariant is broken.
     ///
     /// This type of error is unexpected and the current state is undefined.
@@ -85,6 +85,5 @@ pub enum Ctap2StatusCode {
     ///
     /// It may be possible that some of those errors are actually internal errors.
     CTAP2_ERR_VENDOR_HARDWARE_FAILURE = 0xF3,
-
-    CTAP2_ERR_VENDOR_LAST = 0xFF,
+    _CTAP2_ERR_VENDOR_LAST = 0xFF,
 }

--- a/src/ctap/status_code.rs
+++ b/src/ctap/status_code.rs
@@ -31,9 +31,7 @@ pub enum Ctap2StatusCode {
     CTAP2_ERR_INVALID_CBOR = 0x12,
     CTAP2_ERR_MISSING_PARAMETER = 0x14,
     CTAP2_ERR_LIMIT_EXCEEDED = 0x15,
-    #[cfg(feature = "with_ctap2_1")]
     CTAP2_ERR_FP_DATABASE_FULL = 0x17,
-    #[cfg(feature = "with_ctap2_1")]
     CTAP2_ERR_LARGE_BLOB_STORAGE_FULL = 0x18,
     CTAP2_ERR_CREDENTIAL_EXCLUDED = 0x19,
     CTAP2_ERR_PROCESSING = 0x21,
@@ -63,13 +61,9 @@ pub enum Ctap2StatusCode {
     CTAP2_ERR_ACTION_TIMEOUT = 0x3A,
     CTAP2_ERR_UP_REQUIRED = 0x3B,
     CTAP2_ERR_UV_BLOCKED = 0x3C,
-    #[cfg(feature = "with_ctap2_1")]
     CTAP2_ERR_INTEGRITY_FAILURE = 0x3D,
-    #[cfg(feature = "with_ctap2_1")]
     CTAP2_ERR_INVALID_SUBCOMMAND = 0x3E,
-    #[cfg(feature = "with_ctap2_1")]
     CTAP2_ERR_UV_INVALID = 0x3F,
-    #[cfg(feature = "with_ctap2_1")]
     CTAP2_ERR_UNAUTHORIZED_PERMISSION = 0x40,
     CTAP1_ERR_OTHER = 0x7F,
     _CTAP2_ERR_SPEC_LAST = 0xDF,

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -14,20 +14,18 @@
 
 mod key;
 
-#[cfg(feature = "with_ctap2_1")]
-use crate::ctap::data_formats::{extract_array, extract_text_string};
-use crate::ctap::data_formats::{CredentialProtectionPolicy, PublicKeyCredentialSource};
+use crate::ctap::data_formats::{
+    extract_array, extract_text_string, CredentialProtectionPolicy, PublicKeyCredentialSource,
+};
 use crate::ctap::key_material;
 use crate::ctap::pin_protocol_v1::PIN_AUTH_LENGTH;
 use crate::ctap::status_code::Ctap2StatusCode;
 use crate::ctap::INITIAL_SIGNATURE_COUNTER;
 use crate::embedded_flash::{new_storage, Storage};
-#[cfg(feature = "with_ctap2_1")]
 use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
 use arrayref::array_ref;
-#[cfg(feature = "with_ctap2_1")]
 use cbor::cbor_array_vec;
 use core::convert::TryInto;
 use crypto::rng256::Rng256;
@@ -54,14 +52,11 @@ const NUM_PAGES: usize = 20;
 const MAX_SUPPORTED_RESIDENTIAL_KEYS: usize = 150;
 
 const MAX_PIN_RETRIES: u8 = 8;
-#[cfg(feature = "with_ctap2_1")]
 const DEFAULT_MIN_PIN_LENGTH: u8 = 4;
 // TODO(kaczmarczyck) use this for the minPinLength extension
 // https://github.com/google/OpenSK/issues/129
-#[cfg(feature = "with_ctap2_1")]
 const _DEFAULT_MIN_PIN_LENGTH_RP_IDS: Vec<String> = Vec::new();
 // TODO(kaczmarczyck) Check whether this constant is necessary, or replace it accordingly.
-#[cfg(feature = "with_ctap2_1")]
 const _MAX_RP_IDS_LENGTH: usize = 8;
 
 /// Wrapper for master keys.
@@ -348,7 +343,6 @@ impl PersistentStore {
     }
 
     /// Returns the minimum PIN length.
-    #[cfg(feature = "with_ctap2_1")]
     pub fn min_pin_length(&self) -> Result<u8, Ctap2StatusCode> {
         match self.store.find(key::MIN_PIN_LENGTH)? {
             None => Ok(DEFAULT_MIN_PIN_LENGTH),
@@ -358,14 +352,12 @@ impl PersistentStore {
     }
 
     /// Sets the minimum PIN length.
-    #[cfg(feature = "with_ctap2_1")]
     pub fn set_min_pin_length(&mut self, min_pin_length: u8) -> Result<(), Ctap2StatusCode> {
         Ok(self.store.insert(key::MIN_PIN_LENGTH, &[min_pin_length])?)
     }
 
     /// Returns the list of RP IDs that are used to check if reading the minimum PIN length is
     /// allowed.
-    #[cfg(feature = "with_ctap2_1")]
     pub fn _min_pin_length_rp_ids(&self) -> Result<Vec<String>, Ctap2StatusCode> {
         let rp_ids = self
             .store
@@ -374,11 +366,10 @@ impl PersistentStore {
                 _deserialize_min_pin_length_rp_ids(&value)
             });
         debug_assert!(rp_ids.is_some());
-        Ok(rp_ids.unwrap_or(vec![]))
+        Ok(rp_ids.unwrap_or_default())
     }
 
     /// Sets the list of RP IDs that are used to check if reading the minimum PIN length is allowed.
-    #[cfg(feature = "with_ctap2_1")]
     pub fn _set_min_pin_length_rp_ids(
         &mut self,
         min_pin_length_rp_ids: Vec<String>,
@@ -582,7 +573,6 @@ fn serialize_credential(credential: PublicKeyCredentialSource) -> Result<Vec<u8>
 }
 
 /// Deserializes a list of RP IDs from storage representation.
-#[cfg(feature = "with_ctap2_1")]
 fn _deserialize_min_pin_length_rp_ids(data: &[u8]) -> Option<Vec<String>> {
     let cbor = cbor::read(data).ok()?;
     extract_array(cbor)
@@ -594,7 +584,6 @@ fn _deserialize_min_pin_length_rp_ids(data: &[u8]) -> Option<Vec<String>> {
 }
 
 /// Serializes a list of RP IDs to storage representation.
-#[cfg(feature = "with_ctap2_1")]
 fn _serialize_min_pin_length_rp_ids(rp_ids: Vec<String>) -> Result<Vec<u8>, Ctap2StatusCode> {
     let mut data = Vec::new();
     if cbor::write(cbor_array_vec!(rp_ids), &mut data) {
@@ -988,7 +977,6 @@ mod test {
         assert_eq!(&persistent_store.aaguid().unwrap(), key_material::AAGUID);
     }
 
-    #[cfg(feature = "with_ctap2_1")]
     #[test]
     fn test_min_pin_length() {
         let mut rng = ThreadRng256 {};
@@ -1011,7 +999,6 @@ mod test {
         );
     }
 
-    #[cfg(feature = "with_ctap2_1")]
     #[test]
     fn test_min_pin_length_rp_ids() {
         let mut rng = ThreadRng256 {};
@@ -1080,7 +1067,6 @@ mod test {
         assert_eq!(credential, reconstructed);
     }
 
-    #[cfg(feature = "with_ctap2_1")]
     #[test]
     fn test_serialize_deserialize_min_pin_length_rp_ids() {
         let rp_ids = vec![String::from("example.com")];

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -577,7 +577,7 @@ fn serialize_credential(credential: PublicKeyCredentialSource) -> Result<Vec<u8>
     if cbor::write(credential.into(), &mut data) {
         Ok(data)
     } else {
-        Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_RESPONSE_CANNOT_WRITE_CBOR)
+        Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)
     }
 }
 
@@ -600,7 +600,7 @@ fn _serialize_min_pin_length_rp_ids(rp_ids: Vec<String>) -> Result<Vec<u8>, Ctap
     if cbor::write(cbor_array_vec!(rp_ids), &mut data) {
         Ok(data)
     } else {
-        Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_RESPONSE_CANNOT_WRITE_CBOR)
+        Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)
     }
 }
 

--- a/src/ctap/storage/key.rs
+++ b/src/ctap/storage/key.rs
@@ -92,13 +92,11 @@ make_partition! {
     CRED_RANDOM_SECRET = 2041;
 
     /// List of RP IDs allowed to read the minimum PIN length.
-    #[cfg(feature = "with_ctap2_1")]
     _MIN_PIN_LENGTH_RP_IDS = 2042;
 
     /// The minimum PIN length.
     ///
     /// If the entry is absent, the minimum PIN length is `DEFAULT_MIN_PIN_LENGTH`.
-    #[cfg(feature = "with_ctap2_1")]
     MIN_PIN_LENGTH = 2043;
 
     /// The number of PIN retries.


### PR DESCRIPTION
In our new develop branch, we drop support for CTAP 2.0 separately from CTAP 2.1.

This is related to #106 and makes #128 much less important since the amount of cfg statements is significantly reduced. (I leave it to @jmichelp if we want to close #128.)

- [x] Tests pass
- [x] Appropriate changes to README are included in PR