### PR TITLE
Configuration changes to reduce binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,4 @@ lto = true # Link Time Optimization usually reduces size of binaries and static 
 panic = "abort"
 lto = true # Link Time Optimization usually reduces size of binaries and static libraries
 opt-level = "z"
+codegen-units = 1

--- a/deploy.py
+++ b/deploy.py
@@ -372,6 +372,10 @@ class OpenSKInstaller:
         "-D",
         "warnings",
         "--remap-path-prefix={}=".format(os.getcwd()),
+        "-C",
+        "link-arg=-icf=all",
+        "-C",
+        "force-frame-pointers=no",
     ]
     env = os.environ.copy()
     env["RUSTFLAGS"] = " ".join(rust_flags)


### PR DESCRIPTION
Introduces 3 more configuration changes to reduce the binary size. Effect:
**127.5 KB -> 118.5 KB** (difference -9 kB)

Measurements with:
```sh
export RUSTFLAGS="-C link-arg=-icf=all -C force-frame-pointers=no"
cargo bloat --release --target=thumbv7em-none-eabi --features=with_ctap1
```

### Ablation (what if we remove one?):
| removed config           | size     | difference |
|--------------------------|----------|------------|
| `codegen-units = 1`      | 120.3 KB | 1.8 kB     |
| `-icf=all`               | 119.7 KB | 1.2 kB     |
| `force-frame-pointers=n` | 122.3 KB | 4.8 kB     |

Please note that these numbers can be probabilistic.

### In-depth explanation
(see [Tock issue](https://github.com/tock/tock/issues/1663)):

#### `codegen-units = 1`
By default, Cargo uses 16 codegen units for each crate and LLVM processes them in parallel. This speeds up compilation but prevents LLVM from applying some optimizations which have to look at all of the units at once.

#### `-icf=all`
The `-icf=all` linker parameter allows to more aggressively merge identical code. A side-effect is that functions with an identical code can now have the same address in memory (contrary to `-icf=safe`), which can break function pointer comparison.

#### `force-frame-pointers=n`
Removes frame pointers when possible.
