### PR TITLE
Fix typo in nrf52840_dongle_dfu board

### DIFF
--- a/boards/nordic/nrf52840_dongle_dfu/Cargo.toml
+++ b/boards/nordic/nrf52840_dongle_dfu/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 edition = "2018"
 
 [[bin]]
-path = "../nrf52840_dongle/src/main.rs"
+path = "../nrf52840_dongle_opensk/src/main.rs"
 name = "nrf52840_dongle_dfu"
 
 [dependencies]


### PR DESCRIPTION
Fixes #348. Introduced by #334.

Tested with:
```
./reset.sh
./setup.sh
./deploy.py --board=nrf52840_dongle_dfu --programmer=nordicdfu --erase_storage
./deploy.py --board=nrf52840_dongle_dfu --programmer=nordicdfu --opensk
# No panic and works on webauthn.io
```