### PR TITLE
Install Rust tools with stable compiler

### DIFF
--- a/fuzzing_setup.sh
+++ b/fuzzing_setup.sh
@@ -20,4 +20,4 @@ done_text="$(tput bold)DONE.$(tput sgr0)"
 set -e
 
 # Install cargo-fuzz library.
-cargo install cargo-fuzz
+cargo +stable install cargo-fuzz

--- a/setup.sh
+++ b/setup.sh
@@ -43,7 +43,8 @@ rustup target add thumbv7em-none-eabi
 
 # Install dependency to create applications.
 mkdir -p elf2tab
-cargo install elf2tab --version 0.6.0 --root elf2tab/
+rustup install stable
+cargo +stable install elf2tab --version 0.6.0 --root elf2tab/
 
 # Install python dependencies to factory configure OpenSK (crypto, JTAG lockdown)
 pip3 install --user --upgrade colorama tqdm cryptography "fido2>=0.9.1"


### PR DESCRIPTION
We only need the frozen nightly for Tock (and maybe the app).

The `rustup install stable` is just to make sure the stable compiler is installed. It's usually gonna be a quick no-op.