### PR TITLE
Enterprise attestation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ a few things you can personalize:
     length.
 1.  Increase the `MAX_CRED_BLOB_LENGTH` in `ctap/mod.rs`, if you expect blobs
     bigger than the default value.
+1.  Implement enterprise attestation. This can be as easy as setting
+    ENTERPRISE_ATTESTATION_MODE in `ctap/mod.rs`. If you want to use a different
+    attestation type than batch attestation, you have to implement it first.
 
 ### 3D printed enclosure
 

--- a/src/ctap/command.rs
+++ b/src/ctap/command.rs
@@ -161,7 +161,7 @@ pub struct AuthenticatorMakeCredentialParameters {
     pub options: MakeCredentialOptions,
     pub pin_uv_auth_param: Option<Vec<u8>>,
     pub pin_uv_auth_protocol: Option<u64>,
-    pub enterprise_attestation: Option<bool>,
+    pub enterprise_attestation: Option<u64>,
 }
 
 impl TryFrom<cbor::Value> for AuthenticatorMakeCredentialParameters {
@@ -219,7 +219,7 @@ impl TryFrom<cbor::Value> for AuthenticatorMakeCredentialParameters {
 
         let pin_uv_auth_param = pin_uv_auth_param.map(extract_byte_string).transpose()?;
         let pin_uv_auth_protocol = pin_uv_auth_protocol.map(extract_unsigned).transpose()?;
-        let enterprise_attestation = enterprise_attestation.map(extract_bool).transpose()?;
+        let enterprise_attestation = enterprise_attestation.map(extract_unsigned).transpose()?;
 
         Ok(AuthenticatorMakeCredentialParameters {
             client_data_hash,
@@ -601,7 +601,7 @@ mod test {
             0x05 => cbor_array![],
             0x08 => vec![0x12, 0x34],
             0x09 => 1,
-            0x0A => true,
+            0x0A => 2,
         };
         let returned_make_credential_parameters =
             AuthenticatorMakeCredentialParameters::try_from(cbor_value).unwrap();
@@ -635,7 +635,7 @@ mod test {
             options,
             pin_uv_auth_param: Some(vec![0x12, 0x34]),
             pin_uv_auth_protocol: Some(1),
-            enterprise_attestation: Some(true),
+            enterprise_attestation: Some(2),
         };
 
         assert_eq!(

--- a/src/ctap/data_formats.rs
+++ b/src/ctap/data_formats.rs
@@ -939,6 +939,24 @@ impl From<SetMinPinLengthParams> for cbor::Value {
     }
 }
 
+#[derive(Debug, PartialEq)]
+pub enum EnterpriseAttestationMode {
+    VendorFacilitated = 0x01,
+    PlatformManaged = 0x02,
+}
+
+impl TryFrom<u64> for EnterpriseAttestationMode {
+    type Error = Ctap2StatusCode;
+
+    fn try_from(value: u64) -> Result<Self, Ctap2StatusCode> {
+        match value {
+            1 => Ok(EnterpriseAttestationMode::VendorFacilitated),
+            2 => Ok(EnterpriseAttestationMode::PlatformManaged),
+            _ => Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(test, derive(IntoEnumIterator))]
 pub enum CredentialManagementSubCommand {
@@ -1793,6 +1811,22 @@ mod test {
             0x03 => true,
         };
         assert_eq!(cbor::Value::from(config_sub_command_params), cbor_params);
+    }
+
+    #[test]
+    fn test_from_enterprise_attestation_mode() {
+        assert_eq!(
+            EnterpriseAttestationMode::try_from(1),
+            Ok(EnterpriseAttestationMode::VendorFacilitated),
+        );
+        assert_eq!(
+            EnterpriseAttestationMode::try_from(2),
+            Ok(EnterpriseAttestationMode::PlatformManaged),
+        );
+        assert_eq!(
+            EnterpriseAttestationMode::try_from(3),
+            Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION),
+        );
     }
 
     #[test]

--- a/src/ctap/data_formats.rs
+++ b/src/ctap/data_formats.rs
@@ -1816,6 +1816,10 @@ mod test {
     #[test]
     fn test_from_enterprise_attestation_mode() {
         assert_eq!(
+            EnterpriseAttestationMode::try_from(0),
+            Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION),
+        );
+        assert_eq!(
             EnterpriseAttestationMode::try_from(1),
             Ok(EnterpriseAttestationMode::VendorFacilitated),
         );

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -98,7 +98,7 @@ pub const INITIAL_SIGNATURE_COUNTER: u32 = 1;
 // individual certificates then makes authenticators identifiable. Do NOT set
 // USE_BATCH_ATTESTATION to true at the same time in this case!
 pub const ENTERPRISE_ATTESTATION_MODE: Option<EnterpriseAttestationMode> = None;
-const ENTERPRISE_RP_ID_LIST: Vec<String> = Vec::new();
+const ENTERPRISE_RP_ID_LIST: &[&str] = &[];
 // Our credential ID consists of
 // - 16 byte initialization vector for AES-256,
 // - 32 byte ECDSA private key for the credential,
@@ -598,7 +598,7 @@ where
                 (
                     EnterpriseAttestationMode::PlatformManaged,
                     EnterpriseAttestationMode::PlatformManaged,
-                ) => ENTERPRISE_RP_ID_LIST.contains(&rp_id),
+                ) => ENTERPRISE_RP_ID_LIST.contains(&rp_id.as_str()),
                 _ => true,
             }
         } else {

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -2764,4 +2764,19 @@ mod test {
             ))
         );
     }
+
+    #[test]
+    #[allow(clippy::assertions_on_constants)]
+    /// Make sure that privacy guarantees are uphold.
+    ///
+    /// The current enterprise attestation implementation reuses batch
+    /// attestation. Enterprise attestation would imply a batch size of 1, but
+    /// batch attestation needs a batch size of at least 100k. To prevent
+    /// accidential misconfiguration, this test allows only one of the constants
+    /// to be set. If you implement your own enterprise attestation mechanism,
+    /// and you want batch attestation at the same time, feel free to proceed
+    /// carefully and remove this test.
+    fn check_attestation_privacy() {
+        assert!(!USE_BATCH_ATTESTATION || ENTERPRISE_ATTESTATION_MODE.is_none());
+    }
 }

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -36,10 +36,10 @@ use self::command::{
 use self::config_command::process_config;
 use self::credential_management::process_credential_management;
 use self::data_formats::{
-    AuthenticatorTransport, CoseKey, CredentialProtectionPolicy, GetAssertionExtensions,
-    PackedAttestationStatement, PublicKeyCredentialDescriptor, PublicKeyCredentialParameter,
-    PublicKeyCredentialSource, PublicKeyCredentialType, PublicKeyCredentialUserEntity,
-    SignatureAlgorithm,
+    AuthenticatorTransport, CoseKey, CredentialProtectionPolicy, EnterpriseAttestationMode,
+    GetAssertionExtensions, PackedAttestationStatement, PublicKeyCredentialDescriptor,
+    PublicKeyCredentialParameter, PublicKeyCredentialSource, PublicKeyCredentialType,
+    PublicKeyCredentialUserEntity, SignatureAlgorithm,
 };
 use self::hid::ChannelID;
 use self::large_blobs::{LargeBlobs, MAX_MSG_SIZE};
@@ -61,6 +61,7 @@ use alloc::vec::Vec;
 use arrayref::array_ref;
 use byteorder::{BigEndian, ByteOrder};
 use cbor::cbor_map_options;
+use core::convert::TryFrom;
 #[cfg(feature = "debug_ctap")]
 use core::fmt::Write;
 use crypto::cbc::{cbc_decrypt, cbc_encrypt};
@@ -86,6 +87,18 @@ const USE_BATCH_ATTESTATION: bool = false;
 // solution is a compromise to be compatible with U2F and not wasting storage.
 const USE_SIGNATURE_COUNTER: bool = true;
 pub const INITIAL_SIGNATURE_COUNTER: u32 = 1;
+// This flag allows usage of enterprise attestation. For privacy reasons, it is
+// disabled by default. You can choose between
+// - EnterpriseAttestationMode::VendorFacilitated,
+// - EnterpriseAttestationMode::PlatformManaged.
+// For VendorFacilitated, choose an appriopriate ENTERPRISE_RP_ID_LIST.
+// To enable the feature, send the subcommand enableEnterpriseAttestation in
+// AuthenticatorConfig. An enterprise might want to customize the type of
+// attestation that is used. OpenSK defaults to batch attestation. Configuring
+// individual certificates then makes authenticators identifiable. Do NOT set
+// USE_BATCH_ATTESTATION to true at the same time in this case!
+pub const ENTERPRISE_ATTESTATION_MODE: Option<EnterpriseAttestationMode> = None;
+const ENTERPRISE_RP_ID_LIST: Vec<String> = Vec::new();
 // Our credential ID consists of
 // - 16 byte initialization vector for AES-256,
 // - 32 byte ECDSA private key for the credential,
@@ -562,7 +575,7 @@ where
             options,
             pin_uv_auth_param,
             pin_uv_auth_protocol,
-            enterprise_attestation: _,
+            enterprise_attestation,
         } = make_credential_params;
 
         self.pin_uv_auth_precheck(&pin_uv_auth_param, pin_uv_auth_protocol, cid)?;
