### PR TITLE
Security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,3 +188,7 @@ cargo run --manifest-path tools/heapviz/Cargo.toml -- --logfile console.log --fp
 ## Contributing
 
 See [Contributing.md](docs/contributing.md).
+
+## Reporting a Vulnerability
+
+See [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+To report a security issue, please use http://g.co/vulnz. We use
+http://g.co/vulnz for our intake, and do coordination and disclosure here on
+GitHub (including using GitHub Security Advisory). The Google Security Team will
+respond within 5 working days of your report on g.co/vulnz.


### PR DESCRIPTION
Adds a security policy, that should display in the Security tab of GitHub. The automatic detection might only work once we also added it to stable, though.