### PR TITLE
Binary size optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,4 @@ lto = true # Link Time Optimization usually reduces size of binaries and static 
 [profile.release]
 panic = "abort"
 lto = true # Link Time Optimization usually reduces size of binaries and static libraries
+opt-level = "z"

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -72,7 +72,7 @@ impl PersistentStore {
         let mut store = PersistentStore {
             store: persistent_store::Store::new(storage).ok().unwrap(),
         };
-        store.init(rng).unwrap();
+        store.init(rng).ok().unwrap();
         store
     }
 


### PR DESCRIPTION
TockOS already sets the compiler optimization flag to "z" to minimize its binary size. Adding it for OpenSK reduces the application size from 244.8 KiB to 127.2 KiB. This allows increasing the persistent storage size to contain more than 100 additional credentials.

The second change removes the debug format information for `ctap::status_code::Ctap2StatusCode` from the binary.

Measured with:
```sh
cargo bloat --release --target=thumbv7em-none-eabi --features=with_ctap1
```