### PR TITLE
Remove elf2tab dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ with_ctap1 = ["crypto/with_ctap1"]
 with_nfc = ["libtock_drivers/with_nfc"]
 
 [dev-dependencies]
-elf2tab = "0.6.0"
 enum-iterator = "0.6.0"
 
 [build-dependencies]


### PR DESCRIPTION
We don't use it anymore. Not sure when we used to use it. Let's see if any workflow fails.

Fixes #364
