### PR TITLE
Updates workflows to remove the CTAP 2.1 flag

### DIFF
--- a/.github/workflows/cargo_check.yml
+++ b/.github/workflows/cargo_check.yml
@@ -42,12 +42,6 @@ jobs:
           command: check
           args: --target thumbv7em-none-eabi --release --features with_ctap1
 
-      - name: Check OpenSK with_ctap2_1
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --target thumbv7em-none-eabi --release --features with_ctap2_1
-
       - name: Check OpenSK debug_ctap
         uses: actions-rs/cargo@v1
         with:
@@ -78,17 +72,11 @@ jobs:
           command: check
           args: --target thumbv7em-none-eabi --release --features debug_ctap,with_ctap1
 
-      - name: Check OpenSK debug_ctap,with_ctap2_1
+      - name: Check OpenSK debug_ctap,with_ctap1,panic_console,debug_allocations,verbose
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --target thumbv7em-none-eabi --release --features debug_ctap,with_ctap2_1
-
-      - name: Check OpenSK debug_ctap,with_ctap1,with_ctap2_1,panic_console,debug_allocations,verbose
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --target thumbv7em-none-eabi --release --features debug_ctap,with_ctap1,with_ctap2_1,panic_console,debug_allocations,verbose
+          args: --target thumbv7em-none-eabi --release --features debug_ctap,with_ctap1,,panic_console,debug_allocations,verbose
 
       - name: Check examples
         uses: actions-rs/cargo@v1

--- a/.github/workflows/opensk_test.yml
+++ b/.github/workflows/opensk_test.yml
@@ -51,27 +51,3 @@ jobs:
           command: test
           args: --features std,with_ctap1
 
-      - name: Unit testing of CTAP2 (release mode + CTAP2.1)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --features std,with_ctap2_1
-
-      - name: Unit testing of CTAP2 (debug mode + CTAP2.1)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features std,with_ctap2_1
-
-      - name: Unit testing of CTAP2 (release mode + CTAP1 + CTAP2.1)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --features std,with_ctap1,with_ctap2_1
-
-      - name: Unit testing of CTAP2 (debug mode + CTAP1 + CTAP2.1)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features std,with_ctap1,with_ctap2_1
-

--- a/deploy.py
+++ b/deploy.py
@@ -947,7 +947,16 @@ if __name__ == "__main__":
       dest="application",
       action="store_const",
       const="store_latency",
-      help=("Compiles and installs the store_latency example."))
+      help=("Compiles and installs the store_latency example which print "
+            "latency statistics of the persistent store library."))
+  apps_group.add_argument(
+      "--erase_storage",
+      dest="application",
+      action="store_const",
+      const="erase_storage",
+      help=("Compiles and installs the erase_storage example which erases "
+            "the storage. During operation the dongle red light is on. Once "
+            "the operation is completed the dongle green light is on."))
   apps_group.add_argument(
       "--panic_test",
       dest="application",

--- a/examples/erase_storage.rs
+++ b/examples/erase_storage.rs
@@ -1,0 +1,53 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![no_std]
+
+extern crate lang_items;
+
+use core::fmt::Write;
+use ctap2::embedded_flash::new_storage;
+use libtock_drivers::console::Console;
+use libtock_drivers::led;
+use libtock_drivers::result::FlexUnwrap;
+use persistent_store::{Storage, StorageIndex};
+
+fn is_page_erased(storage: &dyn Storage, page: usize) -> bool {
+    let index = StorageIndex { page, byte: 0 };
+    let length = storage.page_size();
+    storage
+        .read_slice(index, length)
+        .unwrap()
+        .iter()
+        .all(|&x| x == 0xff)
+}
+
+fn main() {
+    led::get(1).flex_unwrap().on().flex_unwrap(); // red on dongle
+    const NUM_PAGES: usize = 20; // should be at least ctap::storage::NUM_PAGES
+    let mut storage = new_storage(NUM_PAGES);
+    writeln!(Console::new(), "Erase {} pages of storage:", NUM_PAGES).unwrap();
+    for page in 0..NUM_PAGES {
+        write!(Console::new(), "- Page {} ", page).unwrap();
+        if is_page_erased(&storage, page) {
+            writeln!(Console::new(), "skipped (was already erased).").unwrap();
+        } else {
+            storage.erase_page(page).unwrap();
+            writeln!(Console::new(), "erased.").unwrap();
+        }
+    }
+    writeln!(Console::new(), "Done.").unwrap();
+    led::get(1).flex_unwrap().off().flex_unwrap();
+    led::get(0).flex_unwrap().on().flex_unwrap(); // green on dongle
+}

--- a/run_desktop_tests.sh
+++ b/run_desktop_tests.sh
@@ -44,7 +44,6 @@ cargo test --manifest-path tools/heapviz/Cargo.toml
 echo "Checking that CTAP2 builds properly..."
 cargo check --release --target=thumbv7em-none-eabi
 cargo check --release --target=thumbv7em-none-eabi --features with_ctap1
-cargo check --release --target=thumbv7em-none-eabi --features with_ctap2_1
 cargo check --release --target=thumbv7em-none-eabi --features debug_ctap
 cargo check --release --target=thumbv7em-none-eabi --features panic_console
 cargo check --release --target=thumbv7em-none-eabi --features debug_allocations
@@ -116,16 +115,4 @@ then
 
   echo "Running unit tests on the desktop (debug mode + CTAP1)..."
   cargo test --features std,with_ctap1
-
-  echo "Running unit tests on the desktop (release mode + CTAP2.1)..."
-  cargo test --release --features std,with_ctap2_1
-
-  echo "Running unit tests on the desktop (debug mode + CTAP2.1)..."
-  cargo test --features std,with_ctap2_1
-
-  echo "Running unit tests on the desktop (release mode + CTAP1 + CTAP2.1)..."
-  cargo test --release --features std,with_ctap1,with_ctap2_1
-
-  echo "Running unit tests on the desktop (debug mode + CTAP1 + CTAP2.1)..."
-  cargo test --features std,with_ctap1,with_ctap2_1
 fi

--- a/src/ctap/hid/mod.rs
+++ b/src/ctap/hid/mod.rs
@@ -219,7 +219,7 @@ impl CtapHid {
                                 cid,
                                 cmd: CtapHid::COMMAND_CBOR,
                                 payload: vec![
-                                    Ctap2StatusCode::CTAP2_ERR_VENDOR_RESPONSE_TOO_LONG as u8,
+                                    Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR as u8,
                                 ],
                             })
                             .unwrap()

--- a/src/ctap/status_code.rs
+++ b/src/ctap/status_code.rs
@@ -31,11 +31,10 @@ pub enum Ctap2StatusCode {
     CTAP2_ERR_INVALID_CBOR = 0x12,
     CTAP2_ERR_MISSING_PARAMETER = 0x14,
     CTAP2_ERR_LIMIT_EXCEEDED = 0x15,
-    CTAP2_ERR_UNSUPPORTED_EXTENSION = 0x16,
     #[cfg(feature = "with_ctap2_1")]
     CTAP2_ERR_FP_DATABASE_FULL = 0x17,
     #[cfg(feature = "with_ctap2_1")]
-    CTAP2_ERR_PC_STORAGE_FULL = 0x18,
+    CTAP2_ERR_LARGE_BLOB_STORAGE_FULL = 0x18,
     CTAP2_ERR_CREDENTIAL_EXCLUDED = 0x19,
     CTAP2_ERR_PROCESSING = 0x21,
     CTAP2_ERR_INVALID_CREDENTIAL = 0x22,
@@ -57,7 +56,7 @@ pub enum Ctap2StatusCode {
     CTAP2_ERR_PIN_AUTH_INVALID = 0x33,
     CTAP2_ERR_PIN_AUTH_BLOCKED = 0x34,
     CTAP2_ERR_PIN_NOT_SET = 0x35,
-    CTAP2_ERR_PIN_REQUIRED = 0x36,
+    CTAP2_ERR_PUAT_REQUIRED = 0x36,
     CTAP2_ERR_PIN_POLICY_VIOLATION = 0x37,
     CTAP2_ERR_PIN_TOKEN_EXPIRED = 0x38,
     CTAP2_ERR_REQUEST_TOO_LARGE = 0x39,
@@ -68,14 +67,15 @@ pub enum Ctap2StatusCode {
     CTAP2_ERR_INTEGRITY_FAILURE = 0x3D,
     #[cfg(feature = "with_ctap2_1")]
     CTAP2_ERR_INVALID_SUBCOMMAND = 0x3E,
+    #[cfg(feature = "with_ctap2_1")]
+    CTAP2_ERR_UV_INVALID = 0x3F,
+    #[cfg(feature = "with_ctap2_1")]
+    CTAP2_ERR_UNAUTHORIZED_PERMISSION = 0x40,
     CTAP1_ERR_OTHER = 0x7F,
-    CTAP2_ERR_SPEC_LAST = 0xDF,
-    CTAP2_ERR_EXTENSION_FIRST = 0xE0,
-    CTAP2_ERR_EXTENSION_LAST = 0xEF,
-    // CTAP2_ERR_VENDOR_FIRST = 0xF0,
-    CTAP2_ERR_VENDOR_RESPONSE_TOO_LONG = 0xF0,
-    CTAP2_ERR_VENDOR_RESPONSE_CANNOT_WRITE_CBOR = 0xF1,
-
+    _CTAP2_ERR_SPEC_LAST = 0xDF,
+    _CTAP2_ERR_EXTENSION_FIRST = 0xE0,
+    _CTAP2_ERR_EXTENSION_LAST = 0xEF,
+    _CTAP2_ERR_VENDOR_FIRST = 0xF0,
     /// An internal invariant is broken.
     ///
     /// This type of error is unexpected and the current state is undefined.
@@ -85,6 +85,5 @@ pub enum Ctap2StatusCode {
     ///
     /// It may be possible that some of those errors are actually internal errors.
     CTAP2_ERR_VENDOR_HARDWARE_FAILURE = 0xF3,
-
-    CTAP2_ERR_VENDOR_LAST = 0xFF,
+    _CTAP2_ERR_VENDOR_LAST = 0xFF,
 }

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -577,7 +577,7 @@ fn serialize_credential(credential: PublicKeyCredentialSource) -> Result<Vec<u8>
     if cbor::write(credential.into(), &mut data) {
         Ok(data)
     } else {
-        Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_RESPONSE_CANNOT_WRITE_CBOR)
+        Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)
     }
 }
 
@@ -600,7 +600,7 @@ fn _serialize_min_pin_length_rp_ids(rp_ids: Vec<String>) -> Result<Vec<u8>, Ctap
     if cbor::write(cbor_array_vec!(rp_ids), &mut data) {
         Ok(data)
     } else {
-        Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_RESPONSE_CANNOT_WRITE_CBOR)
+        Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)
     }
 }
 


### PR DESCRIPTION
Necessary to submit before #248 to not fail the old tests. Just removes the workflows for 2.1, so #248 should be submitted right after this one.

- [x] Tests pass
