### PR TITLE
adds the PIN protocol trait

### DIFF
--- a/src/ctap/client_pin.rs
+++ b/src/ctap/client_pin.rs
@@ -31,14 +31,21 @@ use subtle::ConstantTimeEq;
 
 /// The prefix length of the PIN hash that is stored and compared.
 ///
-/// The code assumes that this value is a multiple of the AES block length and
-/// fits an u8.
+/// The code assumes that this value is a multiple of the AES block length, fits
+/// an u8 and is at most as long as a SHA256. The value is fixed for all PIN
+/// protocols.
 pub const PIN_AUTH_LENGTH: usize = 16;
 
 /// The length of the pinUvAuthToken used throughout PIN protocols.
+///
+/// The code assumes that this value is a multiple of the AES block length. It
+/// is fixed since CTAP2.1.
 pub const PIN_TOKEN_LENGTH: usize = 32;
 
 /// The length of the encrypted PINs when received by SetPin or ChangePin.
+///
+/// The code assumes that this value is a multiple of the AES block length. It
+/// is fixed since CTAP2.1.
 const PIN_PADDED_LENGTH: usize = 64;
 
 /// Computes and encrypts the HMAC-secret outputs.

--- a/src/ctap/config_command.rs
+++ b/src/ctap/config_command.rs
@@ -103,9 +103,7 @@ pub fn process_config(
                 return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
             }
         }
-        if !client_pin.verify_pin_auth_token(&config_data, &auth_param) {
-            return Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID);
-        }
+        client_pin.verify_pin_auth_token(&config_data, &auth_param)?;
     }
 
     match sub_command {

--- a/src/ctap/credential_management.rs
+++ b/src/ctap/credential_management.rs
@@ -290,9 +290,7 @@ pub fn process_credential_management(
                     return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
                 }
             }
-            if !client_pin.verify_pin_auth_token(&management_data, &pin_auth) {
-                return Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID);
-            }
+            client_pin.verify_pin_auth_token(&management_data, &pin_auth)?;
             // The RP ID permission is handled differently per subcommand below.
             client_pin.has_permission(PinPermission::CredentialManagement)?;
         }

--- a/src/ctap/large_blobs.rs
+++ b/src/ctap/large_blobs.rs
@@ -101,9 +101,7 @@ impl LargeBlobs {
                 LittleEndian::write_u32(&mut offset_bytes, offset as u32);
                 message.extend(&offset_bytes);
                 message.extend(&Sha256::hash(set.as_slice()));
-                if !client_pin.verify_pin_auth_token(&message, &pin_uv_auth_param) {
-                    return Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID);
-                }
+                client_pin.verify_pin_auth_token(&message, &pin_uv_auth_param)?;
             }
             if offset + set.len() > self.expected_length {
                 return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);

--- a/src/ctap/pin_protocol.rs
+++ b/src/ctap/pin_protocol.rs
@@ -1,0 +1,460 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::ctap::client_pin::PIN_TOKEN_LENGTH;
+use crate::ctap::data_formats::CoseKey;
+use crate::ctap::status_code::Ctap2StatusCode;
+use alloc::boxed::Box;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryInto;
+use crypto::cbc::{cbc_decrypt, cbc_encrypt};
+use crypto::hkdf::hkdf_empty_salt_256;
+use crypto::hmac::{verify_hmac_256, verify_hmac_256_first_128bits};
+use crypto::rng256::Rng256;
+use crypto::sha256::Sha256;
+use crypto::Hash256;
+
+/// Implements common functions between existing PIN protocols for handshakes.
+pub struct PinProtocol {
+    key_agreement_key: crypto::ecdh::SecKey,
+    pin_uv_auth_token: [u8; PIN_TOKEN_LENGTH],
+}
+
+impl PinProtocol {
+    /// This process is run by the authenticator at power-on.
+    ///
+    /// This function implements "initialize" from the specification.
+    pub fn new(rng: &mut impl Rng256) -> PinProtocol {
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(rng);
+        let pin_uv_auth_token = rng.gen_uniform_u8x32();
+        PinProtocol {
+            key_agreement_key,
+            pin_uv_auth_token,
+        }
+    }
+
+    /// Generates a fresh public key.
+    pub fn regenerate(&mut self, rng: &mut impl Rng256) {
+        self.key_agreement_key = crypto::ecdh::SecKey::gensk(rng);
+    }
+
+    /// Generates a fresh pinUvAuthToken.
+    pub fn reset_pin_uv_auth_token(&mut self, rng: &mut impl Rng256) {
+        self.pin_uv_auth_token = rng.gen_uniform_u8x32();
+    }
+
+    /// Returns the authenticator’s public key as a CoseKey structure.
+    pub fn get_public_key(&self) -> CoseKey {
+        CoseKey::from(self.key_agreement_key.genpk())
+    }
+
+    /// Processes the peer's encapsulated CoseKey and returns the shared secret.
+    pub fn decapsulate(
+        &self,
+        peer_cose_key: CoseKey,
+        pin_uv_auth_protocol: u64,
+    ) -> Result<Box<dyn SharedSecret>, Ctap2StatusCode> {
+        let pk: crypto::ecdh::PubKey = CoseKey::try_into(peer_cose_key)?;
+        let handshake = self.key_agreement_key.exchange_x(&pk);
+        match pin_uv_auth_protocol {
+            1 => Ok(Box::new(SharedSecretV1::new(handshake))),
+            2 => Ok(Box::new(SharedSecretV2::new(handshake))),
+            _ => Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER),
+        }
+    }
+
+    /// Getter for pinUvAuthToken.
+    pub fn get_pin_uv_auth_token(&self) -> &[u8; PIN_TOKEN_LENGTH] {
+        &self.pin_uv_auth_token
+    }
+
+    /// This is used for debugging to inject key material.
+    #[cfg(test)]
+    pub fn new_test(
+        key_agreement_key: crypto::ecdh::SecKey,
+        pin_uv_auth_token: [u8; PIN_TOKEN_LENGTH],
+    ) -> PinProtocol {
+        PinProtocol {
+            key_agreement_key,
+            pin_uv_auth_token,
+        }
+    }
+}
+
+/// Verifies the pinUvAuthToken for the given PIN protocol.
+pub fn verify_pin_uv_auth_token(
+    token: &[u8; PIN_TOKEN_LENGTH],
+    message: &[u8],
+    signature: &[u8],
+    pin_uv_auth_protocol: u64,
+) -> Result<(), Ctap2StatusCode> {
+    match pin_uv_auth_protocol {
+        1 => verify_v1(token, message, signature),
+        2 => verify_v2(token, message, signature),
+        _ => Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER),
+    }
+}
+
+pub trait SharedSecret {
+    /// Returns the encrypted plaintext.
+    fn encrypt(
+        &mut self,
+        rng: &mut dyn Rng256,
+        plaintext: &[u8],
+    ) -> Result<Vec<u8>, Ctap2StatusCode>;
+
+    /// Returns the decrypted ciphertext.
+    fn decrypt(&mut self, ciphertext: &[u8]) -> Result<Vec<u8>, Ctap2StatusCode>;
+
+    /// Verifies that the signature is a valid MAC for the given message.
+    fn verify(&mut self, message: &[u8], signature: &[u8]) -> Result<(), Ctap2StatusCode>;
+}
+
+fn encrypt(
+    rng: &mut dyn Rng256,
+    key: &[u8; 32],
+    plaintext: &[u8],
+    has_iv: bool,
+) -> Result<Vec<u8>, Ctap2StatusCode> {
+    if plaintext.len() % 16 != 0 {
+        return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
+    }
+    let iv = if has_iv {
+        let random_bytes = rng.gen_uniform_u8x32();
+        *array_ref!(random_bytes, 0, 16)
+    } else {
+        [0u8; 16]
+    };
+    let mut blocks = Vec::with_capacity(plaintext.len() / 16);
+    // TODO(https://github.com/rust-lang/rust/issues/74985) Use array_chunks when stable.
+    for block in plaintext.chunks_exact(16) {
+        blocks.push(*array_ref!(block, 0, 16));
+    }
+    let aes_enc_key = crypto::aes256::EncryptionKey::new(key);
+    cbc_encrypt(&aes_enc_key, iv, &mut blocks);
+    let mut ciphertext = if has_iv { iv.to_vec() } else { vec![] };
+    ciphertext.extend(blocks.iter().flatten());
+    Ok(ciphertext)
+}
+
+fn decrypt(key: &[u8; 32], ciphertext: &[u8], has_iv: bool) -> Result<Vec<u8>, Ctap2StatusCode> {
+    if ciphertext.len() % 16 != 0 {
+        return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
+    }
+    let mut block_len = ciphertext.len() / 16;
+    // TODO(https://github.com/rust-lang/rust/issues/74985) Use array_chunks when stable.
+    let mut block_iter = ciphertext.chunks_exact(16);
+    let iv = if has_iv {
+        block_len -= 1;
+        let iv_block = block_iter
+            .next()
+            .ok_or(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER)?;
+        *array_ref!(iv_block, 0, 16)
+    } else {
+        [0u8; 16]
+    };
+    let mut blocks = Vec::with_capacity(block_len);
+    for block in block_iter {
+        blocks.push(*array_ref!(block, 0, 16));
+    }
+    let aes_enc_key = crypto::aes256::EncryptionKey::new(key);
+    let aes_dec_key = crypto::aes256::DecryptionKey::new(&aes_enc_key);
+    cbc_decrypt(&aes_dec_key, iv, &mut blocks);
+    Ok(blocks.iter().flatten().cloned().collect::<Vec<u8>>())
+}
+
+fn verify_v1(key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), Ctap2StatusCode> {
+    if signature.len() != 16 {
+        return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
+    }
+    if verify_hmac_256_first_128bits::<Sha256>(key, message, array_ref![signature, 0, 16]) {
+        Ok(())
+    } else {
+        Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
+    }
+}
+
+pub struct SharedSecretV1 {
+    common_secret: [u8; 32],
+}
+
+impl SharedSecretV1 {
+    /// Creates a new shared secret from the handshake result.
+    fn new(handshake: [u8; 32]) -> SharedSecretV1 {
+        SharedSecretV1 {
+            common_secret: Sha256::hash(&handshake),
+        }
+    }
+
+    /// Creates a new shared secret for testing.
+    #[cfg(test)]
+    pub fn new_test(hash: [u8; 32]) -> SharedSecretV1 {
+        SharedSecretV1 {
+            common_secret: hash,
+        }
+    }
+}
+
+impl SharedSecret for SharedSecretV1 {
+    fn encrypt(
+        &mut self,
+        rng: &mut dyn Rng256,
+        plaintext: &[u8],
+    ) -> Result<Vec<u8>, Ctap2StatusCode> {
+        encrypt(rng, &self.common_secret, plaintext, false)
+    }
+
+    fn decrypt(&mut self, ciphertext: &[u8]) -> Result<Vec<u8>, Ctap2StatusCode> {
+        decrypt(&self.common_secret, ciphertext, false)
+    }
+
+    fn verify(&mut self, message: &[u8], signature: &[u8]) -> Result<(), Ctap2StatusCode> {
+        verify_v1(&self.common_secret, message, signature)
+    }
+}
+
+fn verify_v2(key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), Ctap2StatusCode> {
+    if signature.len() != 32 {
+        return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
+    }
+    if verify_hmac_256::<Sha256>(key, message, array_ref![signature, 0, 32]) {
+        Ok(())
+    } else {
+        Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
+    }
+}
+
+pub struct SharedSecretV2 {
+    handshake: [u8; 32],
+    aes_key: Option<[u8; 32]>,
+    hmac_key: Option<[u8; 32]>,
+}
+
+impl SharedSecretV2 {
+    /// Creates a new shared secret from the handshake result.
+    fn new(handshake: [u8; 32]) -> SharedSecretV2 {
+        SharedSecretV2 {
+            handshake,
+            aes_key: None,
+            hmac_key: None,
+        }
+    }
+
+    fn get_aes_key(&mut self) -> &[u8; 32] {
+        let handshake = &self.handshake;
+        self.aes_key
+            .get_or_insert_with(|| hkdf_empty_salt_256::<Sha256>(handshake, b"CTAP2 AES key"))
+    }
+
+    fn get_hmac_key(&mut self) -> &[u8; 32] {
+        let handshake = &self.handshake;
+        self.hmac_key
+            .get_or_insert_with(|| hkdf_empty_salt_256::<Sha256>(handshake, b"CTAP2 HMAC key"))
+    }
+}
+
+impl SharedSecret for SharedSecretV2 {
+    fn encrypt(
+        &mut self,
+        rng: &mut dyn Rng256,
+        plaintext: &[u8],
+    ) -> Result<Vec<u8>, Ctap2StatusCode> {
+        encrypt(rng, self.get_aes_key(), plaintext, true)
+    }
+
+    fn decrypt(&mut self, ciphertext: &[u8]) -> Result<Vec<u8>, Ctap2StatusCode> {
+        decrypt(self.get_aes_key(), ciphertext, true)
+    }
+
+    fn verify(&mut self, message: &[u8], signature: &[u8]) -> Result<(), Ctap2StatusCode> {
+        verify_v2(self.get_hmac_key(), message, signature)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crypto::rng256::ThreadRng256;
+
+    #[test]
+    fn test_pin_protocol_public_key() {
+        let mut rng = ThreadRng256 {};
+        let mut pin_protocol = PinProtocol::new(&mut rng);
+        let public_key = pin_protocol.get_public_key();
+        pin_protocol.regenerate(&mut rng);
+        let new_public_key = pin_protocol.get_public_key();
+        assert_ne!(public_key, new_public_key);
+    }
+
+    #[test]
+    fn test_pin_protocol_pin_uv_auth_token() {
+        let mut rng = ThreadRng256 {};
+        let mut pin_protocol = PinProtocol::new(&mut rng);
+        let token = *pin_protocol.get_pin_uv_auth_token();
+        pin_protocol.reset_pin_uv_auth_token(&mut rng);
+        let new_token = pin_protocol.get_pin_uv_auth_token();
+        assert_ne!(&token, new_token);
+    }
+
+    #[test]
+    fn test_shared_secret_v1_encrypt_decrypt() {
+        let mut rng = ThreadRng256 {};
+        let mut shared_secret = SharedSecretV1::new([0x55; 32]);
+        let plaintext = vec![0xAA; 64];
+        let ciphertext = shared_secret.encrypt(&mut rng, &plaintext).unwrap();
+        assert_eq!(shared_secret.decrypt(&ciphertext), Ok(plaintext));
+    }
+
+    #[test]
+    fn test_shared_secret_v1_verify() {
+        let mut shared_secret = SharedSecretV1::new([0x55; 32]);
+        let message = [0xAA];
+        let signature = [
+            0x8B, 0x60, 0x15, 0x7D, 0xF3, 0x44, 0x82, 0x2E, 0x54, 0x34, 0x7A, 0x01, 0xFB, 0x02,
+            0x48, 0xA6,
+        ];
+        assert_eq!(shared_secret.verify(&message, &signature), Ok(()));
+        assert_eq!(
+            shared_secret.verify(&[0xBB], &signature),
+            Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
+        );
+        assert_eq!(
+            shared_secret.verify(&message, &[0x12; 16]),
+            Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
+        );
+    }
+
+    #[test]
+    fn test_shared_secret_v2_encrypt_decrypt() {
+        let mut rng = ThreadRng256 {};
+        let mut shared_secret = SharedSecretV2::new([0x55; 32]);
+        let plaintext = vec![0xAA; 64];
+        let ciphertext = shared_secret.encrypt(&mut rng, &plaintext).unwrap();
+        assert_eq!(shared_secret.decrypt(&ciphertext), Ok(plaintext));
+    }
+
+    #[test]
+    fn test_shared_secret_v2_verify() {
+        let mut shared_secret = SharedSecretV2::new([0x55; 32]);
+        let message = [0xAA];
+        let signature = [
+            0xC0, 0x3F, 0x2A, 0x22, 0x5C, 0xC3, 0x4E, 0x05, 0xC1, 0x0E, 0x72, 0x9C, 0x8D, 0xD5,
+            0x7D, 0xE5, 0x98, 0x9C, 0x68, 0x15, 0xEC, 0xE2, 0x3A, 0x95, 0xD5, 0x90, 0xE1, 0xE9,
+            0x3F, 0xF0, 0x1A, 0xAF,
+        ];
+        assert_eq!(shared_secret.verify(&message, &signature), Ok(()));
+        assert_eq!(
+            shared_secret.verify(&[0xBB], &signature),
+            Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
+        );
+        assert_eq!(
+            shared_secret.verify(&message, &[0x12; 32]),
+            Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
+        );
+    }
+
+    #[test]
+    fn test_decapsulate_invalid() {
+        let mut rng = ThreadRng256 {};
+        let pin_protocol = PinProtocol::new(&mut rng);
+        let shared_secret = pin_protocol.decapsulate(pin_protocol.get_public_key(), 3);
+        assert_eq!(
+            shared_secret.err(),
+            Some(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER)
+        );
+    }
+
+    #[test]
+    fn test_decapsulate_symmetric() {
+        let mut rng = ThreadRng256 {};
+        let pin_protocol1 = PinProtocol::new(&mut rng);
+        let pin_protocol2 = PinProtocol::new(&mut rng);
+        for protocol in 1..=2 {
+            let mut shared_secret1 = pin_protocol1
+                .decapsulate(pin_protocol2.get_public_key(), protocol)
+                .unwrap();
+            let mut shared_secret2 = pin_protocol2
+                .decapsulate(pin_protocol1.get_public_key(), protocol)
+                .unwrap();
+            let plaintext = vec![0xAA; 64];
+            let ciphertext = shared_secret1.encrypt(&mut rng, &plaintext).unwrap();
+            assert_eq!(plaintext, shared_secret2.decrypt(&ciphertext).unwrap());
+        }
+    }
+
+    #[test]
+    fn test_verify_pin_uv_auth_token_v1() {
+        let token = [0x91; PIN_TOKEN_LENGTH];
+        let message = [0xAA];
+        let signature = [
+            0x9C, 0x1C, 0xFE, 0x9D, 0xD7, 0x64, 0x6A, 0x06, 0xB9, 0xA8, 0x0F, 0x96, 0xAD, 0x50,
+            0x49, 0x68,
+        ];
+        assert_eq!(
+            verify_pin_uv_auth_token(&token, &message, &signature, 1),
+            Ok(())
+        );
+        assert_eq!(
+            verify_pin_uv_auth_token(&[0x12; PIN_TOKEN_LENGTH], &message, &signature, 1),
+            Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
+        );
+        assert_eq!(
+            verify_pin_uv_auth_token(&token, &[0xBB], &signature, 1),
+            Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
+        );
+        assert_eq!(
+            verify_pin_uv_auth_token(&token, &message, &[0x12; 16], 1),
+            Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
+        );
+    }
+
+    #[test]
+    fn test_verify_pin_uv_auth_token_v2() {
+        let token = [0x91; PIN_TOKEN_LENGTH];
+        let message = [0xAA];
+        let signature = [
+            0x9C, 0x1C, 0xFE, 0x9D, 0xD7, 0x64, 0x6A, 0x06, 0xB9, 0xA8, 0x0F, 0x96, 0xAD, 0x50,
+            0x49, 0x68, 0x94, 0x90, 0x20, 0x53, 0x0F, 0xA3, 0xD2, 0x7A, 0x9F, 0xFD, 0xFA, 0x62,
+            0x36, 0x93, 0xF7, 0x84,
+        ];
+        assert_eq!(
+            verify_pin_uv_auth_token(&token, &message, &signature, 2),
+            Ok(())
+        );
+        assert_eq!(
+            verify_pin_uv_auth_token(&[0x12; PIN_TOKEN_LENGTH], &message, &signature, 2),
+            Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
+        );
+        assert_eq!(
+            verify_pin_uv_auth_token(&token, &[0xBB], &signature, 2),
+            Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
+        );
+        assert_eq!(
+            verify_pin_uv_auth_token(&token, &message, &[0x12; 32], 2),
+            Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
+        );
+    }
+
+    #[test]
+    fn test_verify_pin_uv_auth_token_invalid_protocol() {
+        let token = [0x91; PIN_TOKEN_LENGTH];
+        let message = [0xAA];
+        let signature = [];
+        assert_eq!(
+            verify_pin_uv_auth_token(&token, &message, &signature, 3),
+            Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER)
+        );
+    }
+}


### PR DESCRIPTION
Continues #291 in implementing ClientPin for CTAP2.1.

The main work is the new `PinProtocol` struct and the `SharedSecret` trait that allow a generic ClientPin implementation. The ClientPin struct itself only moves to the new `PinProtocol` implementation for V1, without yet allowing the new V2. `client_pin.rs` and its tests are only adapted to deal with the new interface. This change does not change OpenSK's behaviour (with the small exception of one error code for wrong length arrays that was proactively updated to 2.1). Therefore, ClientPin tests do not reflect the upcoming changes yet, but were not refactored to make it obvious this change is refactoring only.

Plan for the next PRs:
1. use V2
2. add timeout for tokens
3. fully update the command algorithms

- [x] Tests pass
