### PR TITLE
Command logic for credential management

### DIFF
--- a/src/ctap/command.rs
+++ b/src/ctap/command.rs
@@ -14,10 +14,10 @@
 
 use super::data_formats::{
     extract_array, extract_bool, extract_byte_string, extract_map, extract_text_string,
-    extract_unsigned, ok_or_missing, ClientPinSubCommand, CoseKey, GetAssertionExtensions,
-    GetAssertionOptions, MakeCredentialExtensions, MakeCredentialOptions,
-    PublicKeyCredentialDescriptor, PublicKeyCredentialParameter, PublicKeyCredentialRpEntity,
-    PublicKeyCredentialUserEntity,
+    extract_unsigned, ok_or_missing, ClientPinSubCommand, CoseKey, CredentialManagementSubCommand,
+    CredentialManagementSubCommandParameters, GetAssertionExtensions, GetAssertionOptions,
+    MakeCredentialExtensions, MakeCredentialOptions, PublicKeyCredentialDescriptor,
+    PublicKeyCredentialParameter, PublicKeyCredentialRpEntity, PublicKeyCredentialUserEntity,
 };
 use super::key_material;
 use super::status_code::Ctap2StatusCode;
@@ -41,6 +41,7 @@ pub enum Command {
     AuthenticatorClientPin(AuthenticatorClientPinParameters),
     AuthenticatorReset,
     AuthenticatorGetNextAssertion,
+    AuthenticatorCredentialManagement(AuthenticatorCredentialManagementParameters),
     AuthenticatorSelection,
     // TODO(kaczmarczyck) implement FIDO 2.1 commands (see below consts)
     // Vendor specific commands
@@ -109,6 +110,12 @@ impl Command {
             Command::AUTHENTICATOR_GET_NEXT_ASSERTION => {
                 // Parameters are ignored.
                 Ok(Command::AuthenticatorGetNextAssertion)
+            }
+            Command::AUTHENTICATOR_CREDENTIAL_MANAGEMENT => {
+                let decoded_cbor = cbor::read(&bytes[1..])?;
+                Ok(Command::AuthenticatorCredentialManagement(
+                    AuthenticatorCredentialManagementParameters::try_from(decoded_cbor)?,
+                ))
             }
             Command::AUTHENTICATOR_SELECTION => {
                 // Parameters are ignored.
@@ -389,6 +396,43 @@ impl TryFrom<cbor::Value> for AuthenticatorAttestationMaterial {
 }
 
 #[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+pub struct AuthenticatorCredentialManagementParameters {
+    pub sub_command: CredentialManagementSubCommand,
+    pub sub_command_params: Option<CredentialManagementSubCommandParameters>,
+    pub pin_protocol: Option<u64>,
+    pub pin_auth: Option<Vec<u8>>,
+}
+
+impl TryFrom<cbor::Value> for AuthenticatorCredentialManagementParameters {
+    type Error = Ctap2StatusCode;
+
+    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+        destructure_cbor_map! {
+            let {
+                0x01 => sub_command,
+                0x02 => sub_command_params,
+                0x03 => pin_protocol,
+                0x04 => pin_auth,
+            } = extract_map(cbor_value)?;
+        }
+
+        let sub_command = CredentialManagementSubCommand::try_from(ok_or_missing(sub_command)?)?;
+        let sub_command_params = sub_command_params
+            .map(CredentialManagementSubCommandParameters::try_from)
+            .transpose()?;
+        let pin_protocol = pin_protocol.map(extract_unsigned).transpose()?;
+        let pin_auth = pin_auth.map(extract_byte_string).transpose()?;
+
+        Ok(AuthenticatorCredentialManagementParameters {
+            sub_command,
+            sub_command_params,
+            pin_protocol,
+            pin_auth,
+        })
+    }
+}
+
+#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
 pub struct AuthenticatorVendorConfigureParameters {
     pub lockdown: bool,
     pub attestation_material: Option<AuthenticatorAttestationMaterial>,
@@ -551,10 +595,10 @@ mod test {
             9 => 0x03,
             10 => "example.com",
         };
-        let returned_pin_protocol_parameters =
+        let returned_client_pin_parameters =
             AuthenticatorClientPinParameters::try_from(cbor_value).unwrap();
 
-        let expected_pin_protocol_parameters = AuthenticatorClientPinParameters {
+        let expected_client_pin_parameters = AuthenticatorClientPinParameters {
             pin_protocol: 1,
             sub_command: ClientPinSubCommand::GetPinRetries,
             key_agreement: Some(cose_key),
@@ -568,8 +612,8 @@ mod test {
         };
 
         assert_eq!(
-            returned_pin_protocol_parameters,
-            expected_pin_protocol_parameters
+            returned_client_pin_parameters,
+            expected_client_pin_parameters
         );
     }
 
@@ -593,6 +637,37 @@ mod test {
         let cbor_bytes = [Command::AUTHENTICATOR_GET_NEXT_ASSERTION];
         let command = Command::deserialize(&cbor_bytes);
         assert_eq!(command, Ok(Command::AuthenticatorGetNextAssertion));
+    }
+
+    #[test]
+    fn test_from_cbor_cred_management_parameters() {
+        let cbor_value = cbor_map! {
+            1 => CredentialManagementSubCommand::EnumerateCredentialsBegin as u64,
+            2 => cbor_map!{
+                0x01 => vec![0x1D; 32],
+            },
+            3 => 1,
+            4 => vec! [0x9A; 16],
+        };
+        let returned_cred_management_parameters =
+            AuthenticatorCredentialManagementParameters::try_from(cbor_value).unwrap();
+
+        let params = CredentialManagementSubCommandParameters {
+            rp_id_hash: Some(vec![0x1D; 32]),
+            credential_id: None,
+            user: None,
+        };
+        let expected_cred_management_parameters = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::EnumerateCredentialsBegin,
+            sub_command_params: Some(params),
+            pin_protocol: Some(1),
+            pin_auth: Some(vec![0x9A; 16]),
+        };
+
+        assert_eq!(
+            returned_cred_management_parameters,
+            expected_cred_management_parameters
+        );
     }
 
     #[test]

--- a/src/ctap/credential_management.rs
+++ b/src/ctap/credential_management.rs
@@ -1,0 +1,912 @@
+// Copyright 2020-2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::command::AuthenticatorCredentialManagementParameters;
+use super::data_formats::{
+    CoseKey, CredentialManagementSubCommand, CredentialManagementSubCommandParameters,
+    PublicKeyCredentialDescriptor, PublicKeyCredentialRpEntity, PublicKeyCredentialSource,
+    PublicKeyCredentialUserEntity,
+};
+use super::pin_protocol_v1::{PinPermission, PinProtocolV1};
+use super::response::{AuthenticatorCredentialManagementResponse, ResponseData};
+use super::status_code::Ctap2StatusCode;
+use super::storage::PersistentStore;
+use super::timed_permission::TimedPermission;
+use super::{check_command_permission, StatefulCommand, STATEFUL_COMMAND_TIMEOUT_DURATION};
+use alloc::collections::BTreeSet;
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::iter::FromIterator;
+use crypto::sha256::Sha256;
+use crypto::Hash256;
+use libtock_drivers::timer::ClockValue;
+
+/// Generates the response for subcommands enumerating RPs.
+fn enumerate_rps_response(
+    rp_id: Option<String>,
+    total_rps: Option<u64>,
+) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
+    let rp = rp_id.clone().map(|rp_id| PublicKeyCredentialRpEntity {
+        rp_id,
+        rp_name: None,
+        rp_icon: None,
+    });
+    let rp_id_hash = rp_id.map(|rp_id| Sha256::hash(rp_id.as_bytes()).to_vec());
+
+    Ok(AuthenticatorCredentialManagementResponse {
+        existing_resident_credentials_count: None,
+        max_possible_remaining_resident_credentials_count: None,
+        rp,
+        rp_id_hash,
+        total_rps,
+        user: None,
+        credential_id: None,
+        public_key: None,
+        total_credentials: None,
+        cred_protect: None,
+        large_blob_key: None,
+    })
+}
+
+/// Generates the response for subcommands enumerating credentials.
+fn enumerate_credentials_response(
+    credential: PublicKeyCredentialSource,
+    total_credentials: Option<u64>,
+) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
+    let PublicKeyCredentialSource {
+        key_type,
+        credential_id,
+        private_key,
+        rp_id: _,
+        user_handle,
+        user_display_name,
+        cred_protect_policy,
+        creation_order: _,
+        user_name,
+        user_icon,
+    } = credential;
+    let user = PublicKeyCredentialUserEntity {
+        user_id: user_handle,
+        user_name,
+        user_display_name,
+        user_icon,
+    };
+    let credential_id = PublicKeyCredentialDescriptor {
+        key_type,
+        key_id: credential_id,
+        transports: None, // You can set USB as a hint here.
+    };
+    let public_key = CoseKey::from(private_key.genpk());
+    Ok(AuthenticatorCredentialManagementResponse {
+        existing_resident_credentials_count: None,
+        max_possible_remaining_resident_credentials_count: None,
+        rp: None,
+        rp_id_hash: None,
+        total_rps: None,
+        user: Some(user),
+        credential_id: Some(credential_id),
+        public_key: Some(public_key),
+        total_credentials,
+        cred_protect: cred_protect_policy,
+        // TODO(kaczmarczyck) add when largeBlobKey is implemented
+        large_blob_key: None,
+    })
+}
+
+/// Processes the subcommand getCredsMetadata for CredentialManagement.
+fn process_get_creds_metadata(
+    persistent_store: &PersistentStore,
+) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
+    Ok(AuthenticatorCredentialManagementResponse {
+        existing_resident_credentials_count: Some(persistent_store.count_credentials()? as u64),
+        max_possible_remaining_resident_credentials_count: Some(
+            persistent_store.remaining_credentials()? as u64,
+        ),
+        rp: None,
+        rp_id_hash: None,
+        total_rps: None,
+        user: None,
+        credential_id: None,
+        public_key: None,
+        total_credentials: None,
+        cred_protect: None,
+        large_blob_key: None,
+    })
+}
+
+/// Processes the subcommand enumerateRPsBegin for CredentialManagement.
+fn process_enumerate_rps_begin(
+    persistent_store: &PersistentStore,
+    stateful_command_permission: &mut TimedPermission,
+    stateful_command_type: &mut Option<StatefulCommand>,
+    now: ClockValue,
+) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
+    let mut rp_set = BTreeSet::new();
+    let mut iter_result = Ok(());
+    for (_, credential) in persistent_store.iter_credentials(&mut iter_result)? {
+        rp_set.insert(credential.rp_id);
+    }
+    iter_result?;
+    let mut rp_ids = Vec::from_iter(rp_set);
+    let total_rps = rp_ids.len();
+
+    // TODO(kaczmarczyck) behaviour with empty list?
+    let rp_id = rp_ids.pop();
+    if total_rps > 1 {
+        *stateful_command_permission =
+            TimedPermission::granted(now, STATEFUL_COMMAND_TIMEOUT_DURATION);
+        *stateful_command_type = Some(StatefulCommand::EnumerateRps(rp_ids));
+    }
+    enumerate_rps_response(rp_id, Some(total_rps as u64))
+}
+
+/// Processes the subcommand enumerateRPsGetNextRP for CredentialManagement.
+fn process_enumerate_rps_get_next_rp(
+    stateful_command_permission: &mut TimedPermission,
+    stateful_command_type: &mut Option<StatefulCommand>,
+    now: ClockValue,
+) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
+    check_command_permission(stateful_command_permission, now)?;
+    if let Some(StatefulCommand::EnumerateRps(rp_ids)) = stateful_command_type {
+        let rp_id = rp_ids.pop().ok_or(Ctap2StatusCode::CTAP2_ERR_NOT_ALLOWED)?;
+        enumerate_rps_response(Some(rp_id), None)
+    } else {
+        Err(Ctap2StatusCode::CTAP2_ERR_NOT_ALLOWED)
+    }
+}
+
+/// Processes the subcommand enumerateCredentialsBegin for CredentialManagement.
+fn process_enumerate_credentials_begin(
+    persistent_store: &PersistentStore,
+    stateful_command_permission: &mut TimedPermission,
+    stateful_command_type: &mut Option<StatefulCommand>,
+    sub_command_params: CredentialManagementSubCommandParameters,
+    now: ClockValue,
+) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
+    let rp_id_hash = sub_command_params
+        .rp_id_hash
+        .ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?;
+    let mut iter_result = Ok(());
+    let iter = persistent_store.iter_credentials(&mut iter_result)?;
+    let mut rp_credentials: Vec<usize> = iter
+        .filter_map(|(key, credential)| {
+            let cred_rp_id_hash = Sha256::hash(credential.rp_id.as_bytes());
+            if cred_rp_id_hash == rp_id_hash.as_slice() {
+                Some(key)
+            } else {
+                None
+            }
+        })
+        .collect();
+    iter_result?;
+    let total_credentials = rp_credentials.len();
+    let current_key = rp_credentials
+        .pop()
+        .ok_or(Ctap2StatusCode::CTAP2_ERR_NO_CREDENTIALS)?;
+    let credential = persistent_store.get_credential(current_key)?;
+    if total_credentials > 1 {
+        *stateful_command_permission =
+            TimedPermission::granted(now, STATEFUL_COMMAND_TIMEOUT_DURATION);
+        *stateful_command_type = Some(StatefulCommand::EnumerateCredentials(rp_credentials));
+    }
+    enumerate_credentials_response(credential, Some(total_credentials as u64))
+}
+
+/// Processes the subcommand enumerateCredentialsGetNextCredential for CredentialManagement.
+fn process_enumerate_credentials_get_next_credential(
+    persistent_store: &PersistentStore,
+    stateful_command_permission: &mut TimedPermission,
+    mut stateful_command_type: &mut Option<StatefulCommand>,
+    now: ClockValue,
+) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
+    check_command_permission(stateful_command_permission, now)?;
+    if let Some(StatefulCommand::EnumerateCredentials(rp_credentials)) = &mut stateful_command_type
+    {
+        let current_key = rp_credentials
+            .pop()
+            .ok_or(Ctap2StatusCode::CTAP2_ERR_NOT_ALLOWED)?;
+        let credential = persistent_store.get_credential(current_key)?;
+        enumerate_credentials_response(credential, None)
+    } else {
+        Err(Ctap2StatusCode::CTAP2_ERR_NOT_ALLOWED)
+    }
+}
+
+/// Processes the subcommand deleteCredential for CredentialManagement.
+fn process_delete_credential(
+    persistent_store: &mut PersistentStore,
+    sub_command_params: CredentialManagementSubCommandParameters,
+) -> Result<(), Ctap2StatusCode> {
+    let credential_id = sub_command_params
+        .credential_id
+        .ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?
+        .key_id;
+    persistent_store.delete_credential(&credential_id)
+}
+
+/// Processes the subcommand updateUserInformation for CredentialManagement.
+fn process_update_user_information(
+    persistent_store: &mut PersistentStore,
+    sub_command_params: CredentialManagementSubCommandParameters,
+) -> Result<(), Ctap2StatusCode> {
+    let credential_id = sub_command_params
+        .credential_id
+        .ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?
+        .key_id;
+    let user = sub_command_params
+        .user
+        .ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?;
+    persistent_store.update_credential(&credential_id, user)
+}
+
+/// Checks the PIN protocol.
+///
+/// TODO(#246) refactor after #246 is merged
+fn pin_uv_auth_protocol_check(pin_uv_auth_protocol: Option<u64>) -> Result<(), Ctap2StatusCode> {
+    match pin_uv_auth_protocol {
+        Some(1) => Ok(()),
+        _ => Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID),
+    }
+}
+
+/// Processes the CredentialManagement command and all its subcommands.
+pub fn process_credential_management(
+    persistent_store: &mut PersistentStore,
+    stateful_command_permission: &mut TimedPermission,
+    mut stateful_command_type: &mut Option<StatefulCommand>,
+    pin_protocol_v1: &mut PinProtocolV1,
+    cred_management_params: AuthenticatorCredentialManagementParameters,
+    now: ClockValue,
+) -> Result<ResponseData, Ctap2StatusCode> {
+    let AuthenticatorCredentialManagementParameters {
+        sub_command,
+        sub_command_params,
+        pin_protocol,
+        pin_auth,
+    } = cred_management_params;
+
+    match (sub_command, &mut stateful_command_type) {
+        (
+            CredentialManagementSubCommand::EnumerateRpsGetNextRp,
+            Some(StatefulCommand::EnumerateRps(_)),
+        ) => (),
+        (
+            CredentialManagementSubCommand::EnumerateCredentialsGetNextCredential,
+            Some(StatefulCommand::EnumerateCredentials(_)),
+        ) => (),
+        (_, _) => {
+            *stateful_command_type = None;
+        }
+    }
+
+    match sub_command {
+        CredentialManagementSubCommand::GetCredsMetadata
+        | CredentialManagementSubCommand::EnumerateRpsBegin
+        | CredentialManagementSubCommand::DeleteCredential
+        | CredentialManagementSubCommand::EnumerateCredentialsBegin
+        | CredentialManagementSubCommand::UpdateUserInformation => {
+            pin_uv_auth_protocol_check(pin_protocol)?;
+            persistent_store
+                .pin_hash()?
+                .ok_or(Ctap2StatusCode::CTAP2_ERR_PUAT_REQUIRED)?;
+            let pin_auth = pin_auth.ok_or(Ctap2StatusCode::CTAP2_ERR_PUAT_REQUIRED)?;
+            let mut management_data = vec![sub_command as u8];
+            if let Some(sub_command_params) = sub_command_params.clone() {
+                if !cbor::write(sub_command_params.into(), &mut management_data) {
+                    return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
+                }
+            }
+            if !pin_protocol_v1.verify_pin_auth_token(&management_data, &pin_auth) {
+                return Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID);
+            }
+            pin_protocol_v1.has_permission(PinPermission::CredentialManagement)?;
+            pin_protocol_v1.has_no_permission_rp_id()?;
+            // TODO(kaczmarczyck) sometimes allow a RP ID
+        }
+        CredentialManagementSubCommand::EnumerateRpsGetNextRp
+        | CredentialManagementSubCommand::EnumerateCredentialsGetNextCredential => {}
+    }
+
+    let response = match sub_command {
+        CredentialManagementSubCommand::GetCredsMetadata => {
+            Some(process_get_creds_metadata(persistent_store)?)
+        }
+        CredentialManagementSubCommand::EnumerateRpsBegin => Some(process_enumerate_rps_begin(
+            persistent_store,
+            stateful_command_permission,
+            stateful_command_type,
+            now,
+        )?),
+        CredentialManagementSubCommand::EnumerateRpsGetNextRp => {
+            Some(process_enumerate_rps_get_next_rp(
+                stateful_command_permission,
+                stateful_command_type,
+                now,
+            )?)
+        }
+        CredentialManagementSubCommand::EnumerateCredentialsBegin => {
+            Some(process_enumerate_credentials_begin(
+                persistent_store,
+                stateful_command_permission,
+                stateful_command_type,
+                sub_command_params.ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?,
+                now,
+            )?)
+        }
+        CredentialManagementSubCommand::EnumerateCredentialsGetNextCredential => {
+            Some(process_enumerate_credentials_get_next_credential(
+                persistent_store,
+                stateful_command_permission,
+                stateful_command_type,
+                now,
+            )?)
+        }
+        CredentialManagementSubCommand::DeleteCredential => {
+            process_delete_credential(
+                persistent_store,
+                sub_command_params.ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?,
+            )?;
+            None
+        }
+        CredentialManagementSubCommand::UpdateUserInformation => {
+            process_update_user_information(
+                persistent_store,
+                sub_command_params.ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?,
+            )?;
+            None
+        }
+    };
+    Ok(ResponseData::AuthenticatorCredentialManagement(response))
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::data_formats::PublicKeyCredentialType;
+    use super::super::CtapState;
+    use super::*;
+    use crypto::rng256::{Rng256, ThreadRng256};
+
+    const CLOCK_FREQUENCY_HZ: usize = 32768;
+    const DUMMY_CLOCK_VALUE: ClockValue = ClockValue::new(0, CLOCK_FREQUENCY_HZ);
+
+    fn create_credential_source(rng: &mut impl Rng256) -> PublicKeyCredentialSource {
+        let private_key = crypto::ecdsa::SecKey::gensk(rng);
+        PublicKeyCredentialSource {
+            key_type: PublicKeyCredentialType::PublicKey,
+            credential_id: rng.gen_uniform_u8x32().to_vec(),
+            private_key,
+            rp_id: String::from("example.com"),
+            user_handle: vec![0x01],
+            user_display_name: Some("display_name".to_string()),
+            cred_protect_policy: None,
+            creation_order: 0,
+            user_name: Some("name".to_string()),
+            user_icon: Some("icon".to_string()),
+        }
+    }
+
+    #[test]
+    fn test_process_get_creds_metadata() {
+        let mut rng = ThreadRng256 {};
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let pin_uv_auth_token = [0x55; 32];
+        let pin_protocol_v1 = PinProtocolV1::new_test(key_agreement_key, pin_uv_auth_token);
+        let credential_source = create_credential_source(&mut rng);
+
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        ctap_state.pin_protocol_v1 = pin_protocol_v1;
+
+        ctap_state
+            .persistent_store
+            .set_pin_hash(&[0u8; 16])
+            .unwrap();
+        let pin_auth = Some(vec![
+            0xC5, 0xFB, 0x75, 0x55, 0x98, 0xB5, 0x19, 0x01, 0xB3, 0x31, 0x7D, 0xFE, 0x1D, 0xF5,
+            0xFB, 0x00,
+        ]);
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::GetCredsMetadata,
+            sub_command_params: None,
+            pin_protocol: Some(1),
+            pin_auth: pin_auth.clone(),
+        };
+        let cred_management_response = process_credential_management(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        let initial_capacity = match cred_management_response.unwrap() {
+            ResponseData::AuthenticatorCredentialManagement(Some(response)) => {
+                assert_eq!(response.existing_resident_credentials_count, Some(0));
+                response
+                    .max_possible_remaining_resident_credentials_count
+                    .unwrap()
+            }
+            _ => panic!("Invalid response type"),
+        };
+
+        ctap_state
+            .persistent_store
+            .store_credential(credential_source)
+            .unwrap();
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::GetCredsMetadata,
+            sub_command_params: None,
+            pin_protocol: Some(1),
+            pin_auth,
+        };
+        let cred_management_response = process_credential_management(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        match cred_management_response.unwrap() {
+            ResponseData::AuthenticatorCredentialManagement(Some(response)) => {
+                assert_eq!(response.existing_resident_credentials_count, Some(1));
+                assert_eq!(
+                    response.max_possible_remaining_resident_credentials_count,
+                    Some(initial_capacity - 1)
+                );
+            }
+            _ => panic!("Invalid response type"),
+        };
+    }
+
+    #[test]
+    fn test_process_enumerate_rps_with_uv() {
+        let mut rng = ThreadRng256 {};
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let pin_uv_auth_token = [0x55; 32];
+        let pin_protocol_v1 = PinProtocolV1::new_test(key_agreement_key, pin_uv_auth_token);
+        let credential_source1 = create_credential_source(&mut rng);
+        let mut credential_source2 = create_credential_source(&mut rng);
+        credential_source2.rp_id = "another.example.com".to_string();
+
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        ctap_state.pin_protocol_v1 = pin_protocol_v1;
+
+        ctap_state
+            .persistent_store
+            .store_credential(credential_source1)
+            .unwrap();
+        ctap_state
+            .persistent_store
+            .store_credential(credential_source2)
+            .unwrap();
+
+        ctap_state
+            .persistent_store
+            .set_pin_hash(&[0u8; 16])
+            .unwrap();
+        let pin_auth = Some(vec![
+            0x1A, 0xA4, 0x96, 0xDA, 0x62, 0x80, 0x28, 0x13, 0xEB, 0x32, 0xB9, 0xF1, 0xD2, 0xA9,
+            0xD0, 0xD1,
+        ]);
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::EnumerateRpsBegin,
+            sub_command_params: None,
+            pin_protocol: Some(1),
+            pin_auth,
+        };
+        let cred_management_response = process_credential_management(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        let first_rp_id = match cred_management_response.unwrap() {
+            ResponseData::AuthenticatorCredentialManagement(Some(response)) => {
+                assert_eq!(response.total_rps, Some(2));
+                let rp_id = response.rp.unwrap().rp_id;
+                let rp_id_hash = Sha256::hash(rp_id.as_bytes());
+                assert_eq!(rp_id_hash, response.rp_id_hash.unwrap().as_slice());
+                rp_id
+            }
+            _ => panic!("Invalid response type"),
+        };
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::EnumerateRpsGetNextRp,
+            sub_command_params: None,
+            pin_protocol: None,
+            pin_auth: None,
+        };
+        let cred_management_response = process_credential_management(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        let second_rp_id = match cred_management_response.unwrap() {
+            ResponseData::AuthenticatorCredentialManagement(Some(response)) => {
+                assert_eq!(response.total_rps, None);
+                let rp_id = response.rp.unwrap().rp_id;
+                let rp_id_hash = Sha256::hash(rp_id.as_bytes());
+                assert_eq!(rp_id_hash, response.rp_id_hash.unwrap().as_slice());
+                rp_id
+            }
+            _ => panic!("Invalid response type"),
+        };
+
+        assert!(first_rp_id != second_rp_id);
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::EnumerateRpsGetNextRp,
+            sub_command_params: None,
+            pin_protocol: None,
+            pin_auth: None,
+        };
+        let cred_management_response = process_credential_management(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        assert_eq!(
+            cred_management_response,
+            Err(Ctap2StatusCode::CTAP2_ERR_NOT_ALLOWED)
+        );
+    }
+
+    #[test]
+    fn test_process_enumerate_credentials_with_uv() {
+        let mut rng = ThreadRng256 {};
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let pin_uv_auth_token = [0x55; 32];
+        let pin_protocol_v1 = PinProtocolV1::new_test(key_agreement_key, pin_uv_auth_token);
+        let credential_source1 = create_credential_source(&mut rng);
+        let mut credential_source2 = create_credential_source(&mut rng);
+        credential_source2.user_handle = vec![0x02];
+        credential_source2.user_name = Some("user2".to_string());
+        credential_source2.user_display_name = Some("User Two".to_string());
+        credential_source2.user_icon = Some("icon2".to_string());
+
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        ctap_state.pin_protocol_v1 = pin_protocol_v1;
+
+        ctap_state
+            .persistent_store
+            .store_credential(credential_source1)
+            .unwrap();
+        ctap_state
+            .persistent_store
+            .store_credential(credential_source2)
+            .unwrap();
+
+        ctap_state
+            .persistent_store
+            .set_pin_hash(&[0u8; 16])
+            .unwrap();
+        let pin_auth = Some(vec![
+            0xF8, 0xB0, 0x3C, 0xC1, 0xD5, 0x58, 0x9C, 0xB7, 0x4D, 0x42, 0xA1, 0x64, 0x14, 0x28,
+            0x2B, 0x68,
+        ]);
+
+        let sub_command_params = CredentialManagementSubCommandParameters {
+            rp_id_hash: Some(Sha256::hash(b"example.com").to_vec()),
+            credential_id: None,
+            user: None,
+        };
+        // RP ID hash:
+        // A379A6F6EEAFB9A55E378C118034E2751E682FAB9F2D30AB13D2125586CE1947
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::EnumerateCredentialsBegin,
+            sub_command_params: Some(sub_command_params),
+            pin_protocol: Some(1),
+            pin_auth,
+        };
+        let cred_management_response = process_credential_management(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        let first_credential_id = match cred_management_response.unwrap() {
+            ResponseData::AuthenticatorCredentialManagement(Some(response)) => {
+                assert!(response.user.is_some());
+                assert!(response.public_key.is_some());
+                assert_eq!(response.total_credentials, Some(2));
+                response.credential_id.unwrap().key_id
+            }
+            _ => panic!("Invalid response type"),
+        };
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::EnumerateCredentialsGetNextCredential,
+            sub_command_params: None,
+            pin_protocol: None,
+            pin_auth: None,
+        };
+        let cred_management_response = process_credential_management(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        let second_credential_id = match cred_management_response.unwrap() {
+            ResponseData::AuthenticatorCredentialManagement(Some(response)) => {
+                assert!(response.user.is_some());
+                assert!(response.public_key.is_some());
+                assert_eq!(response.total_credentials, None);
+                response.credential_id.unwrap().key_id
+            }
+            _ => panic!("Invalid response type"),
+        };
+
+        assert!(first_credential_id != second_credential_id);
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::EnumerateCredentialsGetNextCredential,
+            sub_command_params: None,
+            pin_protocol: None,
+            pin_auth: None,
+        };
+        let cred_management_response = process_credential_management(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        assert_eq!(
+            cred_management_response,
+            Err(Ctap2StatusCode::CTAP2_ERR_NOT_ALLOWED)
+        );
+    }
+
+    #[test]
+    fn test_process_delete_credential() {
+        let mut rng = ThreadRng256 {};
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let pin_uv_auth_token = [0x55; 32];
+        let pin_protocol_v1 = PinProtocolV1::new_test(key_agreement_key, pin_uv_auth_token);
+        let mut credential_source = create_credential_source(&mut rng);
+        credential_source.credential_id = vec![0x1D; 32];
+
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        ctap_state.pin_protocol_v1 = pin_protocol_v1;
+
+        ctap_state
+            .persistent_store
+            .store_credential(credential_source)
+            .unwrap();
+
+        ctap_state
+            .persistent_store
+            .set_pin_hash(&[0u8; 16])
+            .unwrap();
+        let pin_auth = Some(vec![
+            0xBD, 0xE3, 0xEF, 0x8A, 0x77, 0x01, 0xB1, 0x69, 0x19, 0xE6, 0x62, 0xB9, 0x9B, 0x89,
+            0x9C, 0x64,
+        ]);
+
+        let credential_id = PublicKeyCredentialDescriptor {
+            key_type: PublicKeyCredentialType::PublicKey,
+            key_id: vec![0x1D; 32],
+            transports: None, // You can set USB as a hint here.
+        };
+        let sub_command_params = CredentialManagementSubCommandParameters {
+            rp_id_hash: None,
+            credential_id: Some(credential_id),
+            user: None,
+        };
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::DeleteCredential,
+            sub_command_params: Some(sub_command_params.clone()),
+            pin_protocol: Some(1),
+            pin_auth: pin_auth.clone(),
+        };
+        let cred_management_response = process_credential_management(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        assert_eq!(
+            cred_management_response,
+            Ok(ResponseData::AuthenticatorCredentialManagement(None))
+        );
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::DeleteCredential,
+            sub_command_params: Some(sub_command_params),
+            pin_protocol: Some(1),
+            pin_auth,
+        };
+        let cred_management_response = process_credential_management(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        assert_eq!(
+            cred_management_response,
+            Err(Ctap2StatusCode::CTAP2_ERR_NO_CREDENTIALS)
+        );
+    }
+
+    #[test]
+    fn test_process_update_user_information() {
+        let mut rng = ThreadRng256 {};
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let pin_uv_auth_token = [0x55; 32];
+        let pin_protocol_v1 = PinProtocolV1::new_test(key_agreement_key, pin_uv_auth_token);
+        let mut credential_source = create_credential_source(&mut rng);
+        credential_source.credential_id = vec![0x1D; 32];
+
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        ctap_state.pin_protocol_v1 = pin_protocol_v1;
+
+        ctap_state
+            .persistent_store
+            .store_credential(credential_source)
+            .unwrap();
+
+        ctap_state
+            .persistent_store
+            .set_pin_hash(&[0u8; 16])
+            .unwrap();
+        let pin_auth = Some(vec![
+            0xA5, 0x55, 0x8F, 0x03, 0xC3, 0xD3, 0x73, 0x1C, 0x07, 0xDA, 0x1F, 0x8C, 0xC7, 0xBD,
+            0x9D, 0xB7,
+        ]);
+
+        let credential_id = PublicKeyCredentialDescriptor {
+            key_type: PublicKeyCredentialType::PublicKey,
+            key_id: vec![0x1D; 32],
+            transports: None, // You can set USB as a hint here.
+        };
+        let new_user = PublicKeyCredentialUserEntity {
+            user_id: vec![0xFF],
+            user_name: Some("new_name".to_string()),
+            user_display_name: Some("new_display_name".to_string()),
+            user_icon: Some("new_icon".to_string()),
+        };
+        let sub_command_params = CredentialManagementSubCommandParameters {
+            rp_id_hash: None,
+            credential_id: Some(credential_id),
+            user: Some(new_user),
+        };
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::UpdateUserInformation,
+            sub_command_params: Some(sub_command_params),
+            pin_protocol: Some(1),
+            pin_auth,
+        };
+        let cred_management_response = process_credential_management(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        assert_eq!(
+            cred_management_response,
+            Ok(ResponseData::AuthenticatorCredentialManagement(None))
+        );
+
+        let updated_credential = ctap_state
+            .persistent_store
+            .find_credential("example.com", &[0x1D; 32], false)
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated_credential.user_handle, vec![0x01]);
+        assert_eq!(&updated_credential.user_name.unwrap(), "new_name");
+        assert_eq!(
+            &updated_credential.user_display_name.unwrap(),
+            "new_display_name"
+        );
+        assert_eq!(&updated_credential.user_icon.unwrap(), "new_icon");
+    }
+
+    #[test]
+    fn test_process_credential_management_invalid_pin_protocol() {
+        let mut rng = ThreadRng256 {};
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let pin_uv_auth_token = [0x55; 32];
+        let pin_protocol_v1 = PinProtocolV1::new_test(key_agreement_key, pin_uv_auth_token);
+
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        ctap_state.pin_protocol_v1 = pin_protocol_v1;
+
+        ctap_state
+            .persistent_store
+            .set_pin_hash(&[0u8; 16])
+            .unwrap();
+        let pin_auth = Some(vec![
+            0xC5, 0xFB, 0x75, 0x55, 0x98, 0xB5, 0x19, 0x01, 0xB3, 0x31, 0x7D, 0xFE, 0x1D, 0xF5,
+            0xFB, 0x00,
+        ]);
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::GetCredsMetadata,
+            sub_command_params: None,
+            pin_protocol: Some(123456),
+            pin_auth,
+        };
+        let cred_management_response = process_credential_management(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        assert_eq!(
+            cred_management_response,
+            Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
+        );
+    }
+
+    #[test]
+    fn test_process_credential_management_invalid_pin_auth() {
+        let mut rng = ThreadRng256 {};
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+
+        ctap_state
+            .persistent_store
+            .set_pin_hash(&[0u8; 16])
+            .unwrap();
+
+        let cred_management_params = AuthenticatorCredentialManagementParameters {
+            sub_command: CredentialManagementSubCommand::GetCredsMetadata,
+            sub_command_params: None,
+            pin_protocol: Some(1),
+            pin_auth: Some(vec![0u8; 16]),
+        };
+        let cred_management_response = process_credential_management(
+            &mut ctap_state.persistent_store,
+            &mut ctap_state.stateful_command_permission,
+            &mut ctap_state.stateful_command_type,
+            &mut ctap_state.pin_protocol_v1,
+            cred_management_params,
+            DUMMY_CLOCK_VALUE,
+        );
+        assert_eq!(
+            cred_management_response,
+            Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
+        );
+    }
+}

--- a/src/ctap/credential_management.rs
+++ b/src/ctap/credential_management.rs
@@ -49,17 +49,10 @@ fn enumerate_rps_response(
     let rp_id_hash = rp_id.map(|rp_id| Sha256::hash(rp_id.as_bytes()).to_vec());
 
     Ok(AuthenticatorCredentialManagementResponse {
-        existing_resident_credentials_count: None,
-        max_possible_remaining_resident_credentials_count: None,
         rp,
         rp_id_hash,
         total_rps,
-        user: None,
-        credential_id: None,
-        public_key: None,
-        total_credentials: None,
-        cred_protect: None,
-        large_blob_key: None,
+        ..Default::default()
     })
 }
 
@@ -93,11 +86,6 @@ fn enumerate_credentials_response(
     };
     let public_key = CoseKey::from(private_key.genpk());
     Ok(AuthenticatorCredentialManagementResponse {
-        existing_resident_credentials_count: None,
-        max_possible_remaining_resident_credentials_count: None,
-        rp: None,
-        rp_id_hash: None,
-        total_rps: None,
         user: Some(user),
         credential_id: Some(credential_id),
         public_key: Some(public_key),
@@ -105,6 +93,7 @@ fn enumerate_credentials_response(
         cred_protect: cred_protect_policy,
         // TODO(kaczmarczyck) add when largeBlobKey is implemented
         large_blob_key: None,
+        ..Default::default()
     })
 }
 
@@ -117,15 +106,7 @@ fn process_get_creds_metadata(
         max_possible_remaining_resident_credentials_count: Some(
             persistent_store.remaining_credentials()? as u64,
         ),
-        rp: None,
-        rp_id_hash: None,
-        total_rps: None,
-        user: None,
-        credential_id: None,
-        public_key: None,
-        total_credentials: None,
-        cred_protect: None,
-        large_blob_key: None,
+        ..Default::default()
     })
 }
 

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -165,7 +165,7 @@ pub struct AssertionState {
 pub enum StatefulCommand {
     Reset,
     GetAssertion(AssertionState),
-    EnumerateRps(Vec<String>),
+    EnumerateRps(usize),
     EnumerateCredentials(Vec<usize>),
 }
 

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -180,7 +180,7 @@ pub enum StatefulCommand {
 /// remove all state and permissions. Power cycling allows the Reset command,
 /// and to prevent misuse or accidents, we disallow Reset after receiving
 /// different commands. Therefore, Reset behaves just like all other stateful
-/// commands and is included here. Please not that the allowed time for Reset
+/// commands and is included here. Please note that the allowed time for Reset
 /// differs from all other stateful commands.
 pub struct StatefulPermission {
     permission: TimedPermission,

--- a/src/ctap/pin_protocol_v1.rs
+++ b/src/ctap/pin_protocol_v1.rs
@@ -563,6 +563,13 @@ impl PinProtocolV1 {
         }
     }
 
+    pub fn has_no_permission_rp_id(&self) -> Result<(), Ctap2StatusCode> {
+        if self.permissions_rp_id.is_some() {
+            return Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID);
+        }
+        Ok(())
+    }
+
     pub fn has_permission_for_rp_id(&mut self, rp_id: &str) -> Result<(), Ctap2StatusCode> {
         if let Some(permissions_rp_id) = &self.permissions_rp_id {
             if rp_id != permissions_rp_id {
@@ -1185,6 +1192,19 @@ mod test {
                 Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
             );
         }
+    }
+
+    #[test]
+    fn test_has_no_permission_rp_id() {
+        let mut rng = ThreadRng256 {};
+        let mut pin_protocol_v1 = PinProtocolV1::new(&mut rng);
+        assert_eq!(pin_protocol_v1.has_no_permission_rp_id(), Ok(()));
+        assert_eq!(pin_protocol_v1.permissions_rp_id, None,);
+        pin_protocol_v1.permissions_rp_id = Some("example.com".to_string());
+        assert_eq!(
+            pin_protocol_v1.has_no_permission_rp_id(),
+            Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
+        );
     }
 
     #[test]

--- a/src/ctap/response.rs
+++ b/src/ctap/response.rs
@@ -14,7 +14,8 @@
 
 use super::data_formats::{
     AuthenticatorTransport, CoseKey, CredentialProtectionPolicy, PackedAttestationStatement,
-    PublicKeyCredentialDescriptor, PublicKeyCredentialParameter, PublicKeyCredentialUserEntity,
+    PublicKeyCredentialDescriptor, PublicKeyCredentialParameter, PublicKeyCredentialRpEntity,
+    PublicKeyCredentialUserEntity,
 };
 use alloc::collections::BTreeMap;
 use alloc::string::String;
@@ -30,6 +31,7 @@ pub enum ResponseData {
     AuthenticatorGetInfo(AuthenticatorGetInfoResponse),
     AuthenticatorClientPin(Option<AuthenticatorClientPinResponse>),
     AuthenticatorReset,
+    AuthenticatorCredentialManagement(Option<AuthenticatorCredentialManagementResponse>),
     AuthenticatorSelection,
     AuthenticatorVendor(AuthenticatorVendorResponse),
 }
@@ -41,9 +43,9 @@ impl From<ResponseData> for Option<cbor::Value> {
             ResponseData::AuthenticatorGetAssertion(data) => Some(data.into()),
             ResponseData::AuthenticatorGetNextAssertion(data) => Some(data.into()),
             ResponseData::AuthenticatorGetInfo(data) => Some(data.into()),
-            ResponseData::AuthenticatorClientPin(Some(data)) => Some(data.into()),
-            ResponseData::AuthenticatorClientPin(None) => None,
+            ResponseData::AuthenticatorClientPin(data) => data.map(|d| d.into()),
             ResponseData::AuthenticatorReset => None,
+            ResponseData::AuthenticatorCredentialManagement(data) => data.map(|d| d.into()),
             ResponseData::AuthenticatorSelection => None,
             ResponseData::AuthenticatorVendor(data) => Some(data.into()),
         }
@@ -201,6 +203,54 @@ impl From<AuthenticatorClientPinResponse> for cbor::Value {
 
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug))]
+pub struct AuthenticatorCredentialManagementResponse {
+    pub existing_resident_credentials_count: Option<u64>,
+    pub max_possible_remaining_resident_credentials_count: Option<u64>,
+    pub rp: Option<PublicKeyCredentialRpEntity>,
+    pub rp_id_hash: Option<Vec<u8>>,
+    pub total_rps: Option<u64>,
+    pub user: Option<PublicKeyCredentialUserEntity>,
+    pub credential_id: Option<PublicKeyCredentialDescriptor>,
+    pub public_key: Option<CoseKey>,
+    pub total_credentials: Option<u64>,
+    pub cred_protect: Option<CredentialProtectionPolicy>,
+    pub large_blob_key: Option<Vec<u8>>,
+}
+
+impl From<AuthenticatorCredentialManagementResponse> for cbor::Value {
+    fn from(cred_management_response: AuthenticatorCredentialManagementResponse) -> Self {
+        let AuthenticatorCredentialManagementResponse {
+            existing_resident_credentials_count,
+            max_possible_remaining_resident_credentials_count,
+            rp,
+            rp_id_hash,
+            total_rps,
+            user,
+            credential_id,
+            public_key,
+            total_credentials,
+            cred_protect,
+            large_blob_key,
+        } = cred_management_response;
+
+        cbor_map_options! {
+            0x01 => existing_resident_credentials_count,
+            0x02 => max_possible_remaining_resident_credentials_count,
+            0x03 => rp,
+            0x04 => rp_id_hash,
+            0x05 => total_rps,
+            0x06 => user,
+            0x07 => credential_id,
+            0x08 => public_key.map(cbor::Value::from),
+            0x09 => total_credentials,
+            0x0A => cred_protect,
+            0x0B => large_blob_key,
+        }
+    }
+}
+
+#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug))]
 pub struct AuthenticatorVendorResponse {
     pub cert_programmed: bool,
     pub pkey_programmed: bool,
@@ -222,10 +272,11 @@ impl From<AuthenticatorVendorResponse> for cbor::Value {
 
 #[cfg(test)]
 mod test {
-    use super::super::data_formats::PackedAttestationStatement;
+    use super::super::data_formats::{PackedAttestationStatement, PublicKeyCredentialType};
     use super::super::ES256_CRED_PARAM;
     use super::*;
     use cbor::{cbor_bytes, cbor_map};
+    use crypto::rng256::ThreadRng256;
 
     #[test]
     fn test_make_credential_into_cbor() {
@@ -376,6 +427,88 @@ mod test {
     #[test]
     fn test_reset_into_cbor() {
         let response_cbor: Option<cbor::Value> = ResponseData::AuthenticatorReset.into();
+        assert_eq!(response_cbor, None);
+    }
+
+    #[test]
+    fn test_used_credential_management_into_cbor() {
+        let cred_management_response = AuthenticatorCredentialManagementResponse {
+            existing_resident_credentials_count: None,
+            max_possible_remaining_resident_credentials_count: None,
+            rp: None,
+            rp_id_hash: None,
+            total_rps: None,
+            user: None,
+            credential_id: None,
+            public_key: None,
+            total_credentials: None,
+            cred_protect: None,
+            large_blob_key: None,
+        };
+        let response_cbor: Option<cbor::Value> =
+            ResponseData::AuthenticatorCredentialManagement(Some(cred_management_response)).into();
+        let expected_cbor = cbor_map_options! {};
+        assert_eq!(response_cbor, Some(expected_cbor));
+    }
+
+    #[test]
+    fn test_used_credential_management_optionals_into_cbor() {
+        let mut rng = ThreadRng256 {};
+        let sk = crypto::ecdh::SecKey::gensk(&mut rng);
+        let rp = PublicKeyCredentialRpEntity {
+            rp_id: String::from("example.com"),
+            rp_name: None,
+            rp_icon: None,
+        };
+        let user = PublicKeyCredentialUserEntity {
+            user_id: vec![0xFA, 0xB1, 0xA2],
+            user_name: None,
+            user_display_name: None,
+            user_icon: None,
+        };
+        let cred_descriptor = PublicKeyCredentialDescriptor {
+            key_type: PublicKeyCredentialType::PublicKey,
+            key_id: vec![0x1D; 32],
+            transports: None,
+        };
+        let pk = sk.genpk();
+        let cose_key = CoseKey::from(pk);
+
+        let cred_management_response = AuthenticatorCredentialManagementResponse {
+            existing_resident_credentials_count: Some(100),
+            max_possible_remaining_resident_credentials_count: Some(96),
+            rp: Some(rp.clone()),
+            rp_id_hash: Some(vec![0x1D; 32]),
+            total_rps: Some(3),
+            user: Some(user.clone()),
+            credential_id: Some(cred_descriptor.clone()),
+            public_key: Some(cose_key.clone()),
+            total_credentials: Some(2),
+            cred_protect: Some(CredentialProtectionPolicy::UserVerificationOptional),
+            large_blob_key: Some(vec![0xBB; 64]),
+        };
+        let response_cbor: Option<cbor::Value> =
+            ResponseData::AuthenticatorCredentialManagement(Some(cred_management_response)).into();
+        let expected_cbor = cbor_map_options! {
+            0x01 => 100,
+            0x02 => 96,
+            0x03 => rp,
+            0x04 => vec![0x1D; 32],
+            0x05 => 3,
+            0x06 => user,
+            0x07 => cred_descriptor,
+            0x08 => cbor::Value::from(cose_key),
+            0x09 => 2,
+            0x0A => 0x01,
+            0x0B => vec![0xBB; 64],
+        };
+        assert_eq!(response_cbor, Some(expected_cbor));
+    }
+
+    #[test]
+    fn test_empty_credential_management_into_cbor() {
+        let response_cbor: Option<cbor::Value> =
+            ResponseData::AuthenticatorCredentialManagement(None).into();
         assert_eq!(response_cbor, None);
     }
 

--- a/src/ctap/response.rs
+++ b/src/ctap/response.rs
@@ -204,6 +204,7 @@ impl From<AuthenticatorClientPinResponse> for cbor::Value {
     }
 }
 
+#[derive(Default)]
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug))]
 pub struct AuthenticatorCredentialManagementResponse {
@@ -435,19 +436,7 @@ mod test {
 
     #[test]
     fn test_used_credential_management_into_cbor() {
-        let cred_management_response = AuthenticatorCredentialManagementResponse {
-            existing_resident_credentials_count: None,
-            max_possible_remaining_resident_credentials_count: None,
-            rp: None,
-            rp_id_hash: None,
-            total_rps: None,
-            user: None,
-            credential_id: None,
-            public_key: None,
-            total_credentials: None,
-            cred_protect: None,
-            large_blob_key: None,
-        };
+        let cred_management_response = AuthenticatorCredentialManagementResponse::default();
         let response_cbor: Option<cbor::Value> =
             ResponseData::AuthenticatorCredentialManagement(Some(cred_management_response)).into();
         let expected_cbor = cbor_map_options! {};

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -238,7 +238,7 @@ impl PersistentStore {
     /// # Errors
     ///
     /// Returns `CTAP2_ERR_NO_CREDENTIALS` if the credential is not found.
-    pub fn _delete_credential(&mut self, credential_id: &[u8]) -> Result<(), Ctap2StatusCode> {
+    pub fn delete_credential(&mut self, credential_id: &[u8]) -> Result<(), Ctap2StatusCode> {
         let (key, _) = self.find_credential_item(credential_id)?;
         Ok(self.store.remove(key)?)
     }
@@ -248,7 +248,7 @@ impl PersistentStore {
     /// # Errors
     ///
     /// Returns `CTAP2_ERR_NO_CREDENTIALS` if the credential is not found.
-    pub fn _update_credential(
+    pub fn update_credential(
         &mut self,
         credential_id: &[u8],
         user: PublicKeyCredentialUserEntity,
@@ -692,7 +692,7 @@ mod test {
         }
         let mut count = persistent_store.count_credentials().unwrap();
         for credential_id in credential_ids {
-            assert!(persistent_store._delete_credential(&credential_id).is_ok());
+            assert!(persistent_store.delete_credential(&credential_id).is_ok());
             count -= 1;
             assert_eq!(persistent_store.count_credentials().unwrap(), count);
         }
@@ -710,7 +710,7 @@ mod test {
             user_icon: Some("icon".to_string()),
         };
         assert_eq!(
-            persistent_store._update_credential(&[0x1D], user.clone()),
+            persistent_store.update_credential(&[0x1D], user.clone()),
             Err(Ctap2StatusCode::CTAP2_ERR_NO_CREDENTIALS)
         );
 
@@ -725,7 +725,7 @@ mod test {
         assert_eq!(stored_credential.user_display_name, None);
         assert_eq!(stored_credential.user_icon, None);
         assert!(persistent_store
-            ._update_credential(&credential_id, user.clone())
+            .update_credential(&credential_id, user.clone())
             .is_ok());
         let stored_credential = persistent_store
             .find_credential("example.com", &credential_id, false)


### PR DESCRIPTION
Together with #253 and #254, this PR implements the credential management command. Its logic is equivalent to #107, with the difference of only storing keys for credentials as state between calls to `EnumerateCredentialsGetNextCredential`.

- [x] Tests pass