### PR TITLE
Remove KeyType from CBOR

### DIFF
--- a/libraries/cbor/src/lib.rs
+++ b/libraries/cbor/src/lib.rs
@@ -24,5 +24,5 @@ pub mod values;
 pub mod writer;
 
 pub use self::reader::read;
-pub use self::values::{KeyType, SimpleValue, Value};
+pub use self::values::{SimpleValue, Value};
 pub use self::writer::write;

--- a/libraries/cbor/src/reader.rs
+++ b/libraries/cbor/src/reader.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::values::{Constants, KeyType, SimpleValue, Value};
+use super::values::{Constants, SimpleValue, Value};
 use crate::{cbor_array_vec, cbor_bytes_lit, cbor_map_collection, cbor_text, cbor_unsigned};
 use alloc::str;
 use alloc::vec::Vec;
@@ -22,7 +22,6 @@ pub enum DecoderError {
     UnsupportedMajorType,
     UnknownAdditionalInfo,
     IncompleteCborData,
-    IncorrectMapKeyType,
     TooMuchNesting,
     InvalidUtf8,
     ExtranousData,
@@ -134,7 +133,7 @@ impl<'a> Reader<'a> {
         if signed_size < 0 {
             Err(DecoderError::OutOfRangeIntegerValue)
         } else {
-            Ok(Value::KeyValue(KeyType::Negative(-(size_value as i64) - 1)))
+            Ok(Value::Negative(-(size_value as i64) - 1))
         }
     }
 
@@ -176,18 +175,14 @@ impl<'a> Reader<'a> {
         let mut value_map = Vec::new();
         let mut last_key_option = None;
         for _ in 0..size_value {
-            let key_value = self.decode_complete_data_item(remaining_depth - 1)?;
-            if let Value::KeyValue(key) = key_value {
-                if let Some(last_key) = last_key_option {
-                    if last_key >= key {
-                        return Err(DecoderError::OutOfOrderKey);
-                    }
+            let key = self.decode_complete_data_item(remaining_depth - 1)?;
+            if let Some(last_key) = last_key_option {
+                if last_key >= key {
+                    return Err(DecoderError::OutOfOrderKey);
                 }
-                last_key_option = Some(key.clone());
-                value_map.push((key, self.decode_complete_data_item(remaining_depth - 1)?));
-            } else {
-                return Err(DecoderError::IncorrectMapKeyType);
             }
+            last_key_option = Some(key.clone());
+            value_map.push((key, self.decode_complete_data_item(remaining_depth - 1)?));
         }
         Ok(cbor_map_collection!(value_map))
     }
@@ -612,19 +607,6 @@ mod test {
         for cbor in cases {
             assert_eq!(read(&cbor), Err(DecoderError::IncompleteCborData));
         }
-    }
-
-    #[test]
-    fn test_read_unsupported_map_key_format_error() {
-        // While CBOR can handle all types as map keys, we only support a subset.
-        let bad_map_cbor = vec![
-            0xa2, // map of 2 pairs
-            0x82, 0x01, 0x02, // invalid key : [1, 2]
-            0x02, // value : 2
-            0x61, 0x64, // key : "d"
-            0x03, // value : 3
-        ];
-        assert_eq!(read(&bad_map_cbor), Err(DecoderError::IncorrectMapKeyType));
     }
 
     #[test]

--- a/libraries/cbor/src/values.rs
+++ b/libraries/cbor/src/values.rs
@@ -12,31 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::writer::write;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::cmp::Ordering;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub enum Value {
-    KeyValue(KeyType),
-    Array(Vec<Value>),
-    Map(Vec<(KeyType, Value)>),
-    // TAG is omitted
-    Simple(SimpleValue),
-}
-
-// The specification recommends to limit the available keys.
-// Currently supported are both integer and string types.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum KeyType {
     Unsigned(u64),
     // We only use 63 bits of information here.
     Negative(i64),
     ByteString(Vec<u8>),
     TextString(String),
+    Array(Vec<Value>),
+    Map(Vec<(Value, Value)>),
+    // TAG is omitted
+    Simple(SimpleValue),
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SimpleValue {
     FalseValue = 20,
     TrueValue = 21,
@@ -57,6 +51,15 @@ impl Constants {
 }
 
 impl Value {
+    // For simplicity, this only takes i64. Construct directly for the last bit.
+    pub fn integer(int: i64) -> Value {
+        if int >= 0 {
+            Value::Unsigned(int as u64)
+        } else {
+            Value::Negative(int)
+        }
+    }
+
     pub fn bool_value(b: bool) -> Value {
         if b {
             Value::Simple(SimpleValue::TrueValue)
@@ -67,7 +70,10 @@ impl Value {
 
     pub fn type_label(&self) -> u8 {
         match self {
-            Value::KeyValue(key) => key.type_label(),
+            Value::Unsigned(_) => 0,
+            Value::Negative(_) => 1,
+            Value::ByteString(_) => 2,
+            Value::TextString(_) => 3,
             Value::Array(_) => 4,
             Value::Map(_) => 5,
             Value::Simple(_) => 7,
@@ -75,29 +81,11 @@ impl Value {
     }
 }
 
-impl KeyType {
-    // For simplicity, this only takes i64. Construct directly for the last bit.
-    pub fn integer(int: i64) -> KeyType {
-        if int >= 0 {
-            KeyType::Unsigned(int as u64)
-        } else {
-            KeyType::Negative(int)
-        }
-    }
-
-    pub fn type_label(&self) -> u8 {
-        match self {
-            KeyType::Unsigned(_) => 0,
-            KeyType::Negative(_) => 1,
-            KeyType::ByteString(_) => 2,
-            KeyType::TextString(_) => 3,
-        }
-    }
-}
-
-impl Ord for KeyType {
-    fn cmp(&self, other: &KeyType) -> Ordering {
-        use super::values::KeyType::{ByteString, Negative, TextString, Unsigned};
+impl Ord for Value {
+    fn cmp(&self, other: &Value) -> Ordering {
+        use super::values::Value::{
+            Array, ByteString, Map, Negative, Simple, TextString, Unsigned,
+        };
         let self_type_value = self.type_label();
         let other_type_value = other.type_label();
         if self_type_value != other_type_value {
@@ -108,14 +96,32 @@ impl Ord for KeyType {
             (Negative(n1), Negative(n2)) => n1.cmp(n2).reverse(),
             (ByteString(b1), ByteString(b2)) => b1.len().cmp(&b2.len()).then(b1.cmp(b2)),
             (TextString(t1), TextString(t2)) => t1.len().cmp(&t2.len()).then(t1.cmp(t2)),
-            _ => unreachable!(),
+            (Array(a1), Array(a2)) if a1.len() != a2.len() => a1.len().cmp(&a2.len()),
+            (Map(m1), Map(m2)) if m1.len() != m2.len() => m1.len().cmp(&m2.len()),
+            (Simple(s1), Simple(s2)) => s1.cmp(s2),
+            (v1, v2) => {
+                // This case could handle all of the above as well. Checking individually is faster.
+                let mut encoding1 = Vec::new();
+                write(v1.clone(), &mut encoding1);
+                let mut encoding2 = Vec::new();
+                write(v2.clone(), &mut encoding2);
+                encoding1.cmp(&encoding2)
+            }
         }
     }
 }
 
-impl PartialOrd for KeyType {
-    fn partial_cmp(&self, other: &KeyType) -> Option<Ordering> {
+impl PartialOrd for Value {
+    fn partial_cmp(&self, other: &Value) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+impl Eq for Value {}
+
+impl PartialEq for Value {
+    fn eq(&self, other: &Value) -> bool {
+        self.cmp(other) == Ordering::Equal
     }
 }
 
@@ -131,59 +137,50 @@ impl SimpleValue {
     }
 }
 
-impl From<u64> for KeyType {
+impl From<u64> for Value {
     fn from(unsigned: u64) -> Self {
-        KeyType::Unsigned(unsigned)
+        Value::Unsigned(unsigned)
     }
 }
 
-impl From<i64> for KeyType {
+impl From<i64> for Value {
     fn from(i: i64) -> Self {
-        KeyType::integer(i)
+        Value::integer(i)
     }
 }
 
-impl From<i32> for KeyType {
+impl From<i32> for Value {
     fn from(i: i32) -> Self {
-        KeyType::integer(i as i64)
+        Value::integer(i as i64)
     }
 }
 
-impl From<Vec<u8>> for KeyType {
+impl From<Vec<u8>> for Value {
     fn from(bytes: Vec<u8>) -> Self {
-        KeyType::ByteString(bytes)
+        Value::ByteString(bytes)
     }
 }
 
-impl From<&[u8]> for KeyType {
+impl From<&[u8]> for Value {
     fn from(bytes: &[u8]) -> Self {
-        KeyType::ByteString(bytes.to_vec())
+        Value::ByteString(bytes.to_vec())
     }
 }
 
-impl From<String> for KeyType {
+impl From<String> for Value {
     fn from(text: String) -> Self {
-        KeyType::TextString(text)
+        Value::TextString(text)
     }
 }
 
-impl From<&str> for KeyType {
+impl From<&str> for Value {
     fn from(text: &str) -> Self {
-        KeyType::TextString(text.to_string())
+        Value::TextString(text.to_string())
     }
 }
 
-impl<T> From<T> for Value
-where
-    KeyType: From<T>,
-{
-    fn from(t: T) -> Self {
-        Value::KeyValue(KeyType::from(t))
-    }
-}
-
-impl From<Vec<(KeyType, Value)>> for Value {
-    fn from(map: Vec<(KeyType, Value)>) -> Self {
+impl From<Vec<(Value, Value)>> for Value {
+    fn from(map: Vec<(Value, Value)>) -> Self {
         Value::Map(map)
     }
 }
@@ -191,19 +188,6 @@ impl From<Vec<(KeyType, Value)>> for Value {
 impl From<bool> for Value {
     fn from(b: bool) -> Self {
         Value::bool_value(b)
-    }
-}
-
-pub trait IntoCborKey {
-    fn into_cbor_key(self) -> KeyType;
-}
-
-impl<T> IntoCborKey for T
-where
-    KeyType: From<T>,
-{
-    fn into_cbor_key(self) -> KeyType {
-        KeyType::from(self)
     }
 }
 
@@ -244,32 +228,69 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::{cbor_key_bytes, cbor_key_int, cbor_key_text};
+    use super::*;
+    use crate::{cbor_array, cbor_bool, cbor_bytes, cbor_int, cbor_map, cbor_text};
 
     #[test]
-    fn test_key_type_ordering() {
-        assert!(cbor_key_int!(0) < cbor_key_int!(23));
-        assert!(cbor_key_int!(23) < cbor_key_int!(24));
-        assert!(cbor_key_int!(24) < cbor_key_int!(1000));
-        assert!(cbor_key_int!(1000) < cbor_key_int!(1000000));
-        assert!(cbor_key_int!(1000000) < cbor_key_int!(std::i64::MAX));
-        assert!(cbor_key_int!(std::i64::MAX) < cbor_key_int!(-1));
-        assert!(cbor_key_int!(-1) < cbor_key_int!(-23));
-        assert!(cbor_key_int!(-23) < cbor_key_int!(-24));
-        assert!(cbor_key_int!(-24) < cbor_key_int!(-1000));
-        assert!(cbor_key_int!(-1000) < cbor_key_int!(-1000000));
-        assert!(cbor_key_int!(-1000000) < cbor_key_int!(std::i64::MIN));
-        assert!(cbor_key_int!(std::i64::MIN) < cbor_key_bytes!(vec![]));
-        assert!(cbor_key_bytes!(vec![]) < cbor_key_bytes!(vec![0x00]));
-        assert!(cbor_key_bytes!(vec![0x00]) < cbor_key_bytes!(vec![0x01]));
-        assert!(cbor_key_bytes!(vec![0x01]) < cbor_key_bytes!(vec![0xFF]));
-        assert!(cbor_key_bytes!(vec![0xFF]) < cbor_key_bytes!(vec![0x00, 0x00]));
-        assert!(cbor_key_bytes!(vec![0x00, 0x00]) < cbor_key_text!(""));
-        assert!(cbor_key_text!("") < cbor_key_text!("a"));
-        assert!(cbor_key_text!("a") < cbor_key_text!("b"));
-        assert!(cbor_key_text!("b") < cbor_key_text!("aa"));
-        assert!(cbor_key_int!(1) < cbor_key_bytes!(vec![0x00]));
-        assert!(cbor_key_int!(1) < cbor_key_text!("s"));
-        assert!(cbor_key_int!(-1) < cbor_key_text!("s"));
+    fn test_value_ordering() {
+        assert!(cbor_int!(0) < cbor_int!(23));
+        assert!(cbor_int!(23) < cbor_int!(24));
+        assert!(cbor_int!(24) < cbor_int!(1000));
+        assert!(cbor_int!(1000) < cbor_int!(1000000));
+        assert!(cbor_int!(1000000) < cbor_int!(std::i64::MAX));
+        assert!(cbor_int!(std::i64::MAX) < cbor_int!(-1));
+        assert!(cbor_int!(-1) < cbor_int!(-23));
+        assert!(cbor_int!(-23) < cbor_int!(-24));
+        assert!(cbor_int!(-24) < cbor_int!(-1000));
+        assert!(cbor_int!(-1000) < cbor_int!(-1000000));
+        assert!(cbor_int!(-1000000) < cbor_int!(std::i64::MIN));
+        assert!(cbor_int!(std::i64::MIN) < cbor_bytes!(vec![]));
+        assert!(cbor_bytes!(vec![]) < cbor_bytes!(vec![0x00]));
+        assert!(cbor_bytes!(vec![0x00]) < cbor_bytes!(vec![0x01]));
+        assert!(cbor_bytes!(vec![0x01]) < cbor_bytes!(vec![0xFF]));
+        assert!(cbor_bytes!(vec![0xFF]) < cbor_bytes!(vec![0x00, 0x00]));
+        assert!(cbor_bytes!(vec![0x00, 0x00]) < cbor_text!(""));
+        assert!(cbor_text!("") < cbor_text!("a"));
+        assert!(cbor_text!("a") < cbor_text!("b"));
+        assert!(cbor_text!("b") < cbor_text!("aa"));
+        assert!(cbor_text!("aa") < cbor_array![]);
+        assert!(cbor_array![] < cbor_array![0]);
+        assert!(cbor_array![0] < cbor_array![-1]);
+        assert!(cbor_array![1] < cbor_array![b""]);
+        assert!(cbor_array![b""] < cbor_array![""]);
+        assert!(cbor_array![""] < cbor_array![cbor_array![]]);
+        assert!(cbor_array![cbor_array![]] < cbor_array![cbor_map! {}]);
+        assert!(cbor_array![cbor_map! {}] < cbor_array![false]);
+        assert!(cbor_array![false] < cbor_array![0, 0]);
+        assert!(cbor_array![0, 0] < cbor_map! {});
+        assert!(cbor_map! {} < cbor_map! {0 => 0});
+        assert!(cbor_map! {0 => 0} < cbor_map! {0 => 1});
+        assert!(cbor_map! {0 => 1} < cbor_map! {1 => 0});
+        assert!(cbor_map! {1 => 0} < cbor_map! {-1 => 0});
+        assert!(cbor_map! {-1 => 0} < cbor_map! {b"" => 0});
+        assert!(cbor_map! {b"" => 0} < cbor_map! {"" => 0});
+        assert!(cbor_map! {"" => 0} < cbor_map! {cbor_array![] => 0});
+        assert!(cbor_map! {cbor_array![] => 0} < cbor_map! {cbor_map!{} => 0});
+        assert!(cbor_map! {cbor_map!{} => 0} < cbor_map! {false => 0});
+        assert!(cbor_map! {false => 0} < cbor_map! {0 => 0, 0 => 0});
+        assert!(cbor_map! {0 => 0, 0 => 0} < cbor_bool!(false));
+        assert!(cbor_bool!(false) < cbor_bool!(true));
+        assert!(cbor_bool!(true) < Value::Simple(SimpleValue::NullValue));
+        assert!(Value::Simple(SimpleValue::NullValue) < Value::Simple(SimpleValue::Undefined));
+        assert!(cbor_int!(1) < cbor_bytes!(vec![0x00]));
+        assert!(cbor_int!(1) < cbor_text!("s"));
+        assert!(cbor_int!(1) < cbor_array![]);
+        assert!(cbor_int!(1) < cbor_map! {});
+        assert!(cbor_int!(1) < cbor_bool!(false));
+        assert!(cbor_int!(-1) < cbor_text!("s"));
+        assert!(cbor_int!(-1) < cbor_array![]);
+        assert!(cbor_int!(-1) < cbor_map! {});
+        assert!(cbor_int!(-1) < cbor_bool!(false));
+        assert!(cbor_bytes!(vec![0x00]) < cbor_array![]);
+        assert!(cbor_bytes!(vec![0x00]) < cbor_map! {});
+        assert!(cbor_bytes!(vec![0x00]) < cbor_bool!(false));
+        assert!(cbor_text!("s") < cbor_map! {});
+        assert!(cbor_text!("s") < cbor_bool!(false));
+        assert!(cbor_array![] < cbor_bool!(false));
     }
 }

--- a/libraries/cbor/src/values.rs
+++ b/libraries/cbor/src/values.rs
@@ -69,6 +69,8 @@ impl Value {
     }
 
     pub fn type_label(&self) -> u8 {
+        // TODO use enum discriminant instead when stable
+        // https://github.com/rust-lang/rust/issues/60553
         match self {
             Value::Unsigned(_) => 0,
             Value::Negative(_) => 1,

--- a/libraries/cbor/src/writer.rs
+++ b/libraries/cbor/src/writer.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::values::{Constants, KeyType, Value};
+use super::values::{Constants, Value};
 use alloc::vec::Vec;
 
 pub fn write(value: Value, encoded_cbor: &mut Vec<u8>) -> bool {
@@ -36,15 +36,13 @@ impl<'a> Writer<'a> {
             return false;
         }
         match value {
-            Value::KeyValue(KeyType::Unsigned(unsigned)) => self.start_item(0, unsigned),
-            Value::KeyValue(KeyType::Negative(negative)) => {
-                self.start_item(1, -(negative + 1) as u64)
-            }
-            Value::KeyValue(KeyType::ByteString(byte_string)) => {
+            Value::Unsigned(unsigned) => self.start_item(0, unsigned),
+            Value::Negative(negative) => self.start_item(1, -(negative + 1) as u64),
+            Value::ByteString(byte_string) => {
                 self.start_item(2, byte_string.len() as u64);
                 self.encoded_cbor.extend(byte_string);
             }
-            Value::KeyValue(KeyType::TextString(text_string)) => {
+            Value::TextString(text_string) => {
                 self.start_item(3, text_string.len() as u64);
                 self.encoded_cbor.extend(text_string.into_bytes());
             }
@@ -65,7 +63,7 @@ impl<'a> Writer<'a> {
                 }
                 self.start_item(5, map_len as u64);
                 for (k, v) in map {
-                    if !self.encode_cbor(Value::KeyValue(k), remaining_depth - 1) {
+                    if !self.encode_cbor(k, remaining_depth - 1) {
                         return false;
                     }
                     if !self.encode_cbor(v, remaining_depth - 1) {

--- a/libraries/cbor/src/writer.rs
+++ b/libraries/cbor/src/writer.rs
@@ -35,19 +35,20 @@ impl<'a> Writer<'a> {
         if remaining_depth < 0 {
             return false;
         }
+        let type_label = value.type_label();
         match value {
-            Value::Unsigned(unsigned) => self.start_item(0, unsigned),
-            Value::Negative(negative) => self.start_item(1, -(negative + 1) as u64),
+            Value::Unsigned(unsigned) => self.start_item(type_label, unsigned),
+            Value::Negative(negative) => self.start_item(type_label, -(negative + 1) as u64),
             Value::ByteString(byte_string) => {
-                self.start_item(2, byte_string.len() as u64);
+                self.start_item(type_label, byte_string.len() as u64);
                 self.encoded_cbor.extend(byte_string);
             }
             Value::TextString(text_string) => {
-                self.start_item(3, text_string.len() as u64);
+                self.start_item(type_label, text_string.len() as u64);
                 self.encoded_cbor.extend(text_string.into_bytes());
             }
             Value::Array(array) => {
-                self.start_item(4, array.len() as u64);
+                self.start_item(type_label, array.len() as u64);
                 for el in array {
                     if !self.encode_cbor(el, remaining_depth - 1) {
                         return false;
@@ -61,7 +62,7 @@ impl<'a> Writer<'a> {
                 if map_len != map.len() {
                     return false;
                 }
-                self.start_item(5, map_len as u64);
+                self.start_item(type_label, map_len as u64);
                 for (k, v) in map {
                     if !self.encode_cbor(k, remaining_depth - 1) {
                         return false;
@@ -71,7 +72,7 @@ impl<'a> Writer<'a> {
                     }
                 }
             }
-            Value::Simple(simple_value) => self.start_item(7, simple_value as u64),
+            Value::Simple(simple_value) => self.start_item(type_label, simple_value as u64),
         }
         true
     }

--- a/src/ctap/data_formats.rs
+++ b/src/ctap/data_formats.rs
@@ -586,8 +586,8 @@ enum PublicKeyCredentialSourceField {
     // - CredRandom = 5,
 }
 
-impl From<PublicKeyCredentialSourceField> for cbor::KeyType {
-    fn from(field: PublicKeyCredentialSourceField) -> cbor::KeyType {
+impl From<PublicKeyCredentialSourceField> for cbor::Value {
+    fn from(field: PublicKeyCredentialSourceField) -> cbor::Value {
         (field as u64).into()
     }
 }
@@ -1076,35 +1076,35 @@ impl From<CredentialManagementSubCommandParameters> for cbor::Value {
 
 pub(super) fn extract_unsigned(cbor_value: cbor::Value) -> Result<u64, Ctap2StatusCode> {
     match cbor_value {
-        cbor::Value::KeyValue(cbor::KeyType::Unsigned(unsigned)) => Ok(unsigned),
+        cbor::Value::Unsigned(unsigned) => Ok(unsigned),
         _ => Err(Ctap2StatusCode::CTAP2_ERR_CBOR_UNEXPECTED_TYPE),
     }
 }
 
 pub(super) fn extract_integer(cbor_value: cbor::Value) -> Result<i64, Ctap2StatusCode> {
     match cbor_value {
-        cbor::Value::KeyValue(cbor::KeyType::Unsigned(unsigned)) => {
+        cbor::Value::Unsigned(unsigned) => {
             if unsigned <= core::i64::MAX as u64 {
                 Ok(unsigned as i64)
             } else {
                 Err(Ctap2StatusCode::CTAP2_ERR_CBOR_UNEXPECTED_TYPE)
             }
         }
-        cbor::Value::KeyValue(cbor::KeyType::Negative(signed)) => Ok(signed),
+        cbor::Value::Negative(signed) => Ok(signed),
         _ => Err(Ctap2StatusCode::CTAP2_ERR_CBOR_UNEXPECTED_TYPE),
     }
 }
 
 pub fn extract_byte_string(cbor_value: cbor::Value) -> Result<Vec<u8>, Ctap2StatusCode> {
     match cbor_value {
-        cbor::Value::KeyValue(cbor::KeyType::ByteString(byte_string)) => Ok(byte_string),
+        cbor::Value::ByteString(byte_string) => Ok(byte_string),
         _ => Err(Ctap2StatusCode::CTAP2_ERR_CBOR_UNEXPECTED_TYPE),
     }
 }
 
 pub(super) fn extract_text_string(cbor_value: cbor::Value) -> Result<String, Ctap2StatusCode> {
     match cbor_value {
-        cbor::Value::KeyValue(cbor::KeyType::TextString(text_string)) => Ok(text_string),
+        cbor::Value::TextString(text_string) => Ok(text_string),
         _ => Err(Ctap2StatusCode::CTAP2_ERR_CBOR_UNEXPECTED_TYPE),
     }
 }
@@ -1118,7 +1118,7 @@ pub(super) fn extract_array(cbor_value: cbor::Value) -> Result<Vec<cbor::Value>,
 
 pub(super) fn extract_map(
     cbor_value: cbor::Value,
-) -> Result<Vec<(cbor::KeyType, cbor::Value)>, Ctap2StatusCode> {
+) -> Result<Vec<(cbor::Value, cbor::Value)>, Ctap2StatusCode> {
     match cbor_value {
         cbor::Value::Map(map) => Ok(map),
         _ => Err(Ctap2StatusCode::CTAP2_ERR_CBOR_UNEXPECTED_TYPE),
@@ -1681,7 +1681,7 @@ mod test {
 
     #[test]
     fn test_into_packed_attestation_statement() {
-        let certificate: cbor::values::KeyType = cbor_bytes![vec![0x5C, 0x5C, 0x5C, 0x5C]];
+        let certificate = cbor_bytes![vec![0x5C, 0x5C, 0x5C, 0x5C]];
         let cbor_packed_attestation_statement = cbor_map! {
             "alg" => 1,
             "sig" => vec![0x55, 0x55, 0x55, 0x55],

--- a/src/ctap/response.rs
+++ b/src/ctap/response.rs
@@ -326,7 +326,7 @@ mod test {
 
     #[test]
     fn test_make_credential_into_cbor() {
-        let certificate: cbor::values::KeyType = cbor_bytes![vec![0x5C, 0x5C, 0x5C, 0x5C]];
+        let certificate = cbor_bytes![vec![0x5C, 0x5C, 0x5C, 0x5C]];
         let att_stmt = PackedAttestationStatement {
             alg: 1,
             sig: vec![0x55, 0x55, 0x55, 0x55],


### PR DESCRIPTION
Refactors of our CBOR library to not use a separate type for map keys, but allows all major types as map keys.

This simplifies the implementation, as we don't split off `KeyType` from `Value`. Since our CBOR encodings need to be canonical, the map keys have to be sorted. We add `Array` and `Map` to our `Ord` implementation. Most other changes are trivial, removing all occurances of `KeyType` and `Value::KeyValue`.

There are differences between [CTAP2 CBOR](https://fidoalliance.org/specs/fido-v2.1-rd-20210309/fido-client-to-authenticator-protocol-v2.1-rd-20210309.html#message-encoding) and the [RFC](https://tools.ietf.org/html/rfc8949). But since CTAP only uses integers and strings as map keys, they practically don't need consideration. The implementation therefore may need to be tweaked if CTAP ever uses arrays or maps as map keys.

The binary size reduction in optimized mode is a small plus, down from 127.4 KiB to 127.1 KiB. Calculate with:
```sh
echo 'opt-level = "z"' >> Cargo.toml
cargo bloat --release --target=thumbv7em-none-eabi --features=with_ctap1
```