### PR TITLE
CBOR annotations for crates.io

### DIFF
--- a/libraries/cbor/Cargo.toml
+++ b/libraries/cbor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sk-cbor"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
   "Fabian Kaczmarczyck <kaczmarczyck@google.com>",
   "Guillaume Endignoux <guillaumee@google.com>",
@@ -14,5 +14,9 @@ homepage = "https://github.com/google/OpenSK"
 repository = "https://github.com/google/OpenSK"
 keywords = ["cbor", "serialization", "no_std"]
 categories = ["encoding"]
+readme = "README.md"
+
+[badges]
+maintenance = { status = "passively-maintained" }
 
 [dependencies]

--- a/libraries/cbor/README.md
+++ b/libraries/cbor/README.md
@@ -1,5 +1,11 @@
 # CBOR Parsing Library
 
+[![crates.io](https://img.shields.io/crates/d/sk-cbor.svg)](https://crates.io/crates/sk-cbor)
+[![crates.io](https://img.shields.io/crates/v/sk-cbor.svg)](https://crates.io/crates/sk-cbor)
+[![docs.rs](https://docs.rs/sk-cbor/badge.svg)](https://docs.rs/sk-cbor)
+[![License](https://img.shields.io/crates/l/sk-cbor.svg)](https://crates.io/crates/sk-cbor)
+[![Maintenance](https://img.shields.io/maintenance/yes/2021)](https://crates.io/crates/sk-cbor)
+
 This crate implements Concise Binary Object Representation (CBOR) from [RFC
 8949](https://datatracker.ietf.org/doc/html/rfc8949).
 


### PR DESCRIPTION
This is a small fix to add some annotations to `Cargo.toml`. The default `README.md` seems not to be read by crates.io for our project.