### PR TITLE
cbor: allow user to control nesting

### DIFF
--- a/libraries/cbor/examples/cbor.rs
+++ b/libraries/cbor/examples/cbor.rs
@@ -58,10 +58,10 @@ fn main() {
 
     // Serialize to bytes.
     let mut manual_data = vec![];
-    sk_cbor::writer::write(manual_object, &mut manual_data);
+    sk_cbor::writer::write(manual_object, &mut manual_data).unwrap();
     let hex_manual_data = hexify(&manual_data);
     let mut macro_data = vec![];
-    sk_cbor::writer::write(macro_object, &mut macro_data);
+    sk_cbor::writer::write(macro_object, &mut macro_data).unwrap();
     let hex_macro_data = hexify(&macro_data);
 
     assert_eq!(hex_manual_data, hex_macro_data);

--- a/libraries/cbor/fuzz/fuzz_targets/fuzz_target_cbor.rs
+++ b/libraries/cbor/fuzz/fuzz_targets/fuzz_target_cbor.rs
@@ -8,7 +8,7 @@ use sk_cbor as cbor;
 fuzz_target!(|data: &[u8]| {
     if let Ok(value) = cbor::read(data) {
         let mut result = Vec::new();
-        assert!(cbor::write(value, &mut result));
+        assert!(cbor::write(value, &mut result).is_ok());
         assert_eq!(result, data);
     };
 });

--- a/libraries/cbor/src/values.rs
+++ b/libraries/cbor/src/values.rs
@@ -130,9 +130,9 @@ impl Ord for Value {
             (v1, v2) => {
                 // This case could handle all of the above as well. Checking individually is faster.
                 let mut encoding1 = Vec::new();
-                write(v1.clone(), &mut encoding1);
+                let _ = write(v1.clone(), &mut encoding1);
                 let mut encoding2 = Vec::new();
-                write(v2.clone(), &mut encoding2);
+                let _ = write(v2.clone(), &mut encoding2);
                 encoding1.cmp(&encoding2)
             }
         }

--- a/src/ctap/command.rs
+++ b/src/ctap/command.rs
@@ -51,12 +51,6 @@ pub enum Command {
     AuthenticatorVendorConfigure(AuthenticatorVendorConfigureParameters),
 }
 
-impl From<cbor::reader::DecoderError> for Ctap2StatusCode {
-    fn from(_: cbor::reader::DecoderError) -> Self {
-        Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR
-    }
-}
-
 impl Command {
     const AUTHENTICATOR_MAKE_CREDENTIAL: u8 = 0x01;
     const AUTHENTICATOR_GET_ASSERTION: u8 = 0x02;

--- a/src/ctap/command.rs
+++ b/src/ctap/command.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::cbor_read;
 use super::customization::{MAX_CREDENTIAL_COUNT_IN_LIST, MAX_LARGE_BLOB_ARRAY_SIZE};
 use super::data_formats::{
     extract_array, extract_bool, extract_byte_string, extract_map, extract_text_string,
@@ -82,13 +83,13 @@ impl Command {
         let command_value = bytes[0];
         match command_value {
             Command::AUTHENTICATOR_MAKE_CREDENTIAL => {
-                let decoded_cbor = cbor::read(&bytes[1..])?;
+                let decoded_cbor = cbor_read(&bytes[1..])?;
                 Ok(Command::AuthenticatorMakeCredential(
                     AuthenticatorMakeCredentialParameters::try_from(decoded_cbor)?,
                 ))
             }
             Command::AUTHENTICATOR_GET_ASSERTION => {
-                let decoded_cbor = cbor::read(&bytes[1..])?;
+                let decoded_cbor = cbor_read(&bytes[1..])?;
                 Ok(Command::AuthenticatorGetAssertion(
                     AuthenticatorGetAssertionParameters::try_from(decoded_cbor)?,
                 ))
@@ -98,7 +99,7 @@ impl Command {
                 Ok(Command::AuthenticatorGetInfo)
             }
             Command::AUTHENTICATOR_CLIENT_PIN => {
-                let decoded_cbor = cbor::read(&bytes[1..])?;
+                let decoded_cbor = cbor_read(&bytes[1..])?;
                 Ok(Command::AuthenticatorClientPin(
                     AuthenticatorClientPinParameters::try_from(decoded_cbor)?,
                 ))
@@ -112,7 +113,7 @@ impl Command {
                 Ok(Command::AuthenticatorGetNextAssertion)
             }
             Command::AUTHENTICATOR_CREDENTIAL_MANAGEMENT => {
-                let decoded_cbor = cbor::read(&bytes[1..])?;
+                let decoded_cbor = cbor_read(&bytes[1..])?;
                 Ok(Command::AuthenticatorCredentialManagement(
                     AuthenticatorCredentialManagementParameters::try_from(decoded_cbor)?,
                 ))
@@ -122,19 +123,19 @@ impl Command {
                 Ok(Command::AuthenticatorSelection)
             }
             Command::AUTHENTICATOR_LARGE_BLOBS => {
-                let decoded_cbor = cbor::read(&bytes[1..])?;
+                let decoded_cbor = cbor_read(&bytes[1..])?;
                 Ok(Command::AuthenticatorLargeBlobs(
                     AuthenticatorLargeBlobsParameters::try_from(decoded_cbor)?,
                 ))
             }
             Command::AUTHENTICATOR_CONFIG => {
-                let decoded_cbor = cbor::read(&bytes[1..])?;
+                let decoded_cbor = cbor_read(&bytes[1..])?;
                 Ok(Command::AuthenticatorConfig(
                     AuthenticatorConfigParameters::try_from(decoded_cbor)?,
                 ))
             }
             Command::AUTHENTICATOR_VENDOR_CONFIGURE => {
-                let decoded_cbor = cbor::read(&bytes[1..])?;
+                let decoded_cbor = cbor_read(&bytes[1..])?;
                 Ok(Command::AuthenticatorVendorConfigure(
                     AuthenticatorVendorConfigureParameters::try_from(decoded_cbor)?,
                 ))

--- a/src/ctap/config_command.rs
+++ b/src/ctap/config_command.rs
@@ -99,9 +99,7 @@ pub fn process_config(
         let mut config_data = vec![0xFF; 32];
         config_data.extend(&[0x0D, sub_command as u8]);
         if let Some(sub_command_params) = sub_command_params.clone() {
-            if super::cbor_write(sub_command_params.into(), &mut config_data).is_err() {
-                return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
-            }
+            super::cbor_write(sub_command_params.into(), &mut config_data)?;
         }
         client_pin.verify_pin_uv_auth_token(
             &config_data,

--- a/src/ctap/config_command.rs
+++ b/src/ctap/config_command.rs
@@ -20,7 +20,6 @@ use super::response::ResponseData;
 use super::status_code::Ctap2StatusCode;
 use super::storage::PersistentStore;
 use alloc::vec;
-use sk_cbor as cbor;
 
 /// Processes the subcommand enableEnterpriseAttestation for AuthenticatorConfig.
 fn process_enable_enterprise_attestation(
@@ -100,7 +99,7 @@ pub fn process_config(
         let mut config_data = vec![0xFF; 32];
         config_data.extend(&[0x0D, sub_command as u8]);
         if let Some(sub_command_params) = sub_command_params.clone() {
-            if !cbor::write(sub_command_params.into(), &mut config_data) {
+            if super::cbor_write(sub_command_params.into(), &mut config_data).is_err() {
                 return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
             }
         }

--- a/src/ctap/credential_management.rs
+++ b/src/ctap/credential_management.rs
@@ -30,7 +30,6 @@ use alloc::vec::Vec;
 use crypto::sha256::Sha256;
 use crypto::Hash256;
 use libtock_drivers::timer::ClockValue;
-use sk_cbor as cbor;
 
 /// Generates a set with all existing RP IDs.
 fn get_stored_rp_ids(
@@ -289,7 +288,7 @@ pub fn process_credential_management(
                 pin_uv_auth_protocol.ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?;
             let mut management_data = vec![sub_command as u8];
             if let Some(sub_command_params) = sub_command_params.clone() {
-                if !cbor::write(sub_command_params.into(), &mut management_data) {
+                if super::cbor_write(sub_command_params.into(), &mut management_data).is_err() {
                     return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
                 }
             }

--- a/src/ctap/credential_management.rs
+++ b/src/ctap/credential_management.rs
@@ -288,9 +288,7 @@ pub fn process_credential_management(
                 pin_uv_auth_protocol.ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?;
             let mut management_data = vec![sub_command as u8];
             if let Some(sub_command_params) = sub_command_params.clone() {
-                if super::cbor_write(sub_command_params.into(), &mut management_data).is_err() {
-                    return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
-                }
+                super::cbor_write(sub_command_params.into(), &mut management_data)?;
             }
             client_pin.verify_pin_uv_auth_token(
                 &management_data,

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -727,11 +727,8 @@ fn deserialize_credential(data: &[u8]) -> Option<PublicKeyCredentialSource> {
 /// Serializes a credential to storage representation.
 fn serialize_credential(credential: PublicKeyCredentialSource) -> Result<Vec<u8>, Ctap2StatusCode> {
     let mut data = Vec::new();
-    if super::cbor_write(credential.into(), &mut data).is_ok() {
-        Ok(data)
-    } else {
-        Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)
-    }
+    super::cbor_write(credential.into(), &mut data)?;
+    Ok(data)
 }
 
 /// Deserializes a list of RP IDs from storage representation.
@@ -748,11 +745,8 @@ fn deserialize_min_pin_length_rp_ids(data: &[u8]) -> Option<Vec<String>> {
 /// Serializes a list of RP IDs to storage representation.
 fn serialize_min_pin_length_rp_ids(rp_ids: Vec<String>) -> Result<Vec<u8>, Ctap2StatusCode> {
     let mut data = Vec::new();
-    if super::cbor_write(cbor_array_vec!(rp_ids), &mut data).is_ok() {
-        Ok(data)
-    } else {
-        Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)
-    }
+    super::cbor_write(cbor_array_vec!(rp_ids), &mut data)?;
+    Ok(data)
 }
 
 #[cfg(test)]

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -36,7 +36,6 @@ use core::cmp;
 use core::convert::TryInto;
 use crypto::rng256::Rng256;
 use persistent_store::{fragment, StoreUpdate};
-use sk_cbor as cbor;
 use sk_cbor::cbor_array_vec;
 
 /// Wrapper for master keys.
@@ -721,14 +720,14 @@ impl<'a> Iterator for IterCredentials<'a> {
 
 /// Deserializes a credential from storage representation.
 fn deserialize_credential(data: &[u8]) -> Option<PublicKeyCredentialSource> {
-    let cbor = cbor::read(data).ok()?;
+    let cbor = super::cbor_read(data).ok()?;
     cbor.try_into().ok()
 }
 
 /// Serializes a credential to storage representation.
 fn serialize_credential(credential: PublicKeyCredentialSource) -> Result<Vec<u8>, Ctap2StatusCode> {
     let mut data = Vec::new();
-    if cbor::write(credential.into(), &mut data) {
+    if super::cbor_write(credential.into(), &mut data).is_ok() {
         Ok(data)
     } else {
         Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)
@@ -737,7 +736,7 @@ fn serialize_credential(credential: PublicKeyCredentialSource) -> Result<Vec<u8>
 
 /// Deserializes a list of RP IDs from storage representation.
 fn deserialize_min_pin_length_rp_ids(data: &[u8]) -> Option<Vec<String>> {
-    let cbor = cbor::read(data).ok()?;
+    let cbor = super::cbor_read(data).ok()?;
     extract_array(cbor)
         .ok()?
         .into_iter()
@@ -749,7 +748,7 @@ fn deserialize_min_pin_length_rp_ids(data: &[u8]) -> Option<Vec<String>> {
 /// Serializes a list of RP IDs to storage representation.
 fn serialize_min_pin_length_rp_ids(rp_ids: Vec<String>) -> Result<Vec<u8>, Ctap2StatusCode> {
     let mut data = Vec::new();
-    if cbor::write(cbor_array_vec!(rp_ids), &mut data) {
+    if super::cbor_write(cbor_array_vec!(rp_ids), &mut data).is_ok() {
         Ok(data)
     } else {
         Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)


### PR DESCRIPTION
 - Make the default read/write entrypoints allow infinite nesting.
 - Add {read,write}_nested() entrypoints that allow the crate user to
   control the depth of nesting that's allowed.
 - Along the way, convert the write[_nested] variants to return a
   `Result<(), EncoderError>` rather than a bool.  This exposes
   more failure information (and forces the caller to take notice
   of those tailures), and allows use of the ? operator.