### PR TITLE
Separate file crypto wrappers, starting with AES-CBC

### DIFF
--- a/src/ctap/crypto_wrapper.rs
+++ b/src/ctap/crypto_wrapper.rs
@@ -1,0 +1,102 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::ctap::status_code::Ctap2StatusCode;
+use alloc::vec;
+use alloc::vec::Vec;
+use crypto::cbc::{cbc_decrypt, cbc_encrypt};
+use crypto::rng256::Rng256;
+
+/// Wraps the AES256-CBC encryption to match what we need in CTAP.
+pub fn aes256_cbc_encrypt(
+    rng: &mut dyn Rng256,
+    aes_enc_key: &crypto::aes256::EncryptionKey,
+    plaintext: &[u8],
+    has_iv: bool,
+) -> Result<Vec<u8>, Ctap2StatusCode> {
+    if plaintext.len() % 16 != 0 {
+        return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
+    }
+    let iv = if has_iv {
+        let random_bytes = rng.gen_uniform_u8x32();
+        *array_ref!(random_bytes, 0, 16)
+    } else {
+        [0u8; 16]
+    };
+    let mut blocks = Vec::with_capacity(plaintext.len() / 16);
+    // TODO(https://github.com/rust-lang/rust/issues/74985) Use array_chunks when stable.
+    for block in plaintext.chunks_exact(16) {
+        blocks.push(*array_ref!(block, 0, 16));
+    }
+    cbc_encrypt(aes_enc_key, iv, &mut blocks);
+    let mut ciphertext = if has_iv { iv.to_vec() } else { vec![] };
+    ciphertext.extend(blocks.iter().flatten());
+    Ok(ciphertext)
+}
+
+/// Wraps the AES256-CBC decryption to match what we need in CTAP.
+pub fn aes256_cbc_decrypt(
+    aes_enc_key: &crypto::aes256::EncryptionKey,
+    ciphertext: &[u8],
+    has_iv: bool,
+) -> Result<Vec<u8>, Ctap2StatusCode> {
+    if ciphertext.len() % 16 != 0 {
+        return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
+    }
+    let mut block_len = ciphertext.len() / 16;
+    // TODO(https://github.com/rust-lang/rust/issues/74985) Use array_chunks when stable.
+    let mut block_iter = ciphertext.chunks_exact(16);
+    let iv = if has_iv {
+        block_len -= 1;
+        let iv_block = block_iter
+            .next()
+            .ok_or(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER)?;
+        *array_ref!(iv_block, 0, 16)
+    } else {
+        [0u8; 16]
+    };
+    let mut blocks = Vec::with_capacity(block_len);
+    for block in block_iter {
+        blocks.push(*array_ref!(block, 0, 16));
+    }
+    let aes_dec_key = crypto::aes256::DecryptionKey::new(aes_enc_key);
+    cbc_decrypt(&aes_dec_key, iv, &mut blocks);
+    Ok(blocks.iter().flatten().cloned().collect::<Vec<u8>>())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crypto::rng256::ThreadRng256;
+
+    #[test]
+    fn test_encrypt_decrypt_with_iv() {
+        let mut rng = ThreadRng256 {};
+        let aes_enc_key = crypto::aes256::EncryptionKey::new(&[0xC2; 32]);
+        let plaintext = vec![0xAA; 64];
+        let ciphertext = aes256_cbc_encrypt(&mut rng, &aes_enc_key, &plaintext, true).unwrap();
+        let decrypted = aes256_cbc_decrypt(&aes_enc_key, &ciphertext, true).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_without_iv() {
+        let mut rng = ThreadRng256 {};
+        let aes_enc_key = crypto::aes256::EncryptionKey::new(&[0xC2; 32]);
+        let plaintext = vec![0xAA; 64];
+        let ciphertext = aes256_cbc_encrypt(&mut rng, &aes_enc_key, &plaintext, false).unwrap();
+        let decrypted = aes256_cbc_decrypt(&aes_enc_key, &ciphertext, false).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+}

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -1212,10 +1212,8 @@ mod test {
         PublicKeyCredentialRpEntity, PublicKeyCredentialUserEntity,
     };
     use super::pin_protocol::{authenticate_pin_uv_auth_token, PinProtocol};
-    use super::storage::MasterKeys;
     use super::*;
     use cbor::{cbor_array, cbor_array_vec, cbor_map};
-    use crypto::cbc::{cbc_decrypt, cbc_encrypt};
     use crypto::rng256::ThreadRng256;
 
     const CLOCK_FREQUENCY_HZ: usize = 32768;
@@ -2924,129 +2922,5 @@ mod test {
                 }
             ))
         );
-    }
-
-    // Encrypts the private key and relying party ID hash into a credential ID. Other
-    // information, such as a user name, are not stored, because encrypted credential IDs
-    // are used for credentials stored server-side. Also, we want the key handle to be
-    // compatible with U2F.
-    pub fn legacy_encrypt_key_handle(
-        rng: &mut impl Rng256,
-        master_keys: &MasterKeys,
-        private_key: crypto::ecdsa::SecKey,
-        application: &[u8; 32],
-    ) -> Result<Vec<u8>, Ctap2StatusCode> {
-        let aes_enc_key = crypto::aes256::EncryptionKey::new(&master_keys.encryption);
-        let mut sk_bytes = [0; 32];
-        private_key.to_bytes(&mut sk_bytes);
-        let mut iv = [0; 16];
-        iv.copy_from_slice(&rng.gen_uniform_u8x32()[..16]);
-
-        let mut blocks = [[0u8; 16]; 4];
-        blocks[0].copy_from_slice(&sk_bytes[..16]);
-        blocks[1].copy_from_slice(&sk_bytes[16..]);
-        blocks[2].copy_from_slice(&application[..16]);
-        blocks[3].copy_from_slice(&application[16..]);
-        cbc_encrypt(&aes_enc_key, iv, &mut blocks);
-
-        let mut encrypted_id = Vec::with_capacity(0x70);
-        encrypted_id.extend(&iv);
-        for b in &blocks {
-            encrypted_id.extend(b);
-        }
-        let id_hmac = hmac_256::<Sha256>(&master_keys.hmac, &encrypted_id[..]);
-        encrypted_id.extend(&id_hmac);
-        Ok(encrypted_id)
-    }
-
-    // Decrypts a credential ID and writes the private key into a PublicKeyCredentialSource.
-    // None is returned if the HMAC test fails or the relying party does not match the
-    // decrypted relying party ID hash.
-    pub fn legacy_decrypt_credential_source(
-        master_keys: &MasterKeys,
-        credential_id: Vec<u8>,
-        rp_id_hash: &[u8],
-    ) -> Result<Option<PublicKeyCredentialSource>, Ctap2StatusCode> {
-        if credential_id.len() != CREDENTIAL_ID_SIZE {
-            return Ok(None);
-        }
-        let payload_size = credential_id.len() - 32;
-        if !verify_hmac_256::<Sha256>(
-            &master_keys.hmac,
-            &credential_id[..payload_size],
-            array_ref![credential_id, payload_size, 32],
-        ) {
-            return Ok(None);
-        }
-        let aes_enc_key = crypto::aes256::EncryptionKey::new(&master_keys.encryption);
-        let aes_dec_key = crypto::aes256::DecryptionKey::new(&aes_enc_key);
-        let mut iv = [0; 16];
-        iv.copy_from_slice(&credential_id[..16]);
-        let mut blocks = [[0u8; 16]; 4];
-        for i in 0..4 {
-            blocks[i].copy_from_slice(&credential_id[16 * (i + 1)..16 * (i + 2)]);
-        }
-
-        cbc_decrypt(&aes_dec_key, iv, &mut blocks);
-        let mut decrypted_sk = [0; 32];
-        let mut decrypted_rp_id_hash = [0; 32];
-        decrypted_sk[..16].clone_from_slice(&blocks[0]);
-        decrypted_sk[16..].clone_from_slice(&blocks[1]);
-        decrypted_rp_id_hash[..16].clone_from_slice(&blocks[2]);
-        decrypted_rp_id_hash[16..].clone_from_slice(&blocks[3]);
-        if rp_id_hash != decrypted_rp_id_hash {
-            return Ok(None);
-        }
-
-        let sk_option = crypto::ecdsa::SecKey::from_bytes(&decrypted_sk);
-        Ok(sk_option.map(|sk| PublicKeyCredentialSource {
-            key_type: PublicKeyCredentialType::PublicKey,
-            credential_id,
-            private_key: sk,
-            rp_id: String::from(""),
-            user_handle: vec![],
-            user_display_name: None,
-            cred_protect_policy: None,
-            creation_order: 0,
-            user_name: None,
-            user_icon: None,
-            cred_blob: None,
-            large_blob_key: None,
-        }))
-    }
-
-    #[test]
-    fn test_backwards_compatible() {
-        let mut rng = ThreadRng256 {};
-        let user_immediately_present = |_| Ok(());
-        let private_key = crypto::ecdsa::SecKey::gensk(&mut rng);
-        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
-        let master_keys = ctap_state.persistent_store.master_keys().unwrap();
-
-        // Usually, the relying party ID or its hash is provided by the client.
-        // We are not testing the correctness of our SHA256 here, only if it is checked.
-        let rp_id_hash = [0x55; 32];
-
-        let encrypted_id = ctap_state
-            .encrypt_key_handle(private_key.clone(), &rp_id_hash)
-            .unwrap();
-        let decrypted_source =
-            legacy_decrypt_credential_source(&master_keys, encrypted_id, &rp_id_hash)
-                .unwrap()
-                .unwrap();
-        assert_eq!(private_key, decrypted_source.private_key);
-
-        let encrypted_id = legacy_encrypt_key_handle(
-            ctap_state.rng,
-            &master_keys,
-            private_key.clone(),
-            &rp_id_hash,
-        )
-        .unwrap();
-        let decrypted_source = ctap_state
-            .decrypt_credential_source(encrypted_id, &rp_id_hash)
-            .unwrap()
-            .unwrap();
-        assert_eq!(private_key, decrypted_source.private_key);
     }
 }


### PR DESCRIPTION
This change wants to make it easier to switch between different crypto backends. The new file `crypto_wrapper.rs` implements the interface that CTAP needs, and uses our software implementation as the backend. The implementation is identical to what was added for `pin_protocol.rs`, and simply moved. This allows reusing it in key wrapping, make the function much more readable.

This PR does not change the actual key wrapping functionality. Changes in key wrapping can potentially invalidate all existing server-side credentials, therefore I added some extra tests to ensure backwards compatibility. The first commit of the change contains those tests against the old implementation. The second commit removes them. This is just a precautionary measure. Old credentials can still be decrypted, and vice versa.