### PR TITLE
Added pypi:testresources required by one of the tockloader dependencies;

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -37,6 +37,10 @@ check_command pip3
 source tools/gen_key_materials.sh
 generate_crypto_materials N
 
+# Install python dependencies (testresources) required by "launchpadlib",
+# which is used by one of the tockloader dependencies.
+pip3 install --user testresources
+
 rustup install $(head -n 1 rust-toolchain)
 pip3 install --user --upgrade 'tockloader==1.5' six intelhex
 rustup target add thumbv7em-none-eabi


### PR DESCRIPTION
Signed-off-by: minjun <xi.minjun@gmail.com>

Fixes #343

> It's a good idea to open an issue first for discussion.

Running `setup.sh` on ubuntu versions (at least 20.04, 20.10),  there will be one unmet dependency error message, indicating "launchpadlib" requires "testresources". 

The pypi package "testresources" requires to be installed, but it doesn't. 
 
The solution is easy here: install testresouces pypi package, before installing "tockloader", "intelhex", etc.

- [Y] Tests pass
- [ ] Appropriate changes to README are included in PR