### PR TITLE
Fix broken parsing.

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -243,6 +243,8 @@ class RemoveConstAction(argparse.Action):
     # https://github.com/python/cpython/blob/master/Lib/argparse.py#L138-L147
     # https://github.com/python/cpython/blob/master/Lib/argparse.py#L1028-L1052
     items = getattr(namespace, self.dest, [])
+    if items is None:
+      items = []
     if isinstance(items, list):
       items = items[:]
     else:
@@ -916,6 +918,8 @@ if __name__ == "__main__":
       help=("When set, the output of elf2tab is appended to this file."),
   )
 
+  main_parser.set_defaults(features=["with_ctap1"])
+
   # Start parsing to know if we're going to list things or not.
   partial_args, _ = main_parser.parse_known_args()
 
@@ -976,7 +980,5 @@ if __name__ == "__main__":
       const="nfct_test",
       help=("Compiles and installs the nfct_test example that tests the "
             "NFC driver."))
-
-  main_parser.set_defaults(features=["with_ctap1"])
 
   main(main_parser.parse_args())

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -107,7 +107,7 @@ def main(args):
 
     cert = x509.load_pem_x509_certificate(args.certificate.read())
     # Some sanity/validity checks
-    now = datetime.datetime.now()
+    now = datetime.datetime.utcnow()
     if cert.not_valid_before > now:
       fatal("Certificate validity starts in the future.")
     if cert.not_valid_after <= now:


### PR DESCRIPTION
By setting the default value before pre-parsing we ensure that the item
can't be None. As an extra safety the custom action also checks for
None.

Fixes #316 

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR