### PR TITLE
Storage locations to prepare upgrades

### DIFF
--- a/patches/tock/07-upgrade-partitions.patch
+++ b/patches/tock/07-upgrade-partitions.patch
@@ -1,0 +1,92 @@
+diff --git a/boards/nordic/nrf52840_dongle_opensk/src/main.rs b/boards/nordic/nrf52840_dongle_opensk/src/main.rs
+index 051943867..e38898c3b 100644
+--- a/boards/nordic/nrf52840_dongle_opensk/src/main.rs
++++ b/boards/nordic/nrf52840_dongle_opensk/src/main.rs
+@@ -64,6 +64,7 @@ static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROC
+ static mut STORAGE_LOCATIONS: [kernel::StorageLocation; 1] = [kernel::StorageLocation {
+     address: 0xC0000,
+     size: 0x40000,
++    storage_type: kernel::StorageType::STORE,
+ }];
+ 
+ // Static reference to chip for panic dumps
+diff --git a/boards/nordic/nrf52840_mdk_dfu/src/main.rs b/boards/nordic/nrf52840_mdk_dfu/src/main.rs
+index daaeaedc7..c4b0afee9 100644
+--- a/boards/nordic/nrf52840_mdk_dfu/src/main.rs
++++ b/boards/nordic/nrf52840_mdk_dfu/src/main.rs
+@@ -59,6 +59,7 @@ static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROC
+ static mut STORAGE_LOCATIONS: [kernel::StorageLocation; 1] = [kernel::StorageLocation {
+     address: 0xC0000,
+     size: 0x40000,
++    storage_type: kernel::StorageType::STORE,
+ }];
+ 
+ // Static reference to chip for panic dumps
+diff --git a/boards/nordic/nrf52840dk_opensk/src/main.rs b/boards/nordic/nrf52840dk_opensk/src/main.rs
+index 7898562dd..2443cae8a 100644
+--- a/boards/nordic/nrf52840dk_opensk/src/main.rs
++++ b/boards/nordic/nrf52840dk_opensk/src/main.rs
+@@ -128,6 +128,7 @@ static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROC
+ static mut STORAGE_LOCATIONS: [kernel::StorageLocation; 1] = [kernel::StorageLocation {
+     address: 0xC0000,
+     size: 0x40000,
++    storage_type: kernel::StorageType::STORE,
+ }];
+ 
+ static mut CHIP: Option<&'static nrf52840::chip::Chip> = None;
+diff --git a/kernel/src/lib.rs b/kernel/src/lib.rs
+index 428d90c29..2109a207e 100644
+--- a/kernel/src/lib.rs
++++ b/kernel/src/lib.rs
+@@ -123,7 +123,7 @@ pub use crate::sched::cooperative::{CoopProcessNode, CooperativeSched};
+ pub use crate::sched::mlfq::{MLFQProcessNode, MLFQSched};
+ pub use crate::sched::priority::PrioritySched;
+ pub use crate::sched::round_robin::{RoundRobinProcessNode, RoundRobinSched};
+-pub use crate::sched::{Kernel, Scheduler, StorageLocation};
++pub use crate::sched::{Kernel, Scheduler, StorageLocation, StorageType};
+ 
+ // Export only select items from the process module. To remove the name conflict
+ // this cannot be called `process`, so we use a shortened version. These
+diff --git a/kernel/src/memop.rs b/kernel/src/memop.rs
+index 5465c95f4..e596648f7 100644
+--- a/kernel/src/memop.rs
++++ b/kernel/src/memop.rs
+@@ -127,6 +127,14 @@ pub(crate) fn memop(process: &dyn ProcessType, op_type: usize, r1: usize) -> Ret
+             }
+         }
+ 
++        // Op Type 15: The type of the storage location indexed by r1.
++        15 => {
++            match process.get_storage_location(r1) {
++                None => ReturnCode::FAIL,
++                Some(x) => ReturnCode::SuccessWithValue { value: x.storage_type as usize }
++            }
++        }
++
+         _ => ReturnCode::ENOSUPPORT,
+     }
+ }
+diff --git a/kernel/src/sched.rs b/kernel/src/sched.rs
+index f109960d3..9eaf98585 100644
+--- a/kernel/src/sched.rs
++++ b/kernel/src/sched.rs
+@@ -118,10 +118,19 @@ pub enum SchedulingDecision {
+     TrySleep,
+ }
+ 
++/// Represents the type of a storage slice.
++#[derive(Copy, Clone)]
++pub enum StorageType {
++    STORE = 1,
++    PARTITION = 2,
++    METADATA = 3,
++}
++
+ /// Represents a storage location in flash.
+ pub struct StorageLocation {
+     pub address: usize,
+     pub size: usize,
++    pub storage_type: StorageType,
+ }
+ 
+ /// Main object for the kernel. Each board will need to create one.

--- a/src/embedded_flash/syscall.rs
+++ b/src/embedded_flash/syscall.rs
@@ -38,6 +38,11 @@ mod memop_nr {
     pub const STORAGE_CNT: u32 = 12;
     pub const STORAGE_PTR: u32 = 13;
     pub const STORAGE_LEN: u32 = 14;
+    pub const STORAGE_TYPE: u32 = 15;
+}
+
+mod storage_type {
+    pub const STORE: usize = 1;
 }
 
 fn get_info(nr: usize, arg: usize) -> StorageResult<usize> {
@@ -91,6 +96,9 @@ impl SyscallStorage {
             return Err(StorageError::CustomError);
         }
         for i in 0..memop(memop_nr::STORAGE_CNT, 0)? {
+            if memop(memop_nr::STORAGE_TYPE, i)? != storage_type::STORE {
+                continue;
+            }
             let storage_ptr = memop(memop_nr::STORAGE_PTR, i)?;
             let max_storage_len = memop(memop_nr::STORAGE_LEN, i)?;
             if !syscall.is_page_aligned(storage_ptr) || !syscall.is_page_aligned(max_storage_len) {


### PR DESCRIPTION
This patch adds the kernel changes required to access a potential second partition in the storage. All it requires is adding more `StorageLocations` to the board's `main.rs`.
I can merge this patch with the persistent storage if desired, but this should be easier to review.