### PR TITLE
Interface to syscalls to partition location types

### DIFF
--- a/src/embedded_flash/buffer_upgrade.rs
+++ b/src/embedded_flash/buffer_upgrade.rs
@@ -1,0 +1,74 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::helper::ModRange;
+use super::upgrade_storage::UpgradeStorage;
+use alloc::boxed::Box;
+use persistent_store::{StorageError, StorageResult};
+
+const PARTITION_START: usize = 0x20000;
+const PARTITION_LENGTH: usize = 0x40000;
+const METADATA_LENGTH: usize = 0x1000;
+
+pub struct BufferUpgradeStorage {
+    /// Content of the partition storage.
+    partition: Box<[u8]>,
+
+    /// Content of the metadata storage.
+    metadata: Box<[u8]>,
+}
+
+impl BufferUpgradeStorage {
+    pub fn new() -> StorageResult<BufferUpgradeStorage> {
+        Ok(BufferUpgradeStorage {
+            partition: vec![0xff; PARTITION_LENGTH].into_boxed_slice(),
+            metadata: vec![0xff; METADATA_LENGTH].into_boxed_slice(),
+        })
+    }
+}
+
+impl UpgradeStorage for BufferUpgradeStorage {
+    fn read_partition(&self, offset: usize, length: usize) -> StorageResult<&[u8]> {
+        let partition_range = ModRange::new(PARTITION_START, self.partition.len());
+        if partition_range.contains_range(&ModRange::new(offset, length)) {
+            Ok(&self.partition[offset - PARTITION_START..][..length])
+        } else {
+            Err(StorageError::OutOfBounds)
+        }
+    }
+
+    fn write_partition(&mut self, offset: usize, data: &[u8]) -> StorageResult<()> {
+        let partition_range = ModRange::new(PARTITION_START, self.partition.len());
+        if partition_range.contains_range(&ModRange::new(offset, data.len())) {
+            self.partition[offset - PARTITION_START..][..data.len()].copy_from_slice(data);
+            Ok(())
+        } else {
+            Err(StorageError::OutOfBounds)
+        }
+    }
+
+    fn read_metadata(&self) -> StorageResult<&[u8]> {
+        Ok(&self.metadata[..])
+    }
+
+    fn write_metadata(&mut self, data: &[u8]) -> StorageResult<()> {
+        if data.len() <= METADATA_LENGTH {
+            self.metadata.copy_from_slice(&[0xff; METADATA_LENGTH]);
+            self.metadata[..data.len()].copy_from_slice(data);
+            Ok(())
+        } else {
+            Err(StorageError::NotAligned)
+        }
+    }
+}

--- a/src/embedded_flash/helper.rs
+++ b/src/embedded_flash/helper.rs
@@ -118,19 +118,13 @@ impl ModRange {
     }
 
     /// Returns an iterator for all contained numbers that are divisible by the modulus.
-    ///
-    /// Be aware that `usize::MAX` is a special case for simplicity. It is never in the returned
-    /// iterator, even when divisible by `modulus` and contained in the range.
     pub fn aligned_iter(&self, modulus: usize) -> impl Iterator<Item = usize> {
-        let remainder = self.start % modulus;
-        // Saturating first and limit in case they are usize::MAX.
-        let first = if remainder == 0 {
-            self.start
-        } else {
-            (self.start - remainder).saturating_add(modulus)
-        };
-        let limit = self.start.saturating_add(self.length);
-        (first..limit).step_by(modulus)
+        (self.start..=usize::MAX)
+            .take(self.length)
+            // Skip the minimum number of elements to align.
+            .skip((modulus - self.start % modulus) % modulus)
+            // Only return aligned elements.
+            .step_by(modulus)
     }
 }
 

--- a/src/embedded_flash/helper.rs
+++ b/src/embedded_flash/helper.rs
@@ -111,9 +111,6 @@ impl ModRange {
     ///
     /// Mathematically, we calculate whether: `self ∩ range = range`.
     pub fn contains_range(&self, range: &ModRange) -> bool {
-        if range.is_empty() {
-            return true;
-        }
         range.is_empty()
             || (self.start <= range.start
                 && range.length <= self.length

--- a/src/embedded_flash/helper.rs
+++ b/src/embedded_flash/helper.rs
@@ -1,0 +1,118 @@
+// Copyright 2019-2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::ops::RangeInclusive;
+use persistent_store::{StorageError, StorageResult};
+
+/// Returns a slice from a list of slices that contains the interval [start, start+length).
+pub fn find_slice<'a>(
+    slices: &'a [&'a [u8]],
+    mut start: usize,
+    length: usize,
+) -> StorageResult<&'a [u8]> {
+    for slice in slices {
+        if start >= slice.len() {
+            start -= slice.len();
+            continue;
+        }
+        if start + length > slice.len() {
+            break;
+        }
+        return Ok(&slice[start..][..length]);
+    }
+    Err(StorageError::OutOfBounds)
+}
+
+/// Checks whether the address is aligned with the block_size.
+///
+/// Requires block_size to be a power of two.
+pub fn is_aligned(block_size: usize, address: usize) -> bool {
+    address & (block_size - 1) == 0
+}
+
+/// Returns a range object.
+///
+/// If the range contains indices outside of usize, it returns an empty range.
+#[allow(clippy::reversed_empty_ranges)]
+pub fn create_range(ptr: usize, len: usize) -> RangeInclusive<usize> {
+    if len == 0 {
+        return 1..=0;
+    }
+    if let Some(end) = ptr.checked_add(len - 1) {
+        ptr..=end
+    } else {
+        1..=0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_slice_ok() {
+        assert_eq!(
+            find_slice(&[&[1, 2, 3, 4]], 0, 4).ok(),
+            Some(&[1u8, 2, 3, 4] as &[u8])
+        );
+        assert_eq!(
+            find_slice(&[&[1, 2, 3, 4], &[5, 6]], 1, 2).ok(),
+            Some(&[2u8, 3] as &[u8])
+        );
+        assert_eq!(
+            find_slice(&[&[1, 2, 3, 4], &[5, 6]], 4, 2).ok(),
+            Some(&[5u8, 6] as &[u8])
+        );
+        assert_eq!(
+            find_slice(&[&[1, 2, 3, 4], &[5, 6]], 4, 0).ok(),
+            Some(&[] as &[u8])
+        );
+        assert!(find_slice(&[], 0, 1).is_err());
+        assert!(find_slice(&[&[1, 2, 3, 4], &[5, 6]], 6, 0).is_err());
+        assert!(find_slice(&[&[1, 2, 3, 4], &[5, 6]], 3, 2).is_err());
+    }
+
+    #[test]
+    fn alignment() {
+        for exponent in 0..8 {
+            let block_size = 1 << exponent;
+            for i in 0..10 {
+                assert!(is_aligned(block_size, block_size * i));
+            }
+            for i in 1..block_size {
+                assert!(!is_aligned(block_size, block_size + i));
+            }
+        }
+    }
+
+    #[test]
+    fn partition_slice_contains() {
+        let ptr = 0x200;
+        let len = 0x100;
+        let range = create_range(ptr, len);
+        assert!(!range.contains(&0x300));
+        for i in ptr..ptr + len {
+            assert!(range.contains(&i));
+        }
+        for i in ptr - len..ptr {
+            assert!(!range.contains(&i));
+        }
+        for i in ptr + len..ptr + 2 * len {
+            assert!(!range.contains(&i));
+        }
+        assert!(!create_range(0, 0).contains(&0));
+        assert!(create_range(usize::MAX, 1).contains(&usize::MAX));
+        assert!(!create_range(usize::MAX, 2).contains(&usize::MAX));
+    }
+}

--- a/src/embedded_flash/mod.rs
+++ b/src/embedded_flash/mod.rs
@@ -42,11 +42,10 @@ pub use self::prod::{new_storage, Storage, UpgradeLocations};
 mod test {
     use super::buffer_upgrade::BufferUpgradeStorage;
 
-    const PAGE_SIZE: usize = 0x1000;
-
     pub type Storage = persistent_store::BufferStorage;
 
     pub fn new_storage(num_pages: usize) -> Storage {
+        const PAGE_SIZE: usize = 0x1000;
         let store = vec![0xff; num_pages * PAGE_SIZE].into_boxed_slice();
         let options = persistent_store::BufferOptions {
             word_size: 4,

--- a/src/embedded_flash/mod.rs
+++ b/src/embedded_flash/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(any(test, not(feature = "std")))]
+mod helper;
 #[cfg(not(feature = "std"))]
 mod syscall;
 
@@ -32,7 +34,7 @@ pub use self::prod::{new_storage, Storage};
 
 /// Partition definition for production.
 #[cfg(not(feature = "std"))]
-pub use self::syscall::Partition;
+pub use self::syscall::UpgradeLocations;
 
 /// Definitions for testing.
 #[cfg(feature = "std")]
@@ -60,11 +62,11 @@ mod test {
     }
 
     /// Mock implementation of a partition, only tests page alignment.
-    pub struct Partition {}
+    pub struct UpgradeLocations;
 
-    impl Partition {
-        pub fn new() -> StorageResult<Partition> {
-            Ok(Partition {})
+    impl UpgradeLocations {
+        pub fn new() -> StorageResult<UpgradeLocations> {
+            Ok(UpgradeLocations)
         }
 
         pub fn is_page_in_partition(&self, page_address: usize) -> bool {
@@ -75,8 +77,7 @@ mod test {
             is_page_aligned(page_address)
         }
 
-        #[allow(unused_mut)]
-        pub fn rewrite_page(&self, page_ptr: usize, value: &mut [u8]) -> StorageResult<()> {
+        pub fn rewrite_page(&self, page_ptr: usize, value: &[u8]) -> StorageResult<()> {
             if !is_page_aligned(page_ptr) || value.len() != PAGE_SIZE {
                 return Err(StorageError::NotAligned);
             }
@@ -88,4 +89,4 @@ mod test {
 pub use self::test::{new_storage, Storage};
 
 #[cfg(feature = "std")]
-pub use self::test::Partition;
+pub use self::test::UpgradeLocations;

--- a/src/embedded_flash/mod.rs
+++ b/src/embedded_flash/mod.rs
@@ -17,24 +17,20 @@ mod helper;
 #[cfg(not(feature = "std"))]
 mod syscall;
 
-#[cfg(not(feature = "std"))]
-pub use self::syscall::SyscallStorage;
-
-/// Storage definition for production.
+/// Definitions for production.
 #[cfg(not(feature = "std"))]
 mod prod {
-    pub type Storage = super::SyscallStorage;
+    use super::syscall::SyscallStorage;
+    pub use super::syscall::UpgradeLocations;
+
+    pub type Storage = SyscallStorage;
 
     pub fn new_storage(num_pages: usize) -> Storage {
         Storage::new(num_pages).unwrap()
     }
 }
 #[cfg(not(feature = "std"))]
-pub use self::prod::{new_storage, Storage};
-
-/// Partition definition for production.
-#[cfg(not(feature = "std"))]
-pub use self::syscall::UpgradeLocations;
+pub use self::prod::{new_storage, Storage, UpgradeLocations};
 
 /// Definitions for testing.
 #[cfg(feature = "std")]
@@ -86,7 +82,4 @@ mod test {
     }
 }
 #[cfg(feature = "std")]
-pub use self::test::{new_storage, Storage};
-
-#[cfg(feature = "std")]
-pub use self::test::UpgradeLocations;
+pub use self::test::{new_storage, Storage, UpgradeLocations};

--- a/src/embedded_flash/syscall.rs
+++ b/src/embedded_flash/syscall.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::helper::{create_range, find_slice, is_aligned};
 use alloc::vec::Vec;
+use core::ops::RangeInclusive;
 use libtock_core::syscalls;
 use persistent_store::{Storage, StorageError, StorageIndex, StorageResult};
 
@@ -61,11 +63,35 @@ fn memop(nr: u32, arg: usize) -> StorageResult<usize> {
     }
 }
 
-/// Checks whether the address is aligned with the block_size.
-///
-/// Requires block_size to be a power of two.
-fn is_aligned(block_size: usize, address: usize) -> bool {
-    address & (block_size - 1) == 0
+fn write_slice_op(ptr: usize, value: &[u8]) -> StorageResult<()> {
+    let code = unsafe {
+        syscalls::raw::allow(
+            DRIVER_NUMBER,
+            allow_nr::WRITE_SLICE,
+            // We rely on the driver not writing to the slice. This should use read-only allow
+            // when available. See https://github.com/tock/tock/issues/1274.
+            value.as_ptr() as *mut u8,
+            value.len(),
+        )
+    };
+    if code < 0 {
+        return Err(StorageError::CustomError);
+    }
+
+    let code = syscalls::command(DRIVER_NUMBER, command_nr::WRITE_SLICE, ptr, value.len());
+    if code.is_err() {
+        return Err(StorageError::CustomError);
+    }
+
+    Ok(())
+}
+
+fn erase_page_op(ptr: usize, page_length: usize) -> StorageResult<()> {
+    let code = syscalls::command(DRIVER_NUMBER, command_nr::ERASE_PAGE, ptr, page_length);
+    if code.is_err() {
+        return Err(StorageError::CustomError);
+    }
+    Ok(())
 }
 
 pub struct SyscallStorage {
@@ -100,7 +126,7 @@ impl SyscallStorage {
         };
         if !syscall.word_size.is_power_of_two()
             || !syscall.page_size.is_power_of_two()
-            || !is_aligned(syscall.word_size, syscall.page_size)
+            || !syscall.is_word_aligned(syscall.page_size)
         {
             return Err(StorageError::CustomError);
         }
@@ -110,9 +136,7 @@ impl SyscallStorage {
             }
             let storage_ptr = memop(memop_nr::STORAGE_PTR, i)?;
             let max_storage_len = memop(memop_nr::STORAGE_LEN, i)?;
-            if !is_aligned(syscall.page_size, storage_ptr)
-                || !is_aligned(syscall.page_size, max_storage_len)
-            {
+            if !syscall.is_page_aligned(storage_ptr) || !syscall.is_page_aligned(max_storage_len) {
                 return Err(StorageError::CustomError);
             }
             let storage_len = core::cmp::min(num_pages * syscall.page_size, max_storage_len);
@@ -126,6 +150,14 @@ impl SyscallStorage {
             return Err(StorageError::OutOfBounds);
         }
         Ok(syscall)
+    }
+
+    fn is_word_aligned(&self, x: usize) -> bool {
+        is_aligned(self.word_size, x)
+    }
+
+    fn is_page_aligned(&self, x: usize) -> bool {
+        is_aligned(self.page_size, x)
     }
 }
 
@@ -156,124 +188,63 @@ impl Storage for SyscallStorage {
     }
 
     fn write_slice(&mut self, index: StorageIndex, value: &[u8]) -> StorageResult<()> {
-        if !is_aligned(self.word_size, index.byte) || !is_aligned(self.word_size, value.len()) {
+        if !self.is_word_aligned(index.byte) || !self.is_word_aligned(value.len()) {
             return Err(StorageError::NotAligned);
         }
         let ptr = self.read_slice(index, value.len())?.as_ptr() as usize;
-
-        let code = unsafe {
-            syscalls::raw::allow(
-                DRIVER_NUMBER,
-                allow_nr::WRITE_SLICE,
-                // We rely on the driver not writing to the slice. This should use read-only allow
-                // when available. See https://github.com/tock/tock/issues/1274.
-                value.as_ptr() as *mut u8,
-                value.len(),
-            )
-        };
-        if code < 0 {
-            return Err(StorageError::CustomError);
-        }
-
-        let code = syscalls::command(DRIVER_NUMBER, command_nr::WRITE_SLICE, ptr, value.len());
-        if code.is_err() {
-            return Err(StorageError::CustomError);
-        }
-
-        Ok(())
+        write_slice_op(ptr, value)
     }
 
     fn erase_page(&mut self, page: usize) -> StorageResult<()> {
         let index = StorageIndex { page, byte: 0 };
         let length = self.page_size();
         let ptr = self.read_slice(index, length)?.as_ptr() as usize;
-        let code = syscalls::command(DRIVER_NUMBER, command_nr::ERASE_PAGE, ptr, length);
-        if code.is_err() {
-            return Err(StorageError::CustomError);
-        }
-        Ok(())
+        erase_page_op(ptr, length)
     }
 }
 
-fn find_slice<'a>(
-    slices: &'a [&'a [u8]],
-    mut start: usize,
-    length: usize,
-) -> StorageResult<&'a [u8]> {
-    for slice in slices {
-        if start >= slice.len() {
-            start -= slice.len();
-            continue;
-        }
-        if start + length > slice.len() {
-            break;
-        }
-        return Ok(&slice[start..][..length]);
-    }
-    Err(StorageError::OutOfBounds)
-}
-
-struct PartitionSlice {
-    pub ptr: usize,
-    pub len: usize,
-}
-
-impl PartitionSlice {
-    pub fn contains(&self, address: usize) -> bool {
-        // We want to check the 2 following inequalities:
-        // (1) `ptr <= address`
-        // (2) `address <= ptr + len`
-        // However, the second one may overflow written as is. Using (1), we rewrite to:
-        // (3) `address - ptr <= len`
-        self.ptr <= address && address - self.ptr <= self.len
-    }
-}
-
-pub struct Partition {
+pub struct UpgradeLocations {
     page_size: usize,
-    partition_locations: Vec<PartitionSlice>,
-    metadata_location: PartitionSlice,
+    partitions: Vec<RangeInclusive<usize>>,
+    metadata: RangeInclusive<usize>,
 }
 
-impl Partition {
-    /// Provides access to the other partition if available.
+impl UpgradeLocations {
+    /// Provides access to the other upgrade partition and metadata if available.
     ///
     /// # Errors
     ///
     /// Returns `CustomError` if any of the following conditions do not hold:
     /// - The page size is a power of two.
     /// - The storage slices are page-aligned.
-    pub fn new() -> StorageResult<Partition> {
-        let page_size = get_info(command_nr::get_info_nr::PAGE_SIZE, 0)?;
-        if !page_size.is_power_of_two() {
+    pub fn new() -> StorageResult<UpgradeLocations> {
+        let mut locations = UpgradeLocations {
+            page_size: get_info(command_nr::get_info_nr::PAGE_SIZE, 0)?,
+            partitions: Vec::new(),
+            metadata: 1..=0,
+        };
+        if !locations.page_size.is_power_of_two() {
             return Err(StorageError::CustomError);
         }
-        let mut partition_locations = Vec::new();
-        let mut metadata_location = None;
         for i in 0..memop(memop_nr::STORAGE_CNT, 0)? {
             let storage_type = memop(memop_nr::STORAGE_TYPE, i)?;
             match storage_type {
-                storage_type::STORE => continue,
                 storage_type::PARTITION | storage_type::METADATA => (),
-                _ => return Err(StorageError::CustomError),
+                _ => continue,
             };
             let storage_ptr = memop(memop_nr::STORAGE_PTR, i)?;
             let storage_len = memop(memop_nr::STORAGE_LEN, i)?;
-            if !is_aligned(page_size, storage_ptr) || !is_aligned(page_size, storage_len) {
+            if !locations.is_page_aligned(storage_ptr) || !locations.is_page_aligned(storage_len) {
                 return Err(StorageError::CustomError);
             }
+            let range = create_range(storage_ptr, storage_len);
             match storage_type {
-                storage_type::PARTITION => partition_locations.push(PartitionSlice {
-                    ptr: storage_ptr,
-                    len: storage_len,
-                }),
+                storage_type::PARTITION => locations.partitions.push(range),
                 // We only expect one page of metadata.
                 storage_type::METADATA => {
-                    if metadata_location.is_none() {
-                        metadata_location = Some(PartitionSlice {
-                            ptr: storage_ptr,
-                            len: storage_len,
-                        });
+                    // TODO replace with is_empty with stable Rust 1.47.0
+                    if locations.metadata.start() > locations.metadata.end() {
+                        locations.metadata = range;
                     } else {
                         return Err(StorageError::CustomError);
                     }
@@ -281,102 +252,28 @@ impl Partition {
                 _ => (),
             };
         }
-        if let Some(metadata_location) = metadata_location {
-            Ok(Partition {
-                page_size,
-                partition_locations,
-                metadata_location,
-            })
-        } else {
-            Err(StorageError::CustomError)
-        }
+        Ok(locations)
+    }
+
+    fn is_page_aligned(&self, x: usize) -> bool {
+        is_aligned(self.page_size, x)
     }
 
     pub fn is_page_in_partition(&self, page_address: usize) -> bool {
-        self.partition_locations
+        self.partitions
             .iter()
-            .any(|storage_location| storage_location.contains(page_address))
+            .any(|storage_location| storage_location.contains(&page_address))
     }
 
     pub fn is_page_in_metadata(&self, page_address: usize) -> bool {
-        self.metadata_location.contains(page_address)
+        self.metadata.contains(&page_address)
     }
 
-    pub fn rewrite_page(&self, page_ptr: usize, value: &mut [u8]) -> StorageResult<()> {
-        let value_len = value.len();
-        if !is_aligned(self.page_size, page_ptr) || !is_aligned(self.page_size, value_len) {
+    pub fn rewrite_page(&self, page_ptr: usize, value: &[u8]) -> StorageResult<()> {
+        if !self.is_page_aligned(page_ptr) || !self.is_page_aligned(value.len()) {
             return Err(StorageError::NotAligned);
         }
-
-        let shared_memory = syscalls::allow(DRIVER_NUMBER, allow_nr::WRITE_SLICE, value);
-        if shared_memory.is_err() {
-            return Err(StorageError::CustomError);
-        }
-        let code = syscalls::command(DRIVER_NUMBER, command_nr::ERASE_PAGE, page_ptr, value_len);
-        if code.is_err() {
-            return Err(StorageError::CustomError);
-        }
-        let code = syscalls::command(DRIVER_NUMBER, command_nr::WRITE_SLICE, page_ptr, value_len);
-        if code.is_err() {
-            return Err(StorageError::CustomError);
-        }
-        Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn find_slice_ok() {
-        assert_eq!(
-            find_slice(&[&[1, 2, 3, 4]], 0, 4).ok(),
-            Some(&[1u8, 2, 3, 4] as &[u8])
-        );
-        assert_eq!(
-            find_slice(&[&[1, 2, 3, 4], &[5, 6]], 1, 2).ok(),
-            Some(&[2u8, 3] as &[u8])
-        );
-        assert_eq!(
-            find_slice(&[&[1, 2, 3, 4], &[5, 6]], 4, 2).ok(),
-            Some(&[5u8, 6] as &[u8])
-        );
-        assert_eq!(
-            find_slice(&[&[1, 2, 3, 4], &[5, 6]], 4, 0).ok(),
-            Some(&[] as &[u8])
-        );
-        assert!(find_slice(&[], 0, 1).is_err());
-        assert!(find_slice(&[&[1, 2, 3, 4], &[5, 6]], 6, 0).is_err());
-        assert!(find_slice(&[&[1, 2, 3, 4], &[5, 6]], 3, 2).is_err());
-    }
-
-    #[test]
-    fn alignment() {
-        for exponent in 0..8 {
-            let block_size = 1 << exponent;
-            for i in range(10) {
-                assert!(is_aligned(block_size, block_size * i));
-            }
-            for i in range(block_size) {
-                assert!(!is_aligned(block_size, block_size + i));
-            }
-        }
-    }
-
-    #[test]
-    fn partition_slice_contains() {
-        let ptr = 0x200;
-        let len = 0x100;
-        let slice = PartitionSlice { ptr, len };
-        for i in ptr..ptr + len {
-            assert!(slice.contains(i));
-        }
-        for i in ptr - len..ptr {
-            assert!(!slice.contains(i));
-        }
-        for i in ptr + len..ptr + 2 * len {
-            assert!(!slice.contains(i));
-        }
+        erase_page_op(page_ptr, self.page_size)?;
+        write_slice_op(page_ptr, value)
     }
 }

--- a/src/embedded_flash/syscall.rs
+++ b/src/embedded_flash/syscall.rs
@@ -213,7 +213,7 @@ impl SyscallUpgradeStorage {
     /// Provides access to the other upgrade partition and metadata if available.
     ///
     /// The implementation assumes that storage locations returned by the kernel through
-    /// `memop_nr::STORAGE_*` calls are deterministic and in order.
+    /// `memop_nr::STORAGE_*` calls are in address space order.
     ///
     /// # Errors
     ///

--- a/src/embedded_flash/upgrade_storage.rs
+++ b/src/embedded_flash/upgrade_storage.rs
@@ -1,0 +1,30 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use persistent_store::StorageResult;
+
+/// Accessors to storage locations used for upgrading from a CTAP command.
+pub trait UpgradeStorage {
+    /// Reads a slice of the partition, if within bounds.
+    fn read_partition(&self, offset: usize, length: usize) -> StorageResult<&[u8]>;
+
+    /// Writes the given data to the given offset address, if within bounds of the partition.
+    fn write_partition(&mut self, offset: usize, data: &[u8]) -> StorageResult<()>;
+
+    /// Reads the metadata location.
+    fn read_metadata(&self) -> StorageResult<&[u8]>;
+
+    /// Writes the given data into the metadata location.
+    fn write_metadata(&mut self, data: &[u8]) -> StorageResult<()>;
+}

--- a/src/embedded_flash/upgrade_storage.rs
+++ b/src/embedded_flash/upgrade_storage.rs
@@ -17,14 +17,35 @@ use persistent_store::StorageResult;
 /// Accessors to storage locations used for upgrading from a CTAP command.
 pub trait UpgradeStorage {
     /// Reads a slice of the partition, if within bounds.
+    ///
+    /// The offset is relative to the start of the partition.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError::OutOfBounds`] if the requested slice is not inside the partition.
     fn read_partition(&self, offset: usize, length: usize) -> StorageResult<&[u8]>;
 
     /// Writes the given data to the given offset address, if within bounds of the partition.
+    ///
+    /// The offset is relative to the start of the partition.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError::OutOfBounds`] if the data does not fit the partition.
     fn write_partition(&mut self, offset: usize, data: &[u8]) -> StorageResult<()>;
+
+    /// Returns the length of the partition.
+    fn partition_length(&self) -> usize;
 
     /// Reads the metadata location.
     fn read_metadata(&self) -> StorageResult<&[u8]>;
 
     /// Writes the given data into the metadata location.
+    ///
+    /// The passed in data is appended with 0xFF bytes if shorter than the metadata storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError::OutOfBounds`] if the data is too long to fit the metadata storage.
     fn write_metadata(&mut self, data: &[u8]) -> StorageResult<()>;
 }


### PR DESCRIPTION
Following #338 , this implements an interface to the new types. This PR allows to check if an address is a partition or metadata address, and write the corresponding page.