### PR TITLE
largeBlobKey extension

### DIFF
--- a/src/ctap/credential_management.rs
+++ b/src/ctap/credential_management.rs
@@ -81,6 +81,7 @@ fn enumerate_credentials_response(
         user_name,
         user_icon,
         cred_blob: _,
+        large_blob_key,
     } = credential;
     let user = PublicKeyCredentialUserEntity {
         user_id: user_handle,
@@ -100,8 +101,7 @@ fn enumerate_credentials_response(
         public_key: Some(public_key),
         total_credentials,
         cred_protect: cred_protect_policy,
-        // TODO(kaczmarczyck) add when largeBlobKey extension is implemented
-        large_blob_key: None,
+        large_blob_key,
         ..Default::default()
     })
 }
@@ -348,6 +348,7 @@ mod test {
             user_name: Some("name".to_string()),
             user_icon: Some("icon".to_string()),
             cred_blob: None,
+            large_blob_key: None,
         }
     }
 

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -756,6 +756,7 @@ mod test {
             user_name: None,
             user_icon: None,
             cred_blob: None,
+            large_blob_key: None,
         }
     }
 
@@ -973,6 +974,7 @@ mod test {
             user_name: None,
             user_icon: None,
             cred_blob: None,
+            large_blob_key: None,
         };
         assert_eq!(found_credential, Some(expected_credential));
     }
@@ -995,6 +997,7 @@ mod test {
             user_name: None,
             user_icon: None,
             cred_blob: None,
+            large_blob_key: None,
         };
         assert!(persistent_store.store_credential(credential).is_ok());
 
@@ -1321,6 +1324,7 @@ mod test {
             user_name: None,
             user_icon: None,
             cred_blob: None,
+            large_blob_key: None,
         };
         let serialized = serialize_credential(credential.clone()).unwrap();
         let reconstructed = deserialize_credential(&serialized).unwrap();


### PR DESCRIPTION
Implements the last extension missing for CTAP 2.1. Also cleans up the `GetInfo` output for all options.

One design choice made here is how we want to store the per-credential `largeBlobKey`. The specification mandates:

- only discoverable (aka resident) credentials need a `largeBlobKey`
- only return a `largeBlobKey` when created during `MakeCredential`

Therefore, we have to store per-credential information. I decided to go with the 32 byte array itself, as the cryptographically most straight-forward implementation.
We could sometimes save some memory by only storing a bool indicating existence, and later derive the `largeBlobKey` using a master secret similar to `credRandom`. This approach only pays off with the second created credentials that uses `largeBlobKey`, because of the cost for master secrets. For users (including those never using `largeBlobKey` at all), I expect this to be more expensive on average.

- [x] Tests pass
