### PR TITLE
Rebuild on layout changes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -21,6 +21,8 @@ use uuid::Uuid;
 
 fn main() {
     println!("cargo:rerun-if-changed=crypto_data/aaguid.txt");
+    println!("cargo:rerun-if-changed=layout.ld");
+    println!("cargo:rerun-if-changed=nrf52840_layout.ld");
 
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let aaguid_bin_path = Path::new(&out_dir).join("opensk_aaguid.bin");


### PR DESCRIPTION
With the current setup, changes in `layout.ld`  and `nrf52840_layout.ld` do not trigger a rebuild. If you forget to `cargo clean` are otherwise trigger a rebuild after changes, you get confusing results.

[Tock already has this feature.](https://github.com/tock/tock/blob/master/boards/nordic/nrf52840dk/build.rs)
