### PR TITLE
Resident naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,7 @@ a few things you can personalize:
     check [WebAuthn](https://www.w3.org/TR/webauthn/#signature-counter) for
     documentation.
 1.  Depending on your available flash storage, choose an appropriate maximum
-    number of supported residential keys and number of pages in
-    `ctap/storage.rs`.
+    number of supported resident keys and number of pages in `ctap/storage.rs`.
 1.  Change the default level for the credProtect extension in `ctap/mod.rs`.
     When changing the default, resident credentials become undiscoverable without
     user verification. This helps privacy, but can make usage less comfortable

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -1195,7 +1195,7 @@ mod test {
     }
 
     #[test]
-    fn test_residential_process_make_credential() {
+    fn test_resident_process_make_credential() {
         let mut rng = ThreadRng256 {};
         let user_immediately_present = |_| Ok(());
         let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
@@ -1214,7 +1214,7 @@ mod test {
     }
 
     #[test]
-    fn test_non_residential_process_make_credential() {
+    fn test_non_resident_process_make_credential() {
         let mut rng = ThreadRng256 {};
         let user_immediately_present = |_| Ok(());
         let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
@@ -1526,7 +1526,7 @@ mod test {
     }
 
     #[test]
-    fn test_residential_process_get_assertion() {
+    fn test_resident_process_get_assertion() {
         let mut rng = ThreadRng256 {};
         let user_immediately_present = |_| Ok(());
         let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
@@ -1629,7 +1629,7 @@ mod test {
     }
 
     #[test]
-    fn test_residential_process_get_assertion_hmac_secret() {
+    fn test_resident_process_get_assertion_hmac_secret() {
         let mut rng = ThreadRng256 {};
         let sk = crypto::ecdh::SecKey::gensk(&mut rng);
         let user_immediately_present = |_| Ok(());
@@ -1681,7 +1681,7 @@ mod test {
     }
 
     #[test]
-    fn test_residential_process_get_assertion_with_cred_protect() {
+    fn test_resident_process_get_assertion_with_cred_protect() {
         let mut rng = ThreadRng256 {};
         let private_key = crypto::ecdsa::SecKey::gensk(&mut rng);
         let credential_id = rng.gen_uniform_u8x32().to_vec();

--- a/src/ctap/storage/key.rs
+++ b/src/ctap/storage/key.rs
@@ -84,8 +84,8 @@ make_partition! {
 
     /// The credentials.
     ///
-    /// Depending on `MAX_SUPPORTED_RESIDENTIAL_KEYS`, only a prefix of those keys is used. Each
-    /// board may configure `MAX_SUPPORTED_RESIDENTIAL_KEYS` depending on the storage size.
+    /// Depending on `MAX_SUPPORTED_RESIDENT_KEYS`, only a prefix of those keys is used. Each
+    /// board may configure `MAX_SUPPORTED_RESIDENT_KEYS` depending on the storage size.
     CREDENTIALS = 1700..2000;
 
     /// The secret of the CredRandom feature.
@@ -127,8 +127,8 @@ mod test {
 
     #[test]
     fn enough_credentials() {
-        use super::super::MAX_SUPPORTED_RESIDENTIAL_KEYS;
-        assert!(MAX_SUPPORTED_RESIDENTIAL_KEYS <= CREDENTIALS.end - CREDENTIALS.start);
+        use super::super::MAX_SUPPORTED_RESIDENT_KEYS;
+        assert!(MAX_SUPPORTED_RESIDENT_KEYS <= CREDENTIALS.end - CREDENTIALS.start);
     }
 
     #[test]


### PR DESCRIPTION
tl;dr s/residential/resident/

This PR renames to "resident key", and does not change any functionality. The word "residential" is not used anymore, and is not used in the specification.