### PR TITLE
Adding Makerdiary and Feitian installation guide

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -338,3 +338,7 @@ $ ioreg -p IOUSB
   +-o AppleUSBXHCI Root Hub Simulation@14000000  <class AppleUSBRootHubDevice, id 0x100000a00, registered, matched, active, busy 0 (0 ms), retain 9>
     +-o OpenSK@14400000  <class AppleUSBDevice, id 0x100003c04, registered, matched, active, busy 0 (0 ms), retain 13>
 ```
+
+## Makerdiary & Feitian Additional Installation Guide
+*   [Makerdiary nRF52840-MDK USB dongle](https://github.com/epita-cs2/Implementation-OpenSK-on-Makerdiary-nrf52840-mdk-usb-dongle).
+*   [Feitian OpenSK dongle](https://github.com/epita-cs2/Implementation-OpenSK-on-Feitian-nrf52840-usb-dongle).


### PR DESCRIPTION
we found that our github Installation guide for Makerdiary and Feitian they are good than the one mentioned in Hyperlinks. 
If it is possible to put our links in addition, kindly find them below: 

https://github.com/epita-cs2/Implementation-OpenSK-on-Makerdiary-nrf52840-mdk-usb-dongle

and 

https://github.com/epita-cs2/Implementation-OpenSK-on-Feitian-nrf52840-usb-dongle

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR