### PR TITLE
Remove elf2tab dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ with_ctap2_1 = []
 with_nfc = ["libtock_drivers/with_nfc"]
 
 [dev-dependencies]
-elf2tab = "0.6.0"
 enum-iterator = "0.6.0"
 
 [build-dependencies]


### PR DESCRIPTION
This is a backport of #365 and generated with `git cherry-pick 659f8a16a2d50f2254de0ed9137c4d5abf542644`.
