### PR TITLE
Make StoreUpdate generic over the byte slice ownership

### DIFF
--- a/libraries/persistent_store/fuzz/src/store.rs
+++ b/libraries/persistent_store/fuzz/src/store.rs
@@ -303,7 +303,7 @@ impl<'a> Fuzzer<'a> {
     }
 
     /// Generates a possibly invalid update.
-    fn update(&mut self) -> StoreUpdate {
+    fn update(&mut self) -> StoreUpdate<Vec<u8>> {
         match self.entropy.read_range(0, 1) {
             0 => {
                 let key = self.key();

--- a/libraries/persistent_store/src/model.rs
+++ b/libraries/persistent_store/src/model.rs
@@ -34,7 +34,7 @@ pub enum StoreOperation {
     /// Applies a transaction.
     Transaction {
         /// The list of updates to be applied.
-        updates: Vec<StoreUpdate>,
+        updates: Vec<StoreUpdate<Vec<u8>>>,
     },
 
     /// Deletes all keys above a threshold.
@@ -89,7 +89,7 @@ impl StoreModel {
     }
 
     /// Applies a transaction.
-    fn transaction(&mut self, updates: Vec<StoreUpdate>) -> StoreResult<()> {
+    fn transaction(&mut self, updates: Vec<StoreUpdate<Vec<u8>>>) -> StoreResult<()> {
         // Fail if the transaction is invalid.
         if self.format.transaction_valid(&updates).is_none() {
             return Err(StoreError::InvalidArgument);


### PR DESCRIPTION
This permits to call it without having to create a Vec<u8> when possible.
