### PR TITLE
Fix `config.py` tool according to the new API of fido2 python package

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -46,4 +46,4 @@ mkdir -p elf2tab
 cargo install elf2tab --version 0.6.0 --root elf2tab/
 
 # Install python dependencies to factory configure OpenSK (crypto, JTAG lockdown)
-pip3 install --user --upgrade colorama tqdm cryptography fido2
+pip3 install --user --upgrade colorama tqdm cryptography "fido2>=0.9.1"

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -64,8 +64,7 @@ def info(msg):
 def get_opensk_devices(batch_mode):
   devices = []
   for dev in hid.CtapHidDevice.list_devices():
-    if (dev.descriptor.vid,
-        dev.descriptor.pid) == OPENSK_VID_PID:
+    if (dev.descriptor.vid, dev.descriptor.pid) == OPENSK_VID_PID:
       if dev.capabilities & hid.CAPABILITY.CBOR:
         if batch_mode:
           devices.append(ctap2.CTAP2(dev))

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -137,10 +137,9 @@ def main(args):
     if authenticator.device.capabilities & hid.CAPABILITY.WINK:
       authenticator.device.wink()
     aaguid = uuid.UUID(bytes=authenticator.get_info().aaguid)
-    info(("Programming device {} AAGUID {} ({}). "
-          "Please touch the device to confirm...").format(
-              authenticator.device.descriptor.get("product_string", "Unknown"),
-              aaguid, authenticator.device))
+    info("Programming OpenSK device AAGUID {} ({}).".format(
+        aaguid, authenticator.device))
+    info("Please touch the device to confirm...")
     try:
       result = authenticator.send_cbor(
           OPENSK_VENDOR_CONFIGURE,

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -64,8 +64,8 @@ def info(msg):
 def get_opensk_devices(batch_mode):
   devices = []
   for dev in hid.CtapHidDevice.list_devices():
-    if (dev.descriptor["vendor_id"],
-        dev.descriptor["product_id"]) == OPENSK_VID_PID:
+    if (dev.descriptor.vid,
+        dev.descriptor.pid) == OPENSK_VID_PID:
       if dev.capabilities & hid.CAPABILITY.CBOR:
         if batch_mode:
           devices.append(ctap2.CTAP2(dev))


### PR DESCRIPTION
Fixes #269

Since fido2 v0.8.1 which we developed our configuration tool on, the device descriptor
moved from python `dict` to `NamedTuple`. This PR updates to this new API and ensure 
that we're using the correct version of fido2 module.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR