### PR TITLE
Adds PIN protocol V2 to all commands

### DIFF
--- a/src/ctap/data_formats.rs
+++ b/src/ctap/data_formats.rs
@@ -816,8 +816,8 @@ impl TryFrom<CoseKey> for ecdh::PubKey {
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PinUvAuthProtocol {
-    V1,
-    V2,
+    V1 = 1,
+    V2 = 2,
 }
 
 impl TryFrom<cbor::Value> for PinUvAuthProtocol {

--- a/src/ctap/pin_protocol.rs
+++ b/src/ctap/pin_protocol.rs
@@ -94,6 +94,19 @@ impl PinProtocol {
     }
 }
 
+/// Authenticates the pinUvAuthToken for the given PIN protocol.
+#[cfg(test)]
+pub fn authenticate_pin_uv_auth_token(
+    token: &[u8; PIN_TOKEN_LENGTH],
+    message: &[u8],
+    pin_uv_auth_protocol: PinUvAuthProtocol,
+) -> Vec<u8> {
+    match pin_uv_auth_protocol {
+        PinUvAuthProtocol::V1 => hmac_256::<Sha256>(token, message)[..16].to_vec(),
+        PinUvAuthProtocol::V2 => hmac_256::<Sha256>(token, message).to_vec(),
+    }
+}
+
 /// Verifies the pinUvAuthToken for the given PIN protocol.
 pub fn verify_pin_uv_auth_token(
     token: &[u8; PIN_TOKEN_LENGTH],


### PR DESCRIPTION
Applies all changes started in #293 to other commands. In contrast to #293, not all tests are duplicated for both PIN protocols. We don't need all combinations of PIN protocols and subcommands, as there are in-depth tests for `verify_pin_uv_auth_token`.

Naming is more consistent, the variable name `pin_auth` is now always either
- `pin_uv_auth_param`, the signature
- `pin_uv_auth_token`, the generated data held by a PIN protocol

matching the specification.