### PR TITLE
Add the option alwaysUv

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,8 @@ a few things you can personalize:
 1.  Increase the `MAX_CRED_BLOB_LENGTH` in `ctap/mod.rs`, if you expect blobs
     bigger than the default value.
 1.  If a certification (additional to FIDO's) requires that all requests are
-    protected with user verification, set `CAN_DISABLE_ALWAYS_UV` in
-    `ctap/config_command.rs` to `false`. In that case, consider deploying
-    authenticators after calling `toggleAlwaysUv` to activate the feature.
-    Alternatively, you could change `ctap/storage.rs` to set `alwaysUv` in its
-    initialization.
+    protected with user verification, set `ENFORCE_ALWAYS_UV` in
+    `ctap/config_mod.rs` to `true`.
 
 ### 3D printed enclosure
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ a few things you can personalize:
     length.
 1.  Increase the `MAX_CRED_BLOB_LENGTH` in `ctap/mod.rs`, if you expect blobs
     bigger than the default value.
+1.  If a certification (additional to FIDO's) requires that all requests are
+    protected with user verification, set `CAN_DISABLE_ALWAYS_UV` in
+    `ctap/config_command.rs` to `false`. In that case, consider deploying
+    authenticators after calling `toggleAlwaysUv` to activate the feature.
+    Alternatively, you could change `ctap/storage.rs` to set `alwaysUv` in its
+    initialization.
 
 ### 3D printed enclosure
 

--- a/src/ctap/apdu.rs
+++ b/src/ctap/apdu.rs
@@ -29,6 +29,7 @@ pub enum ApduStatusCode {
     SW_WRONG_DATA = 0x6a_80,
     SW_WRONG_LENGTH = 0x67_00,
     SW_COND_USE_NOT_SATISFIED = 0x69_85,
+    SW_COMMAND_NOT_ALLOWED = 0x69_86,
     SW_FILE_NOT_FOUND = 0x6a_82,
     SW_INCORRECT_P1P2 = 0x6a_86,
     /// Instruction code not supported or invalid

--- a/src/ctap/config_command.rs
+++ b/src/ctap/config_command.rs
@@ -18,7 +18,7 @@ use super::pin_protocol_v1::PinProtocolV1;
 use super::response::ResponseData;
 use super::status_code::Ctap2StatusCode;
 use super::storage::PersistentStore;
-use super::{check_pin_uv_auth_protocol, ENFORCE_ALWAYS_UV, ENTERPRISE_ATTESTATION_MODE};
+use super::{check_pin_uv_auth_protocol, ENTERPRISE_ATTESTATION_MODE};
 use alloc::vec;
 
 /// Processes the subcommand enableEnterpriseAttestation for AuthenticatorConfig.
@@ -37,9 +37,6 @@ fn process_enable_enterprise_attestation(
 fn process_toggle_always_uv(
     persistent_store: &mut PersistentStore,
 ) -> Result<ResponseData, Ctap2StatusCode> {
-    if ENFORCE_ALWAYS_UV {
-        return Err(Ctap2StatusCode::CTAP2_ERR_OPERATION_DENIED);
-    }
     persistent_store.toggle_always_uv()?;
     Ok(ResponseData::AuthenticatorConfig)
 }
@@ -130,6 +127,7 @@ pub fn process_config(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::ctap::ENFORCE_ALWAYS_UV;
     use crypto::rng256::ThreadRng256;
 
     #[test]

--- a/src/ctap/hid/mod.rs
+++ b/src/ctap/hid/mod.rs
@@ -177,7 +177,7 @@ impl CtapHid {
                 match message.cmd {
                     // CTAP specification (version 20190130) section 8.1.9.1.1
                     CtapHid::COMMAND_MSG => {
-                        // If we don't have CTAP1 backward compatibilty, this command in invalid.
+                        // If we don't have CTAP1 backward compatibilty, this command is invalid.
                         #[cfg(not(feature = "with_ctap1"))]
                         return CtapHid::error_message(cid, CtapHid::ERR_INVALID_CMD);
 

--- a/src/ctap/large_blobs.rs
+++ b/src/ctap/large_blobs.rs
@@ -88,7 +88,7 @@ impl LargeBlobs {
             if offset != self.expected_next_offset {
                 return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_SEQ);
             }
-            if persistent_store.pin_hash()?.is_some() {
+            if persistent_store.pin_hash()?.is_some() || persistent_store.has_always_uv()? {
                 let pin_uv_auth_param =
                     pin_uv_auth_param.ok_or(Ctap2StatusCode::CTAP2_ERR_PUAT_REQUIRED)?;
                 // TODO(kaczmarczyck) Error codes for PIN protocol differ across commands.

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -129,6 +129,9 @@ pub const ES256_CRED_PARAM: PublicKeyCredentialParameter = PublicKeyCredentialPa
 const DEFAULT_CRED_PROTECT: Option<CredentialProtectionPolicy> = None;
 // Maximum size stored with the credBlob extension. Must be at least 32.
 const MAX_CRED_BLOB_LENGTH: usize = 32;
+// Enforce the alwaysUv option. With this constant set to true, commands require
+// a PIN to be set up. The command toggleAlwaysUv will fail to disable alwaysUv.
+pub const ENFORCE_ALWAYS_UV: bool = false;
 
 // Checks the PIN protocol parameter against all supported versions.
 pub fn check_pin_uv_auth_protocol(

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -148,7 +148,7 @@ const DEFAULT_CRED_PROTECT: Option<CredentialProtectionPolicy> = None;
 // Maximum size stored with the credBlob extension. Must be at least 32.
 const MAX_CRED_BLOB_LENGTH: usize = 32;
 // Enforce the alwaysUv option. With this constant set to true, commands require
-// a PIN to be set up. The command toggleAlwaysUv will fail to disable alwaysUv.
+// a PIN to be set up. alwaysUv can not be disabled by commands.
 pub const ENFORCE_ALWAYS_UV: bool = false;
 
 // Checks the PIN protocol parameter against all supported versions.

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -1032,7 +1032,7 @@ where
 
     fn process_get_info(&self) -> Result<ResponseData, Ctap2StatusCode> {
         let has_always_uv = self.persistent_store.has_always_uv()?;
-        #[cfg(feature = "with_ctap1")]
+        #[cfg_attr(not(feature = "with_ctap1"), allow(unused_mut))]
         let mut versions = vec![
             String::from(FIDO2_VERSION_STRING),
             String::from(FIDO2_1_VERSION_STRING),
@@ -1043,11 +1043,6 @@ where
                 versions.insert(0, String::from(U2F_VERSION_STRING))
             }
         }
-        #[cfg(not(feature = "with_ctap1"))]
-        let versions = vec![
-            String::from(FIDO2_VERSION_STRING),
-            String::from(FIDO2_1_VERSION_STRING),
-        ];
         let mut options_map = BTreeMap::new();
         options_map.insert(String::from("rk"), true);
         options_map.insert(

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -649,7 +649,7 @@ impl PersistentStore {
     /// Enables alwaysUv, when disabled, and vice versa.
     pub fn toggle_always_uv(&mut self) -> Result<(), Ctap2StatusCode> {
         if ENFORCE_ALWAYS_UV {
-            return Ok(());
+            return Err(Ctap2StatusCode::CTAP2_ERR_OPERATION_DENIED);
         }
         if self.has_always_uv()? {
             Ok(self.store.remove(key::ALWAYS_UV)?)
@@ -1375,6 +1375,10 @@ mod test {
 
         if ENFORCE_ALWAYS_UV {
             assert!(persistent_store.has_always_uv().unwrap());
+            assert_eq!(
+                persistent_store.toggle_always_uv(),
+                Err(Ctap2StatusCode::CTAP2_ERR_OPERATION_DENIED)
+            );
         } else {
             assert!(!persistent_store.has_always_uv().unwrap());
             assert_eq!(persistent_store.toggle_always_uv(), Ok(()));

--- a/src/ctap/storage/key.rs
+++ b/src/ctap/storage/key.rs
@@ -93,6 +93,9 @@ make_partition! {
     /// The stored large blob can be too big for one key, so it has to be sharded.
     LARGE_BLOB_SHARDS = 2000..2004;
 
+    /// If this entry exists and is empty, alwaysUv is enabled.
+    ALWAYS_UV = 2038;
+
     /// If this entry exists and equals 1, the PIN needs to be changed.
     FORCE_PIN_CHANGE = 2040;
 


### PR DESCRIPTION
More progress on #106, implementing the `alwaysUv` option.

This command completes the implementation of `authenticatorConfig`. (There is the subcommand `Vendor Prototype Command`, but we don't need it - yet, at least.)

- [x] Tests pass
- [x] Appropriate changes to README are included in PR