### PR TITLE
Decrease maximum input size for store fuzzing

### DIFF
--- a/libraries/persistent_store/fuzz/src/store.rs
+++ b/libraries/persistent_store/fuzz/src/store.rs
@@ -36,8 +36,9 @@ use std::convert::TryInto;
 pub fn fuzz(mut data: &[u8], debug: bool, stats: Option<&mut Stats>) {
     // We limit the input size to avoid timeouts in oss-fuzz because they use inputs of arbitrary
     // length and timeout after 1 minute. By default, libFuzzer has a maximum length of 4096 bytes.
-    // So we just use some number above 4096 bytes and below 1 minute (might need adjustments).
-    const MAX_DATA_LEN: usize = 100_000;
+    // We use a number between 4096 bytes and 1 minute, ideally such that the proportion of inputs
+    // timing out in oss-fuzz is around 1%.
+    const MAX_DATA_LEN: usize = 50_000;
     if data.len() > MAX_DATA_LEN {
         data = &data[..MAX_DATA_LEN];
     }


### PR DESCRIPTION
We currently have around 12% inputs timing out (was around 27% before the 100k limit).