### PR TITLE
Add Feitian USB Dongle

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -17,6 +17,7 @@ You will need one the following supported boards:
 *   [Nordic nRF52840 Dongle](https://www.nordicsemi.com/Software-and-tools/Development-Kits/nRF52840-Dongle)
     to have a more practical form factor.
 *   [Makerdiary nRF52840-MDK USB dongle](https://wiki.makerdiary.com/nrf52840-mdk/).
+*   [Feitian OpenSK dongle](https://feitiantech.github.io/OpenSK_USB/).
 
 In the case of the Nordic USB dongle, you may also need the following extra
 hardware:


### PR DESCRIPTION
Feitian created an hardware dongle according to nRF52840 design, please refer to https://feitiantech.github.io/OpenSK_USB/hardware/ .
There is no need to change anything to Google OpenSK source code, download the OpenSK firmware to Feitian Dongle, and it can work.