### PR TITLE
Fix CBOR fuzzing timeout

### DIFF
--- a/libraries/cbor/src/values.rs
+++ b/libraries/cbor/src/values.rs
@@ -127,7 +127,7 @@ impl Ord for Value {
                 // Arrays of same length.
                 let mut ordering = Ordering::Equal;
                 for (e1, e2) in a1.iter().zip(a2.iter()) {
-                    ordering = ordering.then(e1.cmp(e2));
+                    ordering = e1.cmp(e2);
                     if !matches!(ordering, Ordering::Equal) {
                         break;
                     }
@@ -139,8 +139,7 @@ impl Ord for Value {
                 // Maps of same length.
                 let mut ordering = Ordering::Equal;
                 for ((k1, v1), (k2, v2)) in m1.iter().zip(m2.iter()) {
-                    ordering = ordering.then(k1.cmp(k2));
-                    ordering = ordering.then_with(|| v1.cmp(v2));
+                    ordering = k1.cmp(k2).then_with(|| v1.cmp(v2));
                     if !matches!(ordering, Ordering::Equal) {
                         break;
                     }


### PR DESCRIPTION
oss-fuzz reported a timeout in the CBOR parser. This timeout can be triggered with an adversarial example of nested arrays or maps, that lead to a specific recursive code path. This led to a regular sized input that needed more than 1 minute to parse. The new implementation is near instant on the same input, as it should be.

The simplest implementation of `cmp` is to encode both values and then compare these byte-by-byte. For nested structures, this means that inner values are written more than once.
The new implementation is still recursive, but is much more likely to early return. Before, we'd have written the whole byte array, and then started comparing. Now, we `break` whenever we have the first mismatch.

Note that this is not an issue for any valid security key inputs. The comparison is used to sort map keys, and arrays or maps are never a map key in CTAP. Maybe someone really uses arrays as map keys, at least CTAP allows it.

I quickly fuzzed the new implementation against the old one, and libfuzzer didn't find any inputs with different results.

This is the (potentially private until fixed) link to the auto-created bug:
[Timeout reported by oss-fuzz](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=37342)

I added @ia0 as a reviewer, thinking that he would like this kind of bug. Feel free to send it to anyone else in the team though :)