### PR TITLE
Upgrade commands

### DIFF
--- a/src/ctap/key_material.rs
+++ b/src/ctap/key_material.rs
@@ -14,9 +14,9 @@
 
 pub const ATTESTATION_PRIVATE_KEY_LENGTH: usize = 32;
 pub const AAGUID_LENGTH: usize = 16;
-pub const _UPGRADE_PUBLIC_KEY_LENGTH: usize = 77;
+pub const UPGRADE_PUBLIC_KEY_LENGTH: usize = 77;
 
 pub const AAGUID: &[u8; AAGUID_LENGTH] =
     include_bytes!(concat!(env!("OUT_DIR"), "/opensk_aaguid.bin"));
-pub const _UPGRADE_PUBLIC_KEY: &[u8; _UPGRADE_PUBLIC_KEY_LENGTH] =
+pub const UPGRADE_PUBLIC_KEY: &[u8; UPGRADE_PUBLIC_KEY_LENGTH] =
     include_bytes!(concat!(env!("OUT_DIR"), "/opensk_upgrade_pubkey_cbor.bin"));

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -35,7 +35,7 @@ mod token_state;
 use self::client_pin::{ClientPin, PinPermission};
 use self::command::{
     AuthenticatorGetAssertionParameters, AuthenticatorMakeCredentialParameters,
-    AuthenticatorVendorConfigureParameters, Command,
+    AuthenticatorVendorConfigureParameters, AuthenticatorVendorUpgradeParameters, Command,
 };
 use self::config_command::process_config;
 use self::credential_management::process_credential_management;
@@ -46,22 +46,25 @@ use self::customization::{
     MAX_RP_IDS_LENGTH, USE_BATCH_ATTESTATION, USE_SIGNATURE_COUNTER,
 };
 use self::data_formats::{
-    AuthenticatorTransport, CoseKey, CredentialProtectionPolicy, EnterpriseAttestationMode,
-    GetAssertionExtensions, PackedAttestationStatement, PinUvAuthProtocol,
-    PublicKeyCredentialDescriptor, PublicKeyCredentialParameter, PublicKeyCredentialSource,
-    PublicKeyCredentialType, PublicKeyCredentialUserEntity, SignatureAlgorithm,
+    AuthenticatorTransport, CoseKey, CoseSignature, CredentialProtectionPolicy,
+    EnterpriseAttestationMode, GetAssertionExtensions, PackedAttestationStatement,
+    PinUvAuthProtocol, PublicKeyCredentialDescriptor, PublicKeyCredentialParameter,
+    PublicKeyCredentialSource, PublicKeyCredentialType, PublicKeyCredentialUserEntity,
+    SignatureAlgorithm,
 };
 use self::hid::ChannelID;
 use self::large_blobs::LargeBlobs;
 use self::response::{
     AuthenticatorGetAssertionResponse, AuthenticatorGetInfoResponse,
-    AuthenticatorMakeCredentialResponse, AuthenticatorVendorResponse, ResponseData,
+    AuthenticatorMakeCredentialResponse, AuthenticatorVendorConfigureResponse,
+    AuthenticatorVendorUpgradeInfoResponse, ResponseData,
 };
 use self::status_code::Ctap2StatusCode;
 use self::storage::PersistentStore;
 use self::timed_permission::TimedPermission;
 #[cfg(feature = "with_ctap1")]
 use self::timed_permission::U2fUserPresenceState;
+use crate::embedded_flash::{UpgradeLocations, UpgradeStorage};
 use alloc::boxed::Box;
 use alloc::string::{String, ToString};
 use alloc::vec;
@@ -71,6 +74,7 @@ use byteorder::{BigEndian, ByteOrder};
 use core::convert::TryFrom;
 #[cfg(feature = "debug_ctap")]
 use core::fmt::Write;
+use crypto::ecdsa;
 use crypto::hmac::{hmac_256, verify_hmac_256};
 use crypto::rng256::Rng256;
 use crypto::sha256::Sha256;
@@ -144,6 +148,52 @@ fn truncate_to_char_boundary(s: &str, mut max: usize) -> &str {
         }
         &s[..max]
     }
+}
+
+/// Parses the metadata of an upgrade, and checks its correctness.
+///
+/// Returns the hash over the upgrade, including partition and some metadata.
+/// The metadata layout is:
+/// | -- 32B upgrade hash (SHA256) -- | 8B other |
+fn parse_metadata(
+    upgrade_locations: &UpgradeLocations,
+    metadata: &[u8],
+) -> Result<[u8; 32], Ctap2StatusCode> {
+    const METADATA_LEN: usize = 40;
+    if metadata.len() < METADATA_LEN {
+        return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
+    }
+    // The hash implementation handles this in chunks, so no memory issues.
+    let partition_slice = upgrade_locations
+        .read_partition(0, upgrade_locations.partition_length())
+        .map_err(|_| Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)?;
+    let mut hasher = Sha256::new();
+    hasher.update(partition_slice);
+    hasher.update(&metadata[32..METADATA_LEN]);
+    let computed_hash = hasher.finalize();
+    if &computed_hash != array_ref!(metadata, 0, 32) {
+        return Err(Ctap2StatusCode::CTAP2_ERR_INTEGRITY_FAILURE);
+    }
+    Ok(computed_hash)
+}
+
+/// Verifies the signature over the given hash.
+///
+/// The public key is COSE encoded, and the hash is a SHA256.
+fn verify_signature(
+    signature: Option<CoseSignature>,
+    public_key_bytes: &[u8],
+    signed_hash: &[u8; 32],
+) -> Result<(), Ctap2StatusCode> {
+    let signature =
+        ecdsa::Signature::try_from(signature.ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?)?;
+    let cbor_public_key = cbor_read(public_key_bytes)?;
+    let cose_key = CoseKey::try_from(cbor_public_key)?;
+    let public_key = ecdsa::PubKey::try_from(cose_key)?;
+    if !public_key.verify_hash_vartime(signed_hash, &signature) {
+        return Err(Ctap2StatusCode::CTAP2_ERR_INTEGRITY_FAILURE);
+    }
+    Ok(())
 }
 
 /// Holds data necessary to sign an assertion for a credential.
@@ -288,6 +338,7 @@ pub struct CtapState<'a, R: Rng256, CheckUserPresence: Fn(ChannelID) -> Result<(
     // The state initializes to Reset and its timeout, and never goes back to Reset.
     stateful_command_permission: StatefulPermission,
     large_blobs: LargeBlobs,
+    upgrade_locations: Option<UpgradeLocations>,
 }
 
 impl<'a, R, CheckUserPresence> CtapState<'a, R, CheckUserPresence>
@@ -314,6 +365,7 @@ where
             ),
             stateful_command_permission: StatefulPermission::new_reset(now),
             large_blobs: LargeBlobs::new(),
+            upgrade_locations: UpgradeLocations::new().ok(),
         }
     }
 
@@ -481,6 +533,10 @@ where
                     Command::AuthenticatorVendorConfigure(params) => {
                         self.process_vendor_configure(params, cid)
                     }
+                    Command::AuthenticatorVendorUpgrade(params) => {
+                        self.process_vendor_upgrade(params)
+                    }
+                    Command::AuthenticatorVendorUpgradeInfo => self.process_vendor_upgrade_info(),
                 };
                 #[cfg(feature = "debug_ctap")]
                 writeln!(&mut Console::new(), "Sending response: {:#?}", response).unwrap();
@@ -1140,13 +1196,13 @@ where
 
         let response = match params.attestation_material {
             // Only reading values.
-            None => AuthenticatorVendorResponse {
+            None => AuthenticatorVendorConfigureResponse {
                 cert_programmed: current_cert.is_some(),
                 pkey_programmed: current_priv_key.is_some(),
             },
             // Device is already fully programmed. We don't leak information.
             Some(_) if current_cert.is_some() && current_priv_key.is_some() => {
-                AuthenticatorVendorResponse {
+                AuthenticatorVendorConfigureResponse {
                     cert_programmed: true,
                     pkey_programmed: true,
                 }
@@ -1171,7 +1227,7 @@ where
                     self.persistent_store
                         .set_attestation_private_key(&data.private_key)?;
                 }
-                AuthenticatorVendorResponse {
+                AuthenticatorVendorConfigureResponse {
                     cert_programmed: true,
                     pkey_programmed: true,
                 }
@@ -1192,7 +1248,60 @@ where
                 return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
             }
         }
-        Ok(ResponseData::AuthenticatorVendor(response))
+        Ok(ResponseData::AuthenticatorVendorConfigure(response))
+    }
+
+    fn process_vendor_upgrade(
+        &mut self,
+        params: AuthenticatorVendorUpgradeParameters,
+    ) -> Result<ResponseData, Ctap2StatusCode> {
+        let AuthenticatorVendorUpgradeParameters {
+            address,
+            data,
+            hash,
+            signature,
+        } = params;
+        let upgrade_locations = self
+            .upgrade_locations
+            .as_mut()
+            .ok_or(Ctap2StatusCode::CTAP1_ERR_INVALID_COMMAND)?;
+        let written_slice = if let Some(address) = address {
+            upgrade_locations
+                .write_partition(address, &data)
+                .map_err(|_| Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER)?;
+            upgrade_locations
+                .read_partition(address, data.len())
+                .map_err(|_| Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER)?
+        } else {
+            // Compares the hash inside the metadata to the actual hash.
+            let upgrade_hash = parse_metadata(upgrade_locations, &data)?;
+            // Only signed firmware images may be fully written.
+            verify_signature(signature, key_material::UPGRADE_PUBLIC_KEY, &upgrade_hash)?;
+            // Write the metadata page after verifying that its hash is signed.
+            upgrade_locations
+                .write_metadata(&data)
+                .map_err(|_| Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER)?;
+            upgrade_locations
+                .read_metadata()
+                .map_err(|_| Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER)?
+        };
+        let written_hash = Sha256::hash(written_slice);
+        if hash != written_hash {
+            return Err(Ctap2StatusCode::CTAP2_ERR_INTEGRITY_FAILURE);
+        }
+        Ok(ResponseData::AuthenticatorVendorUpgrade)
+    }
+
+    fn process_vendor_upgrade_info(&self) -> Result<ResponseData, Ctap2StatusCode> {
+        let upgrade_locations = self
+            .upgrade_locations
+            .as_ref()
+            .ok_or(Ctap2StatusCode::CTAP1_ERR_INVALID_COMMAND)?;
+        Ok(ResponseData::AuthenticatorVendorUpgradeInfo(
+            AuthenticatorVendorUpgradeInfoResponse {
+                info: upgrade_locations.partition_address() as u32,
+            },
+        ))
     }
 
     pub fn generate_auth_data(
@@ -2833,8 +2942,8 @@ mod test {
         );
         assert_eq!(
             response,
-            Ok(ResponseData::AuthenticatorVendor(
-                AuthenticatorVendorResponse {
+            Ok(ResponseData::AuthenticatorVendorConfigure(
+                AuthenticatorVendorConfigureResponse {
                     cert_programmed: false,
                     pkey_programmed: false,
                 }
@@ -2856,8 +2965,8 @@ mod test {
         );
         assert_eq!(
             response,
-            Ok(ResponseData::AuthenticatorVendor(
-                AuthenticatorVendorResponse {
+            Ok(ResponseData::AuthenticatorVendorConfigure(
+                AuthenticatorVendorConfigureResponse {
                     cert_programmed: true,
                     pkey_programmed: true,
                 }
@@ -2894,8 +3003,8 @@ mod test {
         );
         assert_eq!(
             response,
-            Ok(ResponseData::AuthenticatorVendor(
-                AuthenticatorVendorResponse {
+            Ok(ResponseData::AuthenticatorVendorConfigure(
+                AuthenticatorVendorConfigureResponse {
                     cert_programmed: true,
                     pkey_programmed: true,
                 }
@@ -2928,10 +3037,225 @@ mod test {
         );
         assert_eq!(
             response,
-            Ok(ResponseData::AuthenticatorVendor(
-                AuthenticatorVendorResponse {
+            Ok(ResponseData::AuthenticatorVendorConfigure(
+                AuthenticatorVendorConfigureResponse {
                     cert_programmed: true,
                     pkey_programmed: true,
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_metadata() {
+        let mut rng = ThreadRng256 {};
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        // The test buffer starts fully erased with 0xFF bytes.
+        // The compiler issues an incorrect warning.
+        #[allow(unused_mut)]
+        let mut upgrade_locations = ctap_state.upgrade_locations.as_mut().unwrap();
+
+        // Partition of 0x40000 bytes and 8 bytes metadata are hashed.
+        let hashed_data = vec![0xFF; 0x40000 + 8];
+        let expected_hash = Sha256::hash(&hashed_data);
+        let mut metadata = vec![0xFF; 40];
+        metadata[..32].copy_from_slice(&expected_hash);
+        assert_eq!(
+            parse_metadata(upgrade_locations, &metadata),
+            Ok(expected_hash)
+        );
+
+        // Any manipulation of data fails.
+        metadata[32] = 0x88;
+        assert_eq!(
+            parse_metadata(upgrade_locations, &metadata),
+            Err(Ctap2StatusCode::CTAP2_ERR_INTEGRITY_FAILURE)
+        );
+        metadata[32] = 0xFF;
+        metadata[0] ^= 0x01;
+        assert_eq!(
+            parse_metadata(upgrade_locations, &metadata),
+            Err(Ctap2StatusCode::CTAP2_ERR_INTEGRITY_FAILURE)
+        );
+        metadata[0] ^= 0x01;
+        upgrade_locations.write_partition(0, &[0x88; 1]).unwrap();
+        assert_eq!(
+            parse_metadata(upgrade_locations, &metadata),
+            Err(Ctap2StatusCode::CTAP2_ERR_INTEGRITY_FAILURE)
+        );
+    }
+
+    #[test]
+    fn test_verify_signature() {
+        let mut rng = ThreadRng256 {};
+        let private_key = crypto::ecdsa::SecKey::gensk(&mut rng);
+        let message = [0x44; 64];
+        let signed_hash = Sha256::hash(&message);
+        let signature = private_key.sign_rfc6979::<Sha256>(&message);
+
+        let mut signature_bytes = [0; ecdsa::Signature::BYTES_LENGTH];
+        signature.to_bytes(&mut signature_bytes);
+        let cose_signature = CoseSignature {
+            algorithm: SignatureAlgorithm::ES256,
+            bytes: signature_bytes,
+        };
+
+        let public_key = private_key.genpk();
+        let mut public_key_bytes = vec![];
+        cbor_write(
+            cbor::Value::from(CoseKey::from(public_key)),
+            &mut public_key_bytes,
+        )
+        .unwrap();
+
+        assert_eq!(
+            verify_signature(
+                Some(cose_signature.clone()),
+                &public_key_bytes,
+                &signed_hash
+            ),
+            Ok(())
+        );
+        assert_eq!(
+            verify_signature(Some(cose_signature.clone()), &public_key_bytes, &[0x55; 32]),
+            Err(Ctap2StatusCode::CTAP2_ERR_INTEGRITY_FAILURE)
+        );
+        public_key_bytes[0] ^= 0x01;
+        assert_eq!(
+            verify_signature(Some(cose_signature), &public_key_bytes, &signed_hash),
+            Err(Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR)
+        );
+        public_key_bytes[0] ^= 0x01;
+        assert_eq!(
+            verify_signature(None, &public_key_bytes, &signed_hash),
+            Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)
+        );
+        signature_bytes[0] ^= 0x01;
+        let cose_signature = CoseSignature {
+            algorithm: SignatureAlgorithm::ES256,
+            bytes: signature_bytes,
+        };
+        assert_eq!(
+            verify_signature(Some(cose_signature), &public_key_bytes, &signed_hash),
+            Err(Ctap2StatusCode::CTAP2_ERR_INTEGRITY_FAILURE)
+        );
+    }
+
+    #[test]
+    fn test_vendor_upgrade() {
+        // The test partition storage has size 0x40000.
+        // The test metadata storage has size 0x1000.
+        // The test identifier matches partition B.
+        let mut rng = ThreadRng256 {};
+        let private_key = crypto::ecdsa::SecKey::gensk(&mut rng);
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+
+        let data = vec![0xFF; 0x1000];
+        let hash = Sha256::hash(&data).to_vec();
+        let upgrade_locations = ctap_state.upgrade_locations.as_ref().unwrap();
+        let partition_length = upgrade_locations.partition_length();
+        let mut signed_over_data = upgrade_locations
+            .read_partition(0, partition_length)
+            .unwrap()
+            .to_vec();
+        signed_over_data.extend(&[0xFF; 8]);
+        let signed_hash = Sha256::hash(&signed_over_data);
+        let mut metadata = data.clone();
+        metadata[..32].copy_from_slice(&signed_hash);
+        let metadata_hash = Sha256::hash(&metadata).to_vec();
+
+        let signature = private_key.sign_rfc6979::<Sha256>(&signed_over_data);
+        let mut signature_bytes = [0; ecdsa::Signature::BYTES_LENGTH];
+        signature.to_bytes(&mut signature_bytes);
+        let cose_signature = CoseSignature {
+            algorithm: SignatureAlgorithm::ES256,
+            bytes: signature_bytes,
+        };
+
+        // Write to partition and metadata.
+        let response = ctap_state.process_vendor_upgrade(AuthenticatorVendorUpgradeParameters {
+            address: Some(0x20000),
+            data: data.clone(),
+            hash: hash.clone(),
+            signature: None,
+        });
+
+        // We can't inject a public key for our known private key, so the last upgrade step fails.
+        // verify_signature is separately tested for that reason.
+        assert_eq!(response, Ok(ResponseData::AuthenticatorVendorUpgrade));
+        let response = ctap_state.process_vendor_upgrade(AuthenticatorVendorUpgradeParameters {
+            address: None,
+            data: metadata.clone(),
+            hash: metadata_hash.clone(),
+            signature: Some(cose_signature.clone()),
+        });
+        assert_eq!(response, Err(Ctap2StatusCode::CTAP2_ERR_INTEGRITY_FAILURE));
+
+        // Write metadata partly, expecting it to be filled with 0xFF. Fails like above.
+        let response = ctap_state.process_vendor_upgrade(AuthenticatorVendorUpgradeParameters {
+            address: None,
+            data: metadata[..0x800].to_vec(),
+            hash: metadata_hash,
+            signature: Some(cose_signature),
+        });
+        assert_eq!(response, Err(Ctap2StatusCode::CTAP2_ERR_INTEGRITY_FAILURE));
+
+        // Write outside of the partition.
+        let response = ctap_state.process_vendor_upgrade(AuthenticatorVendorUpgradeParameters {
+            address: Some(0x40000),
+            data: data.clone(),
+            hash,
+            signature: None,
+        });
+        assert_eq!(response, Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER));
+
+        // Write a bad hash.
+        let response = ctap_state.process_vendor_upgrade(AuthenticatorVendorUpgradeParameters {
+            address: Some(0x20000),
+            data,
+            hash: [0xEE; 32].to_vec(),
+            signature: None,
+        });
+        assert_eq!(response, Err(Ctap2StatusCode::CTAP2_ERR_INTEGRITY_FAILURE));
+    }
+
+    #[test]
+    fn test_vendor_upgrade_no_second_partition() {
+        let mut rng = ThreadRng256 {};
+        let user_immediately_present = |_| Ok(());
+        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        ctap_state.upgrade_locations = None;
+
+        let data = vec![0xFF; 0x1000];
+        let hash = Sha256::hash(&data).to_vec();
+        let response = ctap_state.process_vendor_upgrade(AuthenticatorVendorUpgradeParameters {
+            address: Some(0),
+            data,
+            hash,
+            signature: None,
+        });
+        assert_eq!(response, Err(Ctap2StatusCode::CTAP1_ERR_INVALID_COMMAND));
+    }
+
+    #[test]
+    fn test_vendor_upgrade_info() {
+        let mut rng = ThreadRng256 {};
+        let user_immediately_present = |_| Ok(());
+        let ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        let partition_address = ctap_state
+            .upgrade_locations
+            .as_ref()
+            .unwrap()
+            .partition_address();
+
+        let upgrade_info_reponse = ctap_state.process_vendor_upgrade_info();
+        assert_eq!(
+            upgrade_info_reponse,
+            Ok(ResponseData::AuthenticatorVendorUpgradeInfo(
+                AuthenticatorVendorUpgradeInfoResponse {
+                    info: partition_address as u32,
                 }
             ))
         );

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -3155,6 +3155,7 @@ mod test {
         let private_key = crypto::ecdsa::SecKey::gensk(&mut rng);
         let user_immediately_present = |_| Ok(());
         let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        const METADATA_LEN: usize = 40;
 
         let data = vec![0xFF; 0x1000];
         let hash = Sha256::hash(&data).to_vec();
@@ -3164,9 +3165,9 @@ mod test {
             .read_partition(0, partition_length)
             .unwrap()
             .to_vec();
-        signed_over_data.extend(&[0xFF; 8]);
+        signed_over_data.extend(&[0xFF; METADATA_LEN - 32]);
         let signed_hash = Sha256::hash(&signed_over_data);
-        let mut metadata = vec![0xFF; 40];
+        let mut metadata = vec![0xFF; METADATA_LEN];
         metadata[..32].copy_from_slice(&signed_hash);
         let metadata_hash = Sha256::hash(&metadata).to_vec();
 
@@ -3200,7 +3201,7 @@ mod test {
         // Write metadata of a wrong size.
         let response = ctap_state.process_vendor_upgrade(AuthenticatorVendorUpgradeParameters {
             address: None,
-            data: metadata[..39].to_vec(),
+            data: metadata[..METADATA_LEN - 1].to_vec(),
             hash: metadata_hash,
             signature: Some(cose_signature),
         });


### PR DESCRIPTION
Implements the commands to upgrade OpenSK. While this PR is pretty large, the most (only interesting) changes are on the actual command logic in `mod.rs`. The other changes are:
- renamed the `Vendor` command to `VendorConfigure`, since we now have more than one vendor command
- added input parameter types to `command.rs`
- added output parameter types to `response.rs`

A few comments:
1. The `Upgrade` command does not come with any way to continue an interrupted upgrade. We might want to add that, or keep 
this nice and simple approach. I'd keep that discussion outside of this PR.
2. The `UpgradeInfo` could be integrated into `GetInfo` in the future, but it does not have a vendor section, so I had to write a new command. We could have used a high parameter number from `GetInfo`, hoping it will not be used in the near future, but the new command was not much more expensive in binary size.
3. The binary size increase due to this PR is around 4 kB.
4. The `UpgradeInfo` is probably not final. There is some freedom in how we implement it, and what other parties need for it to be useful. Conceptually, we need some way to identify where the upgrade is written to, and this identifier will be transmitted to the upgrade server. A valid concern with the chosen approach is that vendors could misuse it to uniquely identify users. This is detectable and therefore not too bad, but might still make sense to avoid. We could piggy-back it into the firmware version or AAGUID too. All this depends on discussions with FIDO, and is therefore subject to change. The current implementation's purpose is to work in a proof of concept.
