### PR TITLE
ECDSA signatures and public keys in CTAP

### DIFF
--- a/libraries/crypto/src/ec/point.rs
+++ b/libraries/crypto/src/ec/point.rs
@@ -120,7 +120,6 @@ impl PointP256 {
     }
 
     // Computes n1*G + n2*self
-    #[cfg(feature = "std")]
     pub fn points_mul(&self, n1: &ExponentP256, n2: &ExponentP256) -> PointP256 {
         let p = self.to_affine();
         let p1 = PointProjective::scalar_base_mul(n1);

--- a/libraries/crypto/src/ecdsa.rs
+++ b/libraries/crypto/src/ecdsa.rs
@@ -264,7 +264,7 @@ impl PubKey {
     /// Verifies if the data's hash matches its signature.
     ///
     /// This function is not a constant time implementation, and does not resist side channel
-    /// attacks. Only use if all data invovled is public knowledge.
+    /// attacks. Only use if all data involved is public knowledge.
     pub fn verify_hash_vartime(&self, hash: &[u8; NBYTES], sign: &Signature) -> bool {
         let m = ExponentP256::modn(Int256::from_bin(hash));
 

--- a/libraries/crypto/src/ecdsa.rs
+++ b/libraries/crypto/src/ecdsa.rs
@@ -148,6 +148,7 @@ impl SecKey {
         }
     }
 
+    /// Creates a private key from the exponent's bytes, or None if checks fail.
     pub fn from_bytes(bytes: &[u8; 32]) -> Option<SecKey> {
         let k = NonZeroExponentP256::from_int_checked(Int256::from_bin(bytes));
         // The branching here is fine because all this reveals is whether the key was invalid.
@@ -158,6 +159,7 @@ impl SecKey {
         Some(SecKey { k })
     }
 
+    /// Writes a private key's exponent's bytes to the passed in array.
     pub fn to_bytes(&self, bytes: &mut [u8; 32]) {
         self.k.to_int().to_bin(bytes);
     }
@@ -166,6 +168,7 @@ impl SecKey {
 impl Signature {
     pub const BYTES_LENGTH: usize = 2 * int256::NBYTES;
 
+    /// Converts a signature to its ASN1 DER representation.
     pub fn to_asn1_der(&self) -> Vec<u8> {
         const DER_INTEGER_TYPE: u8 = 0x02;
         const DER_DEF_LENGTH_SEQUENCE: u8 = 0x30;
@@ -193,6 +196,7 @@ impl Signature {
         encoding
     }
 
+    /// Creates a signature from the exponents' bytes, or None if checks fail.
     pub fn from_bytes(bytes: &[u8; Signature::BYTES_LENGTH]) -> Option<Signature> {
         let r_bytes_ref = array_ref![bytes, 0, int256::NBYTES];
         let r = NonZeroExponentP256::from_int_checked(Int256::from_bin(r_bytes_ref));
@@ -257,6 +261,10 @@ impl PubKey {
         self.p.gety().to_int().to_bin(y);
     }
 
+    /// Verifies if the data's hash matches its signature.
+    ///
+    /// This function is not a constant time implementation, and does not resist side channel
+    /// attacks. Only use if all data invovled is public knowledge.
     pub fn verify_hash_vartime(&self, hash: &[u8; NBYTES], sign: &Signature) -> bool {
         let m = ExponentP256::modn(Int256::from_bin(hash));
 

--- a/src/ctap/data_formats.rs
+++ b/src/ctap/data_formats.rs
@@ -878,7 +878,7 @@ impl TryFrom<cbor::Value> for CoseSignature {
 
         let algorithm = SignatureAlgorithm::try_from(ok_or_missing(algorithm)?)?;
         let bytes = extract_byte_string(ok_or_missing(bytes)?)?;
-        if bytes.len() != 64 {
+        if bytes.len() != ecdsa::Signature::BYTES_LENGTH {
             return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
         }
 

--- a/src/ctap/data_formats.rs
+++ b/src/ctap/data_formats.rs
@@ -17,6 +17,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use arrayref::array_ref;
 use core::convert::TryFrom;
+use core::fmt;
 use crypto::{ecdh, ecdsa};
 #[cfg(test)]
 use enum_iterator::IntoEnumIterator;
@@ -722,12 +723,18 @@ impl TryFrom<cbor::Value> for CoseKey {
             } = extract_map(cbor_value)?;
         }
 
+        let algorithm = extract_integer(ok_or_missing(algorithm)?)?;
+        let nbytes = match algorithm {
+            CoseKey::ECDH_ALGORITHM => ecdh::NBYTES,
+            ES256_ALGORITHM => ecdsa::NBYTES,
+            _ => return Err(Ctap2StatusCode::CTAP2_ERR_UNSUPPORTED_ALGORITHM),
+        };
         let x_bytes = extract_byte_string(ok_or_missing(x_bytes)?)?;
-        if x_bytes.len() != ecdh::NBYTES {
+        if x_bytes.len() != nbytes {
             return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
         }
         let y_bytes = extract_byte_string(ok_or_missing(y_bytes)?)?;
-        if y_bytes.len() != ecdh::NBYTES {
+        if y_bytes.len() != nbytes {
             return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
         }
         let curve = extract_integer(ok_or_missing(curve)?)?;
@@ -736,10 +743,6 @@ impl TryFrom<cbor::Value> for CoseKey {
         }
         let key_type = extract_integer(ok_or_missing(key_type)?)?;
         if key_type != CoseKey::EC2_KEY_TYPE {
-            return Err(Ctap2StatusCode::CTAP2_ERR_UNSUPPORTED_ALGORITHM);
-        }
-        let algorithm = extract_integer(ok_or_missing(algorithm)?)?;
-        if algorithm != CoseKey::ECDH_ALGORITHM && algorithm != ES256_ALGORITHM {
             return Err(Ctap2StatusCode::CTAP2_ERR_UNSUPPORTED_ALGORITHM);
         }
 
@@ -814,6 +817,87 @@ impl TryFrom<CoseKey> for ecdh::PubKey {
         }
         ecdh::PubKey::from_coordinates(&x_bytes, &y_bytes)
             .ok_or(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER)
+    }
+}
+
+impl TryFrom<CoseKey> for ecdsa::PubKey {
+    type Error = Ctap2StatusCode;
+
+    fn try_from(cose_key: CoseKey) -> Result<Self, Ctap2StatusCode> {
+        let CoseKey {
+            x_bytes,
+            y_bytes,
+            algorithm,
+        } = cose_key;
+
+        if algorithm != ES256_ALGORITHM {
+            return Err(Ctap2StatusCode::CTAP2_ERR_UNSUPPORTED_ALGORITHM);
+        }
+        ecdsa::PubKey::from_coordinates(&x_bytes, &y_bytes)
+            .ok_or(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER)
+    }
+}
+
+/// Data structure for receiving a signature.
+///
+/// See https://datatracker.ietf.org/doc/html/rfc8152#appendix-C.1.1 for reference.
+///
+/// TODO derive Debug and PartialEq with compiler version 1.47
+#[derive(Clone)]
+pub struct CoseSignature {
+    pub algorithm: SignatureAlgorithm,
+    pub bytes: [u8; ecdsa::Signature::BYTES_LENGTH],
+}
+
+impl fmt::Debug for CoseSignature {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter
+            .debug_struct("CoseSignature")
+            .field("algorithm", &self.algorithm)
+            .field("bytes", &self.bytes.to_vec())
+            .finish()
+    }
+}
+
+impl PartialEq for CoseSignature {
+    fn eq(&self, other: &CoseSignature) -> bool {
+        self.algorithm == other.algorithm && self.bytes[..] == other.bytes[..]
+    }
+}
+
+impl TryFrom<cbor::Value> for CoseSignature {
+    type Error = Ctap2StatusCode;
+
+    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+        destructure_cbor_map! {
+            let {
+                "alg" => algorithm,
+                "signature" => bytes,
+            } = extract_map(cbor_value)?;
+        }
+
+        let algorithm = SignatureAlgorithm::try_from(ok_or_missing(algorithm)?)?;
+        let bytes = extract_byte_string(ok_or_missing(bytes)?)?;
+        if bytes.len() != 64 {
+            return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
+        }
+
+        Ok(CoseSignature {
+            algorithm,
+            bytes: *array_ref![bytes.as_slice(), 0, ecdsa::Signature::BYTES_LENGTH],
+        })
+    }
+}
+
+impl TryFrom<CoseSignature> for ecdsa::Signature {
+    type Error = Ctap2StatusCode;
+
+    fn try_from(cose_signature: CoseSignature) -> Result<Self, Ctap2StatusCode> {
+        match cose_signature.algorithm {
+            SignatureAlgorithm::ES256 => ecdsa::Signature::from_bytes(&cose_signature.bytes)
+                .ok_or(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER),
+            SignatureAlgorithm::Unknown => Err(Ctap2StatusCode::CTAP2_ERR_UNSUPPORTED_ALGORITHM),
+        }
     }
 }
 
@@ -1147,6 +1231,7 @@ mod test {
         cbor_text, cbor_unsigned,
     };
     use crypto::rng256::{Rng256, ThreadRng256};
+    use crypto::sha256::Sha256;
 
     #[test]
     fn test_extract_unsigned() {
@@ -1812,6 +1897,56 @@ mod test {
         let pk = sk.genpk();
         let cose_key = CoseKey::from(pk);
         assert_eq!(cose_key.algorithm, ES256_ALGORITHM);
+    }
+
+    #[test]
+    fn test_from_into_cose_signature() {
+        let mut rng = ThreadRng256 {};
+        let sk = crypto::ecdsa::SecKey::gensk(&mut rng);
+        let dummy_signature = sk.sign_rfc6979::<Sha256>(&[]);
+        let mut bytes = [0; ecdsa::Signature::BYTES_LENGTH];
+        dummy_signature.to_bytes(&mut bytes);
+        let cbor_value = cbor_map! {
+            "alg" => ES256_ALGORITHM,
+            "signature" => bytes,
+        };
+        let cose_signature = CoseSignature::try_from(cbor_value).unwrap();
+        let created_signature = crypto::ecdsa::Signature::try_from(cose_signature).unwrap();
+        let mut created_bytes = [0; ecdsa::Signature::BYTES_LENGTH];
+        created_signature.to_bytes(&mut created_bytes);
+        assert_eq!(bytes[..], created_bytes[..]);
+    }
+
+    #[test]
+    fn test_cose_signature_wrong_algorithm() {
+        let mut rng = ThreadRng256 {};
+        let sk = crypto::ecdsa::SecKey::gensk(&mut rng);
+        let dummy_signature = sk.sign_rfc6979::<Sha256>(&[]);
+        let mut bytes = [0; ecdsa::Signature::BYTES_LENGTH];
+        dummy_signature.to_bytes(&mut bytes);
+        let cbor_value = cbor_map! {
+            "alg" => -1, // unused algorithm
+            "signature" => bytes,
+        };
+        let cose_signature = CoseSignature::try_from(cbor_value).unwrap();
+        let created_signature = crypto::ecdsa::Signature::try_from(cose_signature);
+        // Can not compare directly, since ecdsa::Signature does not implement Debug.
+        assert_eq!(
+            created_signature.err(),
+            Some(Ctap2StatusCode::CTAP2_ERR_UNSUPPORTED_ALGORITHM)
+        );
+    }
+
+    #[test]
+    fn test_cose_signature_wrong_signature_length() {
+        let cbor_value = cbor_map! {
+            "alg" => ES256_ALGORITHM,
+            "signature" => [0; ecdsa::Signature::BYTES_LENGTH + 1],
+        };
+        assert_eq!(
+            CoseSignature::try_from(cbor_value),
+            Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER)
+        );
     }
 
     #[test]

--- a/src/ctap/data_formats.rs
+++ b/src/ctap/data_formats.rs
@@ -1941,6 +1941,14 @@ mod test {
     fn test_cose_signature_wrong_signature_length() {
         let cbor_value = cbor_map! {
             "alg" => ES256_ALGORITHM,
+            "signature" => [0; ecdsa::Signature::BYTES_LENGTH - 1],
+        };
+        assert_eq!(
+            CoseSignature::try_from(cbor_value),
+            Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER)
+        );
+        let cbor_value = cbor_map! {
+            "alg" => ES256_ALGORITHM,
             "signature" => [0; ecdsa::Signature::BYTES_LENGTH + 1],
         };
         assert_eq!(

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -741,14 +741,11 @@ where
                 .attestation_certificate()?
                 .ok_or(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)?;
             (
-                attestation_key.sign_rfc6979::<crypto::sha256::Sha256>(&signature_data),
+                attestation_key.sign_rfc6979::<Sha256>(&signature_data),
                 Some(vec![attestation_certificate]),
             )
         } else {
-            (
-                sk.sign_rfc6979::<crypto::sha256::Sha256>(&signature_data),
-                None,
-            )
+            (sk.sign_rfc6979::<Sha256>(&signature_data), None)
         };
         let attestation_statement = PackedAttestationStatement {
             alg: SignatureAlgorithm::ES256 as i64,
@@ -829,7 +826,7 @@ where
         signature_data.extend(client_data_hash);
         let signature = credential
             .private_key
-            .sign_rfc6979::<crypto::sha256::Sha256>(&signature_data);
+            .sign_rfc6979::<Sha256>(&signature_data);
 
         let cred_desc = PublicKeyCredentialDescriptor {
             key_type: PublicKeyCredentialType::PublicKey,


### PR DESCRIPTION
Adds access to ECDSA `Signature`s and `PubKey`s. Adds `CoseSignature` to show usage of the crypto changes, and will be used itself for upgradability later.

The `Debug` and `PartialEq` implementations can be derived instead with compiler version 1.47.

Also some constants and imports are more consistent.