### PR TITLE
Allow RP ID in token permissions for some subcommands of credential management

### DIFF
--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -638,7 +638,7 @@ where
                 }
                 self.pin_protocol_v1
                     .has_permission(PinPermission::MakeCredential)?;
-                self.pin_protocol_v1.require_rp_id_permission(&rp_id)?;
+                self.pin_protocol_v1.ensure_rp_id_permission(&rp_id)?;
                 UP_FLAG | UV_FLAG | AT_FLAG | ed_flag
             }
             None => {
@@ -923,7 +923,7 @@ where
                 }
                 self.pin_protocol_v1
                     .has_permission(PinPermission::GetAssertion)?;
-                self.pin_protocol_v1.require_rp_id_permission(&rp_id)?;
+                self.pin_protocol_v1.ensure_rp_id_permission(&rp_id)?;
                 UV_FLAG
             }
             None => {

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -638,7 +638,7 @@ where
                 }
                 self.pin_protocol_v1
                     .has_permission(PinPermission::MakeCredential)?;
-                self.pin_protocol_v1.has_permission_for_rp_id(&rp_id)?;
+                self.pin_protocol_v1.require_rp_id_permission(&rp_id)?;
                 UP_FLAG | UV_FLAG | AT_FLAG | ed_flag
             }
             None => {
@@ -923,7 +923,7 @@ where
                 }
                 self.pin_protocol_v1
                     .has_permission(PinPermission::GetAssertion)?;
-                self.pin_protocol_v1.has_permission_for_rp_id(&rp_id)?;
+                self.pin_protocol_v1.require_rp_id_permission(&rp_id)?;
                 UV_FLAG
             }
             None => {

--- a/src/ctap/pin_protocol_v1.rs
+++ b/src/ctap/pin_protocol_v1.rs
@@ -543,7 +543,7 @@ impl PinProtocolV1 {
     /// Check if the passed RP ID is associated with the token permission.
     ///
     /// If no RP ID is associated, associate the passed RP ID as a side effect.
-    pub fn require_rp_id_permission(&mut self, rp_id: &str) -> Result<(), Ctap2StatusCode> {
+    pub fn ensure_rp_id_permission(&mut self, rp_id: &str) -> Result<(), Ctap2StatusCode> {
         match &self.permissions_rp_id {
             Some(p) if rp_id != p => Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID),
             None => {
@@ -1230,11 +1230,11 @@ mod test {
     }
 
     #[test]
-    fn test_require_rp_id_permission() {
+    fn test_ensure_rp_id_permission() {
         let mut rng = ThreadRng256 {};
         let mut pin_protocol_v1 = PinProtocolV1::new(&mut rng);
         assert_eq!(
-            pin_protocol_v1.require_rp_id_permission("example.com"),
+            pin_protocol_v1.ensure_rp_id_permission("example.com"),
             Ok(())
         );
         assert_eq!(
@@ -1242,11 +1242,11 @@ mod test {
             Some(String::from("example.com"))
         );
         assert_eq!(
-            pin_protocol_v1.require_rp_id_permission("example.com"),
+            pin_protocol_v1.ensure_rp_id_permission("example.com"),
             Ok(())
         );
         assert_eq!(
-            pin_protocol_v1.require_rp_id_permission("counter-example.com"),
+            pin_protocol_v1.ensure_rp_id_permission("counter-example.com"),
             Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
         );
     }

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -151,7 +151,7 @@ impl PersistentStore {
     /// # Errors
     ///
     /// Returns `CTAP2_ERR_NO_CREDENTIALS` if the credential is not found.
-    fn find_credential_item(
+    pub fn find_credential_item(
         &self,
         credential_id: &[u8],
     ) -> Result<(usize, PublicKeyCredentialSource), Ctap2StatusCode> {


### PR DESCRIPTION
Related to #106 . Adds missing functionality related to RP ID permissions checking in credential management.

- [x] Tests pass