### PR TITLE
Remove derive_debug feature

### DIFF
--- a/.github/workflows/crypto_test.yml
+++ b/.github/workflows/crypto_test.yml
@@ -33,10 +33,10 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path libraries/crypto/Cargo.toml --release --features std,derive_debug
+          args: --manifest-path libraries/crypto/Cargo.toml --release --features std
 
       - name: Unit testing of crypto library (debug mode)
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path libraries/crypto/Cargo.toml --features std,derive_debug
+          args: --manifest-path libraries/crypto/Cargo.toml --features std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ subtle = { version = "2.2", default-features = false, features = ["nightly"] }
 
 [features]
 debug_allocations = ["lang_items/debug_allocations"]
-debug_ctap = ["crypto/derive_debug", "libtock_drivers/debug_ctap"]
+debug_ctap = ["libtock_drivers/debug_ctap"]
 panic_console = ["lang_items/panic_console"]
-std = ["cbor/std", "crypto/std", "crypto/derive_debug", "lang_items/std", "persistent_store/std"]
+std = ["cbor/std", "crypto/std", "lang_items/std", "persistent_store/std"]
 verbose = ["debug_ctap", "libtock_drivers/verbose_usb"]
 with_ctap1 = ["crypto/with_ctap1"]
 with_nfc = ["libtock_drivers/with_nfc"]

--- a/libraries/crypto/Cargo.toml
+++ b/libraries/crypto/Cargo.toml
@@ -25,5 +25,4 @@ regex = { version = "1", optional = true }
 
 [features]
 std = ["cbor/std", "hex", "rand", "ring", "untrusted", "serde", "serde_json", "regex"]
-derive_debug = []
 with_ctap1 = []

--- a/libraries/crypto/src/ec/exponent256.rs
+++ b/libraries/crypto/src/ec/exponent256.rs
@@ -18,11 +18,10 @@ use core::ops::Mul;
 use subtle::{self, Choice, ConditionallySelectable, CtOption};
 
 // An exponent on the elliptic curve, that is an element modulo the curve order N.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 // TODO: remove this Default once https://github.com/dalek-cryptography/subtle/issues/63 is
 // resolved.
 #[derive(Default)]
-#[cfg_attr(feature = "derive_debug", derive(Debug))]
 pub struct ExponentP256 {
     int: Int256,
 }
@@ -92,11 +91,10 @@ impl Mul for &ExponentP256 {
 }
 
 // A non-zero exponent on the elliptic curve.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 // TODO: remove this Default once https://github.com/dalek-cryptography/subtle/issues/63 is
 // resolved.
 #[derive(Default)]
-#[cfg_attr(feature = "derive_debug", derive(Debug))]
 pub struct NonZeroExponentP256 {
     e: ExponentP256,
 }

--- a/libraries/crypto/src/ec/gfp256.rs
+++ b/libraries/crypto/src/ec/gfp256.rs
@@ -111,7 +111,6 @@ impl Mul for &GFP256 {
     }
 }
 
-#[cfg(feature = "derive_debug")]
 impl core::fmt::Debug for GFP256 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(f, "GFP256::{:?}", self.int)

--- a/libraries/crypto/src/ec/int256.rs
+++ b/libraries/crypto/src/ec/int256.rs
@@ -636,7 +636,6 @@ impl SubAssign<&Int256> for Int256 {
     }
 }
 
-#[cfg(feature = "derive_debug")]
 impl core::fmt::Debug for Int256 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(f, "Int256 {{ digits: {:08x?} }}", self.digits)

--- a/libraries/crypto/src/ec/point.rs
+++ b/libraries/crypto/src/ec/point.rs
@@ -542,7 +542,6 @@ impl Add for &PointProjective {
     }
 }
 
-#[cfg(feature = "derive_debug")]
 impl core::fmt::Debug for PointP256 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("PointP256")
@@ -552,7 +551,6 @@ impl core::fmt::Debug for PointP256 {
     }
 }
 
-#[cfg(feature = "derive_debug")]
 impl PartialEq for PointP256 {
     fn eq(&self, other: &PointP256) -> bool {
         self.x == other.x && self.y == other.y

--- a/libraries/crypto/src/ecdh.rs
+++ b/libraries/crypto/src/ecdh.rs
@@ -26,7 +26,7 @@ pub struct SecKey {
     a: NonZeroExponentP256,
 }
 
-#[cfg_attr(feature = "derive_debug", derive(Clone, PartialEq, Debug))]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PubKey {
     p: PointP256,
 }

--- a/libraries/crypto/src/ecdsa.rs
+++ b/libraries/crypto/src/ecdsa.rs
@@ -30,8 +30,7 @@ use core::marker::PhantomData;
 
 pub const NBYTES: usize = int256::NBYTES;
 
-#[derive(Clone, PartialEq)]
-#[cfg_attr(feature = "derive_debug", derive(Debug))]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SecKey {
     k: NonZeroExponentP256,
 }
@@ -41,7 +40,7 @@ pub struct Signature {
     s: NonZeroExponentP256,
 }
 
-#[cfg_attr(feature = "derive_debug", derive(Clone))]
+#[derive(Clone)]
 pub struct PubKey {
     p: PointP256,
 }

--- a/run_desktop_tests.sh
+++ b/run_desktop_tests.sh
@@ -91,7 +91,7 @@ then
   cargo test --release --features std
   cd ../..
   cd libraries/crypto
-  RUSTFLAGS='-C target-feature=+aes' cargo test --release --features std,derive_debug
+  RUSTFLAGS='-C target-feature=+aes' cargo test --release --features std
   cd ../..
   cd libraries/persistent_store
   cargo test --release --features std
@@ -103,7 +103,7 @@ then
   cargo test --features std
   cd ../..
   cd libraries/crypto
-  RUSTFLAGS='-C target-feature=+aes' cargo test --features std,derive_debug
+  RUSTFLAGS='-C target-feature=+aes' cargo test --features std
   cd ../..
   cd libraries/persistent_store
   cargo test --features std

--- a/src/ctap/apdu.rs
+++ b/src/ctap/apdu.rs
@@ -18,9 +18,8 @@ use core::convert::TryFrom;
 
 const APDU_HEADER_LEN: usize = 4;
 
-#[cfg_attr(test, derive(Clone, Debug))]
+#[derive(Clone, Debug, PartialEq)]
 #[allow(non_camel_case_types, dead_code)]
-#[derive(PartialEq)]
 pub enum ApduStatusCode {
     SW_SUCCESS = 0x90_00,
     /// Command successfully executed; 'XX' bytes of data are
@@ -51,9 +50,8 @@ pub enum ApduInstructions {
     GetResponse = 0xC0,
 }
 
-#[cfg_attr(test, derive(Clone, Debug))]
+#[derive(Clone, Debug, Default, PartialEq)]
 #[allow(dead_code)]
-#[derive(Default, PartialEq)]
 pub struct ApduHeader {
     pub cla: u8,
     pub ins: u8,
@@ -72,8 +70,7 @@ impl From<&[u8; APDU_HEADER_LEN]> for ApduHeader {
     }
 }
 
-#[cfg_attr(test, derive(Clone, Debug))]
-#[derive(PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 /// The APDU cases
 pub enum Case {
     Le1,
@@ -85,18 +82,16 @@ pub enum Case {
     Le3,
 }
 
-#[cfg_attr(test, derive(Clone, Debug))]
+#[derive(Clone, Debug, PartialEq)]
 #[allow(dead_code)]
-#[derive(PartialEq)]
 pub enum ApduType {
     Instruction,
     Short(Case),
     Extended(Case),
 }
 
-#[cfg_attr(test, derive(Clone, Debug))]
+#[derive(Clone, Debug, PartialEq)]
 #[allow(dead_code)]
-#[derive(PartialEq)]
 pub struct APDU {
     pub header: ApduHeader,
     pub lc: u16,

--- a/src/ctap/command.rs
+++ b/src/ctap/command.rs
@@ -38,7 +38,7 @@ pub const MAX_CREDENTIAL_COUNT_IN_LIST: Option<usize> = None;
 const MIN_LARGE_BLOB_LEN: usize = 17;
 
 // CTAP specification (version 20190130) section 6.1
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Debug, PartialEq)]
 pub enum Command {
     AuthenticatorMakeCredential(AuthenticatorMakeCredentialParameters),
     AuthenticatorGetAssertion(AuthenticatorGetAssertionParameters),
@@ -148,7 +148,7 @@ impl Command {
     }
 }
 
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Debug, PartialEq)]
 pub struct AuthenticatorMakeCredentialParameters {
     pub client_data_hash: Vec<u8>,
     pub rp: PublicKeyCredentialRpEntity,
@@ -236,7 +236,7 @@ impl TryFrom<cbor::Value> for AuthenticatorMakeCredentialParameters {
     }
 }
 
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Debug, PartialEq)]
 pub struct AuthenticatorGetAssertionParameters {
     pub rp_id: String,
     pub client_data_hash: Vec<u8>,
@@ -307,7 +307,7 @@ impl TryFrom<cbor::Value> for AuthenticatorGetAssertionParameters {
     }
 }
 
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Debug, PartialEq)]
 pub struct AuthenticatorClientPinParameters {
     pub pin_protocol: u64,
     pub sub_command: ClientPinSubCommand,
@@ -363,7 +363,7 @@ impl TryFrom<cbor::Value> for AuthenticatorClientPinParameters {
     }
 }
 
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Debug, PartialEq)]
 pub struct AuthenticatorLargeBlobsParameters {
     pub get: Option<usize>,
     pub set: Option<Vec<u8>>,
@@ -438,7 +438,7 @@ impl TryFrom<cbor::Value> for AuthenticatorLargeBlobsParameters {
     }
 }
 
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Debug, PartialEq)]
 pub struct AuthenticatorConfigParameters {
     pub sub_command: ConfigSubCommand,
     pub sub_command_params: Option<ConfigSubCommandParams>,
@@ -478,7 +478,7 @@ impl TryFrom<cbor::Value> for AuthenticatorConfigParameters {
     }
 }
 
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Debug, PartialEq)]
 pub struct AuthenticatorAttestationMaterial {
     pub certificate: Vec<u8>,
     pub private_key: [u8; key_material::ATTESTATION_PRIVATE_KEY_LENGTH],
@@ -507,7 +507,7 @@ impl TryFrom<cbor::Value> for AuthenticatorAttestationMaterial {
     }
 }
 
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Debug, PartialEq)]
 pub struct AuthenticatorCredentialManagementParameters {
     pub sub_command: CredentialManagementSubCommand,
     pub sub_command_params: Option<CredentialManagementSubCommandParameters>,
@@ -544,7 +544,7 @@ impl TryFrom<cbor::Value> for AuthenticatorCredentialManagementParameters {
     }
 }
 
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Debug, PartialEq)]
 pub struct AuthenticatorVendorConfigureParameters {
     pub lockdown: bool,
     pub attestation_material: Option<AuthenticatorAttestationMaterial>,

--- a/src/ctap/ctap1.rs
+++ b/src/ctap/ctap1.rs
@@ -29,8 +29,7 @@ pub type Ctap1StatusCode = ApduStatusCode;
 // The specification referenced in this file is at:
 // https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-raw-message-formats-v1.2-ps-20170411.pdf
 
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Clone, Debug))]
-#[derive(PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Ctap1Flags {
     CheckOnly = 0x07,
     EnforceUpAndSign = 0x03,
@@ -56,7 +55,7 @@ impl Into<u8> for Ctap1Flags {
     }
 }
 
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Debug, PartialEq)]
 // TODO: remove #allow when https://github.com/rust-lang/rust/issues/64362 is fixed
 enum U2fCommand {
     #[allow(dead_code)]

--- a/src/ctap/data_formats.rs
+++ b/src/ctap/data_formats.rs
@@ -27,8 +27,7 @@ use enum_iterator::IntoEnumIterator;
 const ES256_ALGORITHM: i64 = -7;
 
 // https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialrpentity
-#[derive(Clone)]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PublicKeyCredentialRpEntity {
     pub rp_id: String,
     pub rp_name: Option<String>,
@@ -70,8 +69,7 @@ impl From<PublicKeyCredentialRpEntity> for cbor::Value {
 }
 
 // https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialuserentity
-#[derive(Clone)]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PublicKeyCredentialUserEntity {
     pub user_id: Vec<u8>,
     pub user_name: Option<String>,
@@ -118,8 +116,7 @@ impl From<PublicKeyCredentialUserEntity> for cbor::Value {
 }
 
 // https://www.w3.org/TR/webauthn/#enumdef-publickeycredentialtype
-#[derive(Clone, PartialEq)]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug))]
+#[derive(Clone, Debug, PartialEq)]
 pub enum PublicKeyCredentialType {
     PublicKey,
     // This is the default for all strings not covered above.
@@ -151,8 +148,7 @@ impl TryFrom<cbor::Value> for PublicKeyCredentialType {
 }
 
 // https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialparameters
-#[derive(PartialEq)]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug))]
+#[derive(Debug, PartialEq)]
 pub struct PublicKeyCredentialParameter {
     pub cred_type: PublicKeyCredentialType,
     pub alg: SignatureAlgorithm,
@@ -185,8 +181,7 @@ impl From<PublicKeyCredentialParameter> for cbor::Value {
 }
 
 // https://www.w3.org/TR/webauthn/#enumdef-authenticatortransport
-#[derive(Clone)]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(test, derive(IntoEnumIterator))]
 pub enum AuthenticatorTransport {
     Usb,
@@ -223,8 +218,7 @@ impl TryFrom<cbor::Value> for AuthenticatorTransport {
 }
 
 // https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialdescriptor
-#[derive(Clone)]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PublicKeyCredentialDescriptor {
     pub key_type: PublicKeyCredentialType,
     pub key_id: Vec<u8>,
@@ -275,8 +269,7 @@ impl From<PublicKeyCredentialDescriptor> for cbor::Value {
     }
 }
 
-#[derive(Default)]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Clone, Debug, PartialEq))]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct MakeCredentialExtensions {
     pub hmac_secret: bool,
     pub cred_protect: Option<CredentialProtectionPolicy>,
@@ -321,8 +314,7 @@ impl TryFrom<cbor::Value> for MakeCredentialExtensions {
     }
 }
 
-#[derive(Clone, Default)]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct GetAssertionExtensions {
     pub hmac_secret: Option<GetAssertionHmacSecretInput>,
     pub cred_blob: bool,
@@ -359,8 +351,7 @@ impl TryFrom<cbor::Value> for GetAssertionExtensions {
     }
 }
 
-#[derive(Clone)]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Clone, Debug, PartialEq)]
 pub struct GetAssertionHmacSecretInput {
     pub key_agreement: CoseKey,
     pub salt_enc: Vec<u8>,
@@ -391,8 +382,7 @@ impl TryFrom<cbor::Value> for GetAssertionHmacSecretInput {
 }
 
 // Even though options are optional, we can use the default if not present.
-#[derive(Default)]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Debug, Default, PartialEq)]
 pub struct MakeCredentialOptions {
     pub rk: bool,
     pub uv: bool,
@@ -425,7 +415,7 @@ impl TryFrom<cbor::Value> for MakeCredentialOptions {
     }
 }
 
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Debug, PartialEq)]
 pub struct GetAssertionOptions {
     pub up: bool,
     pub uv: bool,
@@ -470,8 +460,7 @@ impl TryFrom<cbor::Value> for GetAssertionOptions {
 }
 
 // https://www.w3.org/TR/webauthn/#packed-attestation
-#[cfg_attr(test, derive(PartialEq))]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug))]
+#[derive(Debug, PartialEq)]
 pub struct PackedAttestationStatement {
     pub alg: i64,
     pub sig: Vec<u8>,
@@ -490,8 +479,7 @@ impl From<PackedAttestationStatement> for cbor::Value {
     }
 }
 
-#[derive(PartialEq)]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug))]
+#[derive(Debug, PartialEq)]
 pub enum SignatureAlgorithm {
     ES256 = ES256_ALGORITHM as isize,
     // This is the default for all numbers not covered above.
@@ -516,8 +504,7 @@ impl TryFrom<cbor::Value> for SignatureAlgorithm {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, PartialOrd)]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug))]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
 #[cfg_attr(test, derive(IntoEnumIterator))]
 pub enum CredentialProtectionPolicy {
     UserVerificationOptional = 0x01,
@@ -548,9 +535,7 @@ impl TryFrom<cbor::Value> for CredentialProtectionPolicy {
 //
 // Note that we only use the WebAuthn definition as an example. This data-structure is not specified
 // by FIDO. In particular we may choose how we serialize and deserialize it.
-#[derive(Clone)]
-#[cfg_attr(test, derive(PartialEq))]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug))]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PublicKeyCredentialSource {
     // TODO function to convert to / from Vec<u8>
     pub key_type: PublicKeyCredentialType,
@@ -688,8 +673,7 @@ impl PublicKeyCredentialSource {
 }
 
 // The COSE key is used for both ECDH and ECDSA public keys for transmission.
-#[derive(Clone)]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Clone, Debug, PartialEq)]
 pub struct CoseKey {
     x_bytes: [u8; ecdh::NBYTES],
     y_bytes: [u8; ecdh::NBYTES],
@@ -818,7 +802,7 @@ impl TryFrom<CoseKey> for ecdh::PubKey {
     }
 }
 
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Clone, Debug, PartialEq))]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(test, derive(IntoEnumIterator))]
 pub enum ClientPinSubCommand {
     GetPinRetries = 0x01,
@@ -856,8 +840,7 @@ impl TryFrom<cbor::Value> for ClientPinSubCommand {
     }
 }
 
-#[derive(Clone, Copy)]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(test, derive(IntoEnumIterator))]
 pub enum ConfigSubCommand {
     EnableEnterpriseAttestation = 0x01,
@@ -887,8 +870,7 @@ impl TryFrom<cbor::Value> for ConfigSubCommand {
     }
 }
 
-#[derive(Clone)]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ConfigSubCommandParams {
     SetMinPinLength(SetMinPinLengthParams),
 }
@@ -903,8 +885,7 @@ impl From<ConfigSubCommandParams> for cbor::Value {
     }
 }
 
-#[derive(Clone)]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SetMinPinLengthParams {
     pub new_min_pin_length: Option<u8>,
     pub min_pin_length_rp_ids: Option<Vec<String>>,
@@ -958,8 +939,7 @@ impl From<SetMinPinLengthParams> for cbor::Value {
     }
 }
 
-#[derive(Clone, Copy)]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(test, derive(IntoEnumIterator))]
 pub enum CredentialManagementSubCommand {
     GetCredsMetadata = 0x01,
@@ -995,8 +975,7 @@ impl TryFrom<cbor::Value> for CredentialManagementSubCommand {
     }
 }
 
-#[derive(Clone)]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug, PartialEq))]
+#[derive(Clone, Debug, PartialEq)]
 pub struct CredentialManagementSubCommandParameters {
     pub rp_id_hash: Option<Vec<u8>>,
     pub credential_id: Option<PublicKeyCredentialDescriptor>,

--- a/src/ctap/response.rs
+++ b/src/ctap/response.rs
@@ -22,8 +22,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use cbor::{cbor_array_vec, cbor_bool, cbor_map_btree, cbor_map_options, cbor_text};
 
-#[cfg_attr(test, derive(PartialEq))]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug))]
+#[derive(Debug, PartialEq)]
 pub enum ResponseData {
     AuthenticatorMakeCredential(AuthenticatorMakeCredentialResponse),
     AuthenticatorGetAssertion(AuthenticatorGetAssertionResponse),
@@ -57,8 +56,7 @@ impl From<ResponseData> for Option<cbor::Value> {
     }
 }
 
-#[cfg_attr(test, derive(PartialEq))]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug))]
+#[derive(Debug, PartialEq)]
 pub struct AuthenticatorMakeCredentialResponse {
     pub fmt: String,
     pub auth_data: Vec<u8>,
@@ -84,8 +82,7 @@ impl From<AuthenticatorMakeCredentialResponse> for cbor::Value {
     }
 }
 
-#[cfg_attr(test, derive(PartialEq))]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug))]
+#[derive(Debug, PartialEq)]
 pub struct AuthenticatorGetAssertionResponse {
     pub credential: Option<PublicKeyCredentialDescriptor>,
     pub auth_data: Vec<u8>,
@@ -117,8 +114,7 @@ impl From<AuthenticatorGetAssertionResponse> for cbor::Value {
     }
 }
 
-#[cfg_attr(test, derive(PartialEq))]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug))]
+#[derive(Debug, PartialEq)]
 pub struct AuthenticatorGetInfoResponse {
     pub versions: Vec<String>,
     pub extensions: Option<Vec<String>>,
@@ -191,8 +187,7 @@ impl From<AuthenticatorGetInfoResponse> for cbor::Value {
     }
 }
 
-#[cfg_attr(test, derive(PartialEq))]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug))]
+#[derive(Debug, PartialEq)]
 pub struct AuthenticatorClientPinResponse {
     pub key_agreement: Option<CoseKey>,
     pub pin_token: Option<Vec<u8>>,
@@ -215,8 +210,7 @@ impl From<AuthenticatorClientPinResponse> for cbor::Value {
     }
 }
 
-#[cfg_attr(test, derive(PartialEq))]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug))]
+#[derive(Debug, PartialEq)]
 pub struct AuthenticatorLargeBlobsResponse {
     pub config: Vec<u8>,
 }
@@ -231,9 +225,7 @@ impl From<AuthenticatorLargeBlobsResponse> for cbor::Value {
     }
 }
 
-#[derive(Default)]
-#[cfg_attr(test, derive(PartialEq))]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug))]
+#[derive(Debug, Default, PartialEq)]
 pub struct AuthenticatorCredentialManagementResponse {
     pub existing_resident_credentials_count: Option<u64>,
     pub max_possible_remaining_resident_credentials_count: Option<u64>,
@@ -280,8 +272,7 @@ impl From<AuthenticatorCredentialManagementResponse> for cbor::Value {
     }
 }
 
-#[cfg_attr(test, derive(PartialEq))]
-#[cfg_attr(any(test, feature = "debug_ctap"), derive(Debug))]
+#[derive(Debug, PartialEq)]
 pub struct AuthenticatorVendorResponse {
     pub cert_programmed: bool,
     pub pkey_programmed: bool,


### PR DESCRIPTION
Fixes (with some side effects we'll discuss on the issue) #251

Removes most conditional trait imports. `IntoEnumIterator` is an exception as it is only in `dev-dependencies`. Binary sizes seem to be unaffected, after checking with our workflows:

```
./reproduce_hashes.sh
git diff --no-index reproducible/reference_elf2tab_ubuntu-18.04.txt reproducible/elf2tab.txt || true
```

- [x] Tests pass