### PR TITLE
Fix ctap2 fuzz targets to use prod cbor parsing

### DIFF
--- a/fuzz/fuzz_helper/src/lib.rs
+++ b/fuzz/fuzz_helper/src/lib.rs
@@ -27,9 +27,8 @@ use ctap2::ctap::hid::receive::MessageAssembler;
 use ctap2::ctap::hid::send::HidPacketIterator;
 use ctap2::ctap::hid::{ChannelID, CtapHid, HidPacket, Message};
 use ctap2::ctap::status_code::Ctap2StatusCode;
-use ctap2::ctap::CtapState;
+use ctap2::ctap::{cbor_read, CtapState};
 use libtock_drivers::timer::{ClockValue, Timestamp};
-use sk_cbor as cbor;
 
 const COMMAND_INIT: u8 = 0x06;
 const CHANNEL_BROADCAST: ChannelID = [0xFF, 0xFF, 0xFF, 0xFF];
@@ -102,7 +101,7 @@ fn is_type(data: &[u8], input_type: InputType) -> bool {
     if input_type == InputType::Ctap1 {
         return true;
     }
-    match cbor::read(data) {
+    match cbor_read(data) {
         Err(_) => false,
         Ok(decoded_cbor) => match input_type {
             InputType::CborMakeCredentialParameter => {

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -122,7 +122,7 @@ pub const ES256_CRED_PARAM: PublicKeyCredentialParameter = PublicKeyCredentialPa
 };
 
 // Helpers to perform CBOR read/write while respecting CTAP2 nesting limits.
-fn cbor_read(encoded_cbor: &[u8]) -> Result<cbor::Value, Ctap2StatusCode> {
+pub fn cbor_read(encoded_cbor: &[u8]) -> Result<cbor::Value, Ctap2StatusCode> {
     cbor::reader::read_nested(encoded_cbor, Some(MAX_CBOR_NESTING_DEPTH))
         .map_err(|_e| Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR)
 }


### PR DESCRIPTION
This fixes a left-over from #329.
