### PR TITLE
adds storage access for upgrade keys

### DIFF
--- a/src/ctap/data_formats.rs
+++ b/src/ctap/data_formats.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use super::status_code::Ctap2StatusCode;
-use crate::embedded_flash;
 use alloc::string::String;
 use alloc::vec::Vec;
 use arrayref::array_ref;
@@ -1160,28 +1159,6 @@ impl From<CredentialManagementSubCommandParameters> for cbor::Value {
     }
 }
 
-/// Translates a the partition identifier for an upgrade to A or B.
-#[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(test, derive(IntoEnumIterator))]
-#[repr(u32)]
-pub enum UpgradeIdentifier {
-    A = embedded_flash::PARTITION_A_IDENTIFIER,
-    B = embedded_flash::PARTITION_B_IDENTIFIER,
-}
-
-impl TryFrom<cbor::Value> for UpgradeIdentifier {
-    type Error = Ctap2StatusCode;
-
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
-        let identifier = extract_unsigned(cbor_value)?;
-        match identifier as u32 {
-            embedded_flash::PARTITION_A_IDENTIFIER => Ok(UpgradeIdentifier::A),
-            embedded_flash::PARTITION_B_IDENTIFIER => Ok(UpgradeIdentifier::B),
-            _ => Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER),
-        }
-    }
-}
-
 pub(super) fn extract_unsigned(cbor_value: cbor::Value) -> Result<u64, Ctap2StatusCode> {
     match cbor_value {
         cbor::Value::Unsigned(unsigned) => Ok(unsigned),
@@ -2220,26 +2197,5 @@ mod test {
         assert!(PublicKeyCredentialSource::try_from(cbor_false!()).is_err());
         assert!(PublicKeyCredentialSource::try_from(cbor_array!(false)).is_err());
         assert!(PublicKeyCredentialSource::try_from(cbor_array!(b"foo".to_vec())).is_err());
-    }
-
-    #[test]
-    fn test_from_into_upgrade_identifier() {
-        let cbor_upgrade_identifier: cbor::Value =
-            cbor_int!(embedded_flash::PARTITION_A_IDENTIFIER as i64);
-        assert_eq!(
-            UpgradeIdentifier::try_from(cbor_upgrade_identifier),
-            Ok(UpgradeIdentifier::A)
-        );
-        let cbor_upgrade_identifier: cbor::Value =
-            cbor_int!(embedded_flash::PARTITION_B_IDENTIFIER as i64);
-        assert_eq!(
-            UpgradeIdentifier::try_from(cbor_upgrade_identifier),
-            Ok(UpgradeIdentifier::B)
-        );
-        let cbor_upgrade_identifier: cbor::Value = cbor_int!(0x12345678);
-        assert_eq!(
-            UpgradeIdentifier::try_from(cbor_upgrade_identifier),
-            Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER)
-        );
     }
 }

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -21,8 +21,8 @@ use crate::ctap::customization::{
     NUM_PAGES,
 };
 use crate::ctap::data_formats::{
-    extract_array, extract_text_string, CredentialProtectionPolicy, PublicKeyCredentialSource,
-    PublicKeyCredentialUserEntity,
+    extract_array, extract_text_string, CoseKey, CredentialProtectionPolicy,
+    PublicKeyCredentialSource, PublicKeyCredentialUserEntity, UpgradeIdentifier,
 };
 use crate::ctap::key_material;
 use crate::ctap::status_code::Ctap2StatusCode;
@@ -570,6 +570,42 @@ impl PersistentStore {
         Ok(self.store.insert(key::AAGUID, aaguid)?)
     }
 
+    /// Returns the upgrade public key if defined for the identifier.
+    // TODO remove allow
+    #[allow(dead_code)]
+    pub fn upgrade_public_key(
+        &self,
+        identifier: UpgradeIdentifier,
+    ) -> Result<Option<CoseKey>, Ctap2StatusCode> {
+        let value = match identifier {
+            UpgradeIdentifier::A => self.store.find(key::UPGRADE_PUBLIC_KEY_A)?,
+            UpgradeIdentifier::B => self.store.find(key::UPGRADE_PUBLIC_KEY_B)?,
+        };
+        value
+            .map(|k| {
+                deserialize_cose_key(&k).ok_or(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)
+            })
+            .transpose()
+    }
+
+    /// Sets an upgrade public key.
+    ///
+    /// Overwrites an existing key for the given identifier.
+    // TODO remove allow
+    #[allow(dead_code)]
+    pub fn set_upgrade_public_key(
+        &mut self,
+        identifier: UpgradeIdentifier,
+        public_key: CoseKey,
+    ) -> Result<(), Ctap2StatusCode> {
+        let storage_key = match identifier {
+            UpgradeIdentifier::A => key::UPGRADE_PUBLIC_KEY_A,
+            UpgradeIdentifier::B => key::UPGRADE_PUBLIC_KEY_B,
+        };
+        let serialized_key = serialize_cose_key(public_key)?;
+        Ok(self.store.insert(storage_key, &serialized_key)?)
+    }
+
     /// Resets the store as for a CTAP reset.
     ///
     /// In particular persistent entries are not reset.
@@ -746,6 +782,19 @@ fn deserialize_min_pin_length_rp_ids(data: &[u8]) -> Option<Vec<String>> {
 fn serialize_min_pin_length_rp_ids(rp_ids: Vec<String>) -> Result<Vec<u8>, Ctap2StatusCode> {
     let mut data = Vec::new();
     super::cbor_write(cbor_array_vec!(rp_ids), &mut data)?;
+    Ok(data)
+}
+
+/// Deserializes a COSE key from storage representation.
+fn deserialize_cose_key(data: &[u8]) -> Option<CoseKey> {
+    let cbor = super::cbor_read(data).ok()?;
+    cbor.try_into().ok()
+}
+
+/// Serializes a COSE key to storage representation.
+fn serialize_cose_key(cose_key: CoseKey) -> Result<Vec<u8>, Ctap2StatusCode> {
+    let mut data = Vec::new();
+    super::cbor_write(cose_key.into(), &mut data)?;
     Ok(data)
 }
 
@@ -1130,7 +1179,7 @@ mod test {
         let mut rng = ThreadRng256 {};
         let mut persistent_store = PersistentStore::new(&mut rng);
 
-        // Make sure the attestation are absent. There is no batch attestation in tests.
+        // Make sure the attestation and upgrade are absent. There is no batch attestation in tests.
         assert!(persistent_store
             .attestation_private_key()
             .unwrap()
@@ -1139,15 +1188,29 @@ mod test {
             .attestation_certificate()
             .unwrap()
             .is_none());
+        assert!(persistent_store
+            .upgrade_public_key(UpgradeIdentifier::A)
+            .unwrap()
+            .is_none());
+        assert!(persistent_store
+            .upgrade_public_key(UpgradeIdentifier::B)
+            .unwrap()
+            .is_none());
 
         // Make sure the persistent keys are initialized to dummy values.
         let dummy_key = [0x41u8; key_material::ATTESTATION_PRIVATE_KEY_LENGTH];
         let dummy_cert = [0xddu8; 20];
+        let dummy_identifier = UpgradeIdentifier::A;
+        let private_key = crypto::ecdsa::SecKey::gensk(&mut rng);
+        let dummy_upgrade_key = CoseKey::from(private_key.genpk());
         persistent_store
             .set_attestation_private_key(&dummy_key)
             .unwrap();
         persistent_store
             .set_attestation_certificate(&dummy_cert)
+            .unwrap();
+        persistent_store
+            .set_upgrade_public_key(dummy_identifier, dummy_upgrade_key.clone())
             .unwrap();
         assert_eq!(&persistent_store.aaguid().unwrap(), key_material::AAGUID);
 
@@ -1161,7 +1224,54 @@ mod test {
             persistent_store.attestation_certificate().unwrap().unwrap(),
             &dummy_cert
         );
+        assert_eq!(
+            persistent_store
+                .upgrade_public_key(dummy_identifier)
+                .unwrap()
+                .unwrap(),
+            dummy_upgrade_key
+        );
         assert_eq!(&persistent_store.aaguid().unwrap(), key_material::AAGUID);
+    }
+
+    #[test]
+    fn test_upgrade_keys() {
+        let mut rng = ThreadRng256 {};
+        let mut persistent_store = PersistentStore::new(&mut rng);
+
+        let dummy_identifier = UpgradeIdentifier::A;
+        let old_private_key = crypto::ecdsa::SecKey::gensk(&mut rng);
+        let old_upgrade_key = CoseKey::from(old_private_key.genpk());
+        persistent_store
+            .set_upgrade_public_key(dummy_identifier, old_upgrade_key)
+            .unwrap();
+        let other_identifier = UpgradeIdentifier::B;
+        let other_private_key = crypto::ecdsa::SecKey::gensk(&mut rng);
+        let other_upgrade_key = CoseKey::from(other_private_key.genpk());
+        persistent_store
+            .set_upgrade_public_key(other_identifier, other_upgrade_key.clone())
+            .unwrap();
+
+        let dummy_private_key = crypto::ecdsa::SecKey::gensk(&mut rng);
+        let dummy_upgrade_key = CoseKey::from(dummy_private_key.genpk());
+        persistent_store
+            .set_upgrade_public_key(dummy_identifier, dummy_upgrade_key.clone())
+            .unwrap();
+
+        assert_eq!(
+            &persistent_store
+                .upgrade_public_key(dummy_identifier)
+                .unwrap()
+                .unwrap(),
+            &dummy_upgrade_key
+        );
+        assert_eq!(
+            &persistent_store
+                .upgrade_public_key(other_identifier)
+                .unwrap()
+                .unwrap(),
+            &other_upgrade_key
+        );
     }
 
     #[test]

--- a/src/ctap/storage/key.rs
+++ b/src/ctap/storage/key.rs
@@ -70,6 +70,12 @@ make_partition! {
     /// The aaguid.
     AAGUID = 3;
 
+    /// The upgrade public key for partition A.
+    UPGRADE_PUBLIC_KEY_A = 4;
+
+    /// The upgrade public key for partition B.
+    UPGRADE_PUBLIC_KEY_B = 5;
+
     // This is the persistent key limit:
     // - When adding a (persistent) key above this message, make sure its value is smaller than
     //   NUM_PERSISTENT_KEYS.

--- a/src/ctap/storage/key.rs
+++ b/src/ctap/storage/key.rs
@@ -71,10 +71,10 @@ make_partition! {
     AAGUID = 3;
 
     /// The upgrade public key for partition A.
-    UPGRADE_PUBLIC_KEY_A = 4;
+    _UPGRADE_PUBLIC_KEY_A = 4;
 
     /// The upgrade public key for partition B.
-    UPGRADE_PUBLIC_KEY_B = 5;
+    _UPGRADE_PUBLIC_KEY_B = 5;
 
     // This is the persistent key limit:
     // - When adding a (persistent) key above this message, make sure its value is smaller than

--- a/src/embedded_flash/buffer_upgrade.rs
+++ b/src/embedded_flash/buffer_upgrade.rs
@@ -14,6 +14,7 @@
 
 use super::helper::ModRange;
 use super::upgrade_storage::UpgradeStorage;
+use super::UpgradeIdentifier;
 use alloc::boxed::Box;
 use persistent_store::{StorageError, StorageResult};
 
@@ -57,6 +58,10 @@ impl UpgradeStorage for BufferUpgradeStorage {
         }
     }
 
+    fn partition_address(&self) -> usize {
+        0x60000
+    }
+
     fn partition_length(&self) -> usize {
         PARTITION_LENGTH
     }
@@ -75,7 +80,7 @@ impl UpgradeStorage for BufferUpgradeStorage {
         }
     }
 
-    fn identifier(&self) -> usize {
-        0x60000
+    fn identifier(&self) -> UpgradeIdentifier {
+        UpgradeIdentifier::B
     }
 }

--- a/src/embedded_flash/buffer_upgrade.rs
+++ b/src/embedded_flash/buffer_upgrade.rs
@@ -74,4 +74,8 @@ impl UpgradeStorage for BufferUpgradeStorage {
             Err(StorageError::OutOfBounds)
         }
     }
+
+    fn identifier(&self) -> usize {
+        0x60000
+    }
 }

--- a/src/embedded_flash/mod.rs
+++ b/src/embedded_flash/mod.rs
@@ -19,8 +19,11 @@ mod helper;
 mod syscall;
 mod upgrade_storage;
 
-pub const PARTITION_A_IDENTIFIER: u32 = 0x20000;
-pub const PARTITION_B_IDENTIFIER: u32 = 0x60000;
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum UpgradeIdentifier {
+    A = 0,
+    B = 1,
+}
 
 pub use upgrade_storage::UpgradeStorage;
 

--- a/src/embedded_flash/mod.rs
+++ b/src/embedded_flash/mod.rs
@@ -19,6 +19,9 @@ mod helper;
 mod syscall;
 mod upgrade_storage;
 
+pub const PARTITION_A_IDENTIFIER: u32 = 0x20000;
+pub const PARTITION_B_IDENTIFIER: u32 = 0x60000;
+
 pub use upgrade_storage::UpgradeStorage;
 
 /// Definitions for production.

--- a/src/embedded_flash/syscall.rs
+++ b/src/embedded_flash/syscall.rs
@@ -324,4 +324,8 @@ impl UpgradeStorage for SyscallUpgradeStorage {
             Err(StorageError::OutOfBounds)
         }
     }
+
+    fn identifier(&self) -> usize {
+        self.partition.start()
+    }
 }

--- a/src/embedded_flash/upgrade_storage.rs
+++ b/src/embedded_flash/upgrade_storage.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::UpgradeIdentifier;
 use persistent_store::StorageResult;
 
 /// Accessors to storage locations used for upgrading from a CTAP command.
@@ -34,6 +35,9 @@ pub trait UpgradeStorage {
     /// Returns [`StorageError::OutOfBounds`] if the data does not fit the partition.
     fn write_partition(&mut self, offset: usize, data: &[u8]) -> StorageResult<()>;
 
+    /// Returns the address of the partition.
+    fn partition_address(&self) -> usize;
+
     /// Returns the length of the partition.
     fn partition_length(&self) -> usize;
 
@@ -49,8 +53,6 @@ pub trait UpgradeStorage {
     /// Returns [`StorageError::OutOfBounds`] if the data is too long to fit the metadata storage.
     fn write_metadata(&mut self, data: &[u8]) -> StorageResult<()>;
 
-    /// Returns an identifier for these upgrade locations.
-    ///
-    /// We currently use the offset of the partition.
-    fn identifier(&self) -> usize;
+    /// Returns the identifier for these upgrade locations.
+    fn identifier(&self) -> UpgradeIdentifier;
 }

--- a/src/embedded_flash/upgrade_storage.rs
+++ b/src/embedded_flash/upgrade_storage.rs
@@ -48,4 +48,9 @@ pub trait UpgradeStorage {
     ///
     /// Returns [`StorageError::OutOfBounds`] if the data is too long to fit the metadata storage.
     fn write_metadata(&mut self, data: &[u8]) -> StorageResult<()>;
+
+    /// Returns an identifier for these upgrade locations.
+    ///
+    /// We currently use the offset of the partition.
+    fn identifier(&self) -> usize;
 }


### PR DESCRIPTION
Implements storage access for the public keys for upgrading. Getter and Setter and currently dead code, but will be used in the following PRs.

This PR introduces an identifier, and the app is expected to know its layout in advance to have these identifiers properly set. Public keys are bound to specific partitions, and binaries only work when compiled for the correct address. This design means to reduce the chance of accidentally flashing the wrong firmware. It does come with a quirk of having these constants that need to match the board settings for the current and the other partition.