### PR TITLE
removes all occurences of CTAP 2.1 flags from workflows

### DIFF
--- a/.github/workflows/cargo_check.yml
+++ b/.github/workflows/cargo_check.yml
@@ -42,12 +42,6 @@ jobs:
           command: check
           args: --target thumbv7em-none-eabi --release --features with_ctap1
 
-      - name: Check OpenSK with_ctap2_1
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --target thumbv7em-none-eabi --release --features with_ctap2_1
-
       - name: Check OpenSK debug_ctap
         uses: actions-rs/cargo@v1
         with:
@@ -78,17 +72,11 @@ jobs:
           command: check
           args: --target thumbv7em-none-eabi --release --features debug_ctap,with_ctap1
 
-      - name: Check OpenSK debug_ctap,with_ctap2_1
+      - name: Check OpenSK debug_ctap,with_ctap1,panic_console,debug_allocations,verbose
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --target thumbv7em-none-eabi --release --features debug_ctap,with_ctap2_1
-
-      - name: Check OpenSK debug_ctap,with_ctap1,with_ctap2_1,panic_console,debug_allocations,verbose
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --target thumbv7em-none-eabi --release --features debug_ctap,with_ctap1,with_ctap2_1,panic_console,debug_allocations,verbose
+          args: --target thumbv7em-none-eabi --release --features debug_ctap,with_ctap1,,panic_console,debug_allocations,verbose
 
       - name: Check examples
         uses: actions-rs/cargo@v1

--- a/.github/workflows/opensk_test.yml
+++ b/.github/workflows/opensk_test.yml
@@ -51,27 +51,3 @@ jobs:
           command: test
           args: --features std,with_ctap1
 
-      - name: Unit testing of CTAP2 (release mode + CTAP2.1)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --features std,with_ctap2_1
-
-      - name: Unit testing of CTAP2 (debug mode + CTAP2.1)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features std,with_ctap2_1
-
-      - name: Unit testing of CTAP2 (release mode + CTAP1 + CTAP2.1)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --features std,with_ctap1,with_ctap2_1
-
-      - name: Unit testing of CTAP2 (debug mode + CTAP1 + CTAP2.1)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features std,with_ctap1,with_ctap2_1
-

--- a/run_desktop_tests.sh
+++ b/run_desktop_tests.sh
@@ -44,7 +44,6 @@ cargo test --manifest-path tools/heapviz/Cargo.toml
 echo "Checking that CTAP2 builds properly..."
 cargo check --release --target=thumbv7em-none-eabi
 cargo check --release --target=thumbv7em-none-eabi --features with_ctap1
-cargo check --release --target=thumbv7em-none-eabi --features with_ctap2_1
 cargo check --release --target=thumbv7em-none-eabi --features debug_ctap
 cargo check --release --target=thumbv7em-none-eabi --features panic_console
 cargo check --release --target=thumbv7em-none-eabi --features debug_allocations
@@ -116,16 +115,4 @@ then
 
   echo "Running unit tests on the desktop (debug mode + CTAP1)..."
   cargo test --features std,with_ctap1
-
-  echo "Running unit tests on the desktop (release mode + CTAP2.1)..."
-  cargo test --release --features std,with_ctap2_1
-
-  echo "Running unit tests on the desktop (debug mode + CTAP2.1)..."
-  cargo test --features std,with_ctap2_1
-
-  echo "Running unit tests on the desktop (release mode + CTAP1 + CTAP2.1)..."
-  cargo test --release --features std,with_ctap1,with_ctap2_1
-
-  echo "Running unit tests on the desktop (debug mode + CTAP1 + CTAP2.1)..."
-  cargo test --features std,with_ctap1,with_ctap2_1
 fi


### PR DESCRIPTION
Necessary to submit before #248 to not fail the old tests. Just removes the workflows for 2.1, so #248 should be submitted right after this one.

- [x] Tests pass
