### PR TITLE
Reduce the store fuzzer input length

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -308,7 +308,7 @@ class OpenSKInstaller:
 
   def update_rustc_if_needed(self):
     target_toolchain_fullstring = "stable"
-    with open("rust-toolchain", "r") as f:
+    with open("rust-toolchain", "r", encoding="utf-8") as f:
       target_toolchain_fullstring = f.readline().strip()
     target_toolchain = target_toolchain_fullstring.split("-", maxsplit=1)
     if len(target_toolchain) == 1:

--- a/fuzz/make_corpus.py
+++ b/fuzz/make_corpus.py
@@ -29,7 +29,7 @@ def make_corpus(corpus_dir, corpus_json):
 
   if os.path.isfile(corpus_json) and \
     os.path.splitext(corpus_json)[-1] == ".json":
-    with open(corpus_json) as corpus_file:
+    with open(corpus_json, encoding="utf-8") as corpus_file:
       corpus = json.load(corpus_file)
   else:
     raise TypeError

--- a/libraries/persistent_store/fuzz/src/store.rs
+++ b/libraries/persistent_store/fuzz/src/store.rs
@@ -38,7 +38,7 @@ pub fn fuzz(mut data: &[u8], debug: bool, stats: Option<&mut Stats>) {
     // length and timeout after 1 minute. By default, libFuzzer has a maximum length of 4096 bytes.
     // We use a number between 4096 bytes and 1 minute, ideally such that the proportion of inputs
     // timing out in oss-fuzz is around 1%.
-    const MAX_DATA_LEN: usize = 50_000;
+    const MAX_DATA_LEN: usize = 20_000;
     if data.len() > MAX_DATA_LEN {
         data = &data[..MAX_DATA_LEN];
     }


### PR DESCRIPTION
We still hit timeouts about 4% of the time some days (other days there are 0%, not sure why).