### PR TITLE
Final changes for CTAP2.1

### DIFF
--- a/src/ctap/data_formats.rs
+++ b/src/ctap/data_formats.rs
@@ -409,8 +409,11 @@ impl TryFrom<cbor::Value> for MakeCredentialOptions {
             Some(options_entry) => extract_bool(options_entry)?,
             None => false,
         };
-        if up.is_some() {
-            return Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION);
+        // In CTAP2.0, the up option is supposed to always fail when present.
+        if let Some(options_entry) = up {
+            if !extract_bool(options_entry)? {
+                return Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION);
+            }
         }
         let uv = match uv {
             Some(options_entry) => extract_bool(options_entry)?,

--- a/src/ctap/response.rs
+++ b/src/ctap/response.rs
@@ -211,7 +211,7 @@ impl From<AuthenticatorGetInfoResponse> for cbor::Value {
 #[derive(Debug, PartialEq)]
 pub struct AuthenticatorClientPinResponse {
     pub key_agreement: Option<CoseKey>,
-    pub pin_token: Option<Vec<u8>>,
+    pub pin_uv_auth_token: Option<Vec<u8>>,
     pub retries: Option<u64>,
     pub power_cycle_state: Option<bool>,
     // - 0x05: uvRetries missing as we don't support internal UV.
@@ -221,14 +221,14 @@ impl From<AuthenticatorClientPinResponse> for cbor::Value {
     fn from(client_pin_response: AuthenticatorClientPinResponse) -> Self {
         let AuthenticatorClientPinResponse {
             key_agreement,
-            pin_token,
+            pin_uv_auth_token,
             retries,
             power_cycle_state,
         } = client_pin_response;
 
         cbor_map_options! {
             0x01 => key_agreement.map(cbor::Value::from),
-            0x02 => pin_token,
+            0x02 => pin_uv_auth_token,
             0x03 => retries,
             0x04 => power_cycle_state,
         }
@@ -495,7 +495,7 @@ mod test {
         let cose_key = CoseKey::from(pk);
         let client_pin_response = AuthenticatorClientPinResponse {
             key_agreement: Some(cose_key.clone()),
-            pin_token: Some(vec![70]),
+            pin_uv_auth_token: Some(vec![70]),
             retries: Some(8),
             power_cycle_state: Some(false),
         };


### PR DESCRIPTION
Implements protocol changes for `MakeCredential` and `GetAssertion`. Mostly moves around code in `mod.rs`, as protocol step orders changed. Generally, we don't follow the order strictly, since we parse parameters before processing them. Therefore, commands with 2 different possible error codes might fail out of order.

It also renames a response parameter `pin_token` to `pin_uv_auth_token`.

The functional changes are:
- The token was regenerated after use, this is fixed.
- Under some circumstances, `MakeCredential` works without pin_uv_auth_param.
- Stricter default `credProtect` settings don't cause unsolicited extension outputs.
- Option `up=true` is now accepted again in `MakeCredential` (prevented by certification for 2.0, reverts #217).