### PR TITLE
cbor: don't allow infinite nesting by default

### DIFF
--- a/libraries/cbor/src/reader.rs
+++ b/libraries/cbor/src/reader.rs
@@ -38,9 +38,10 @@ pub enum DecoderError {
 }
 
 /// Deserialize CBOR binary data to produce a single [`Value`], expecting that there is no additional data.
-/// Supports arbitrarily nested CBOR (so the [`DecoderError::TooMuchNesting`] error is never emitted).
+/// Maximum level of nesting supported is 127; more deeply nested structures will fail with
+/// [`DecoderError::TooMuchNesting`].
 pub fn read(encoded_cbor: &[u8]) -> Result<Value, DecoderError> {
-    read_nested(encoded_cbor, None)
+    read_nested(encoded_cbor, Some(i8::MAX))
 }
 
 /// Deserialize CBOR binary data to produce a single [`Value`], expecting that there is no additional data.  If

--- a/libraries/cbor/src/writer.rs
+++ b/libraries/cbor/src/writer.rs
@@ -25,9 +25,10 @@ pub enum EncoderError {
 }
 
 /// Convert a [`Value`] to serialized CBOR data, consuming it along the way and appending to the provided vector.
-/// Supports arbitrarily nested CBOR (so the [`EncoderError::TooMuchNesting`] error is never emitted).
+/// Maximum level of nesting supported is 127; more deeply nested structures will fail with
+/// [`EncoderError::TooMuchNesting`].
 pub fn write(value: Value, encoded_cbor: &mut Vec<u8>) -> Result<(), EncoderError> {
-    write_nested(value, encoded_cbor, None)
+    write_nested(value, encoded_cbor, Some(i8::MAX))
 }
 
 /// Convert a [`Value`] to serialized CBOR data, consuming it along the way and appending to the provided vector.  If


### PR DESCRIPTION
Change the read()/write() methods to use a nesting limit of 127
internally, to avoid the possibility of heavily nested inputs exhausting
the stack.

Library users that still want to skip nesting checks can still get at
this functionality by using `{read,write}_nested(..., None)`.