@@ -572,6 +585,26 @@ where
         }
 
         let rp_id = rp.rp_id;
+        let ep_att = if let Some(enterprise_attestation) = enterprise_attestation {
+            let authenticator_mode =
+                ENTERPRISE_ATTESTATION_MODE.ok_or(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER)?;
+            if !self.persistent_store.enterprise_attestation()? {
+                return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
+            }
+            match (
+                EnterpriseAttestationMode::try_from(enterprise_attestation)?,
+                authenticator_mode,
+            ) {
+                (
+                    EnterpriseAttestationMode::PlatformManaged,
+                    EnterpriseAttestationMode::PlatformManaged,
+                ) => ENTERPRISE_RP_ID_LIST.contains(&rp_id),
+                _ => true,
+            }
+        } else {
+            false
+        };
+
         let mut cred_protect_policy = extensions.cred_protect;
         if cred_protect_policy.unwrap_or(CredentialProtectionPolicy::UserVerificationOptional)
             < DEFAULT_CRED_PROTECT.unwrap_or(CredentialProtectionPolicy::UserVerificationOptional)
@@ -723,7 +756,7 @@ where
         let mut signature_data = auth_data.clone();
         signature_data.extend(client_data_hash);
 
-        let (signature, x5c) = if USE_BATCH_ATTESTATION {
+        let (signature, x5c) = if USE_BATCH_ATTESTATION || ep_att {
             let attestation_private_key = self
                 .persistent_store
                 .attestation_private_key()?
@@ -750,11 +783,13 @@ where
             x5c,
             ecdaa_key_id: None,
         };
+        let ep_att = if ep_att { Some(true) } else { None };
         Ok(ResponseData::AuthenticatorMakeCredential(
             AuthenticatorMakeCredentialResponse {
                 fmt: String::from("packed"),
                 auth_data,
                 att_stmt: attestation_statement,
+                ep_att,
                 large_blob_key,
             },
         ))
@@ -1026,6 +1061,12 @@ where
         options_map.insert(String::from("up"), true);
         options_map.insert(String::from("pinUvAuthToken"), true);
         options_map.insert(String::from("largeBlobs"), true);
+        if ENTERPRISE_ATTESTATION_MODE.is_some() {
+            options_map.insert(
+                String::from("ep"),
+                self.persistent_store.enterprise_attestation()?,
+            );
+        }
         options_map.insert(String::from("authnrCfg"), true);
         options_map.insert(String::from("credMgmt"), true);
         options_map.insert(String::from("setMinPINLength"), true);
@@ -1227,6 +1268,7 @@ mod test {
                     fmt,
                     auth_data,
                     att_stmt,
+                    ep_att,
                     large_blob_key,
                 } = make_credential_response;
                 // The expected response is split to only assert the non-random parts.
@@ -1247,6 +1289,7 @@ mod test {
                     &auth_data[auth_data.len() - expected_extension_cbor.len()..auth_data.len()],
                     expected_extension_cbor
                 );
+                assert!(ep_att.is_none());
                 assert_eq!(att_stmt.alg, SignatureAlgorithm::ES256 as i64);
                 assert_eq!(large_blob_key, None);
             }
@@ -1276,12 +1319,13 @@ mod test {
                     String::from("largeBlobKey"),
                 ]],
             0x03 => ctap_state.persistent_store.aaguid().unwrap(),
-            0x04 => cbor_map! {
+            0x04 => cbor_map_options! {
                 "rk" => true,
                 "clientPin" => false,
                 "up" => true,
                 "pinUvAuthToken" => true,
                 "largeBlobs" => true,
+                "ep" => ENTERPRISE_ATTESTATION_MODE.map(|_| false),
                 "authnrCfg" => true,
                 "credMgmt" => true,
                 "setMinPINLength" => true,

--- a/src/ctap/response.rs
+++ b/src/ctap/response.rs
@@ -61,6 +61,7 @@ pub struct AuthenticatorMakeCredentialResponse {
     pub fmt: String,
     pub auth_data: Vec<u8>,
     pub att_stmt: PackedAttestationStatement,
+    pub ep_att: Option<bool>,
     pub large_blob_key: Option<Vec<u8>>,
 }
 
@@ -70,6 +71,7 @@ impl From<AuthenticatorMakeCredentialResponse> for cbor::Value {
             fmt,
             auth_data,
             att_stmt,
+            ep_att,
             large_blob_key,
         } = make_credential_response;
 
@@ -77,6 +79,7 @@ impl From<AuthenticatorMakeCredentialResponse> for cbor::Value {
             0x01 => fmt,
             0x02 => auth_data,
             0x03 => att_stmt,
+            0x04 => ep_att,
             0x05 => large_blob_key,
         }
     }
@@ -320,6 +323,7 @@ mod test {
             fmt: "packed".to_string(),
             auth_data: vec![0xAD],
             att_stmt,
+            ep_att: Some(true),
             large_blob_key: Some(vec![0x1B]),
         };
         let response_cbor: Option<cbor::Value> =
@@ -328,6 +332,7 @@ mod test {
             0x01 => "packed",
             0x02 => vec![0xAD],
             0x03 => cbor_packed_attestation_statement,
+            0x04 => true,
             0x05 => vec![0x1B],
         };
         assert_eq!(response_cbor, Some(expected_cbor));

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -460,8 +460,8 @@ impl PersistentStore {
         min_pin_length_rp_ids: Vec<String>,
     ) -> Result<(), Ctap2StatusCode> {
         let mut min_pin_length_rp_ids = min_pin_length_rp_ids;
-        for rp_id in DEFAULT_MIN_PIN_LENGTH_RP_IDS.iter() {
-            let rp_id = String::from(*rp_id);
+        for &rp_id in DEFAULT_MIN_PIN_LENGTH_RP_IDS.iter() {
+            let rp_id = String::from(rp_id);
             if !min_pin_length_rp_ids.contains(&rp_id) {
                 min_pin_length_rp_ids.push(rp_id);
             }
@@ -1209,8 +1209,8 @@ mod test {
             persistent_store.set_min_pin_length_rp_ids(rp_ids.clone()),
             Ok(())
         );
-        for rp_id in DEFAULT_MIN_PIN_LENGTH_RP_IDS.iter() {
-            let rp_id = rp_id.to_string().to_string();
+        for &rp_id in DEFAULT_MIN_PIN_LENGTH_RP_IDS.iter() {
+            let rp_id = String::from(rp_id);
             if !rp_ids.contains(&rp_id) {
                 rp_ids.push(rp_id);
             }

--- a/src/ctap/storage/key.rs
+++ b/src/ctap/storage/key.rs
@@ -93,7 +93,10 @@ make_partition! {
     /// The stored large blob can be too big for one key, so it has to be sharded.
     LARGE_BLOB_SHARDS = 2000..2004;
 
-    /// If this entry exists and equals 1, the PIN needs to be changed.
+    /// If this entry exists and is empty, enterprise attestation is enabled.
+    ENTERPRISE_ATTESTATION = 2039;
+
+    /// If this entry exists and is empty, the PIN needs to be changed.
     FORCE_PIN_CHANGE = 2040;
 
     /// The secret of the CredRandom feature.


### PR DESCRIPTION
Adds enterprise attestation for #106 .

There is not just a single attestation to use for enterprise, as it is up to the enterprise to choose. This PR has useful defaults and implements all logic around the actual attestation cryptography to make it easy to extend the implementation. With the constants set as is, this PR does not actually change OpenSK's behaviour. (Except for fixing the formerly unused command parameter type in MakeCredential.)

- [x] Tests pass
- [x] Appropriate changes to README are included in PR