### PR TITLE
Fix possible missing entries after multiple consecutive interrupted overflowing compactions

### DIFF
--- a/libraries/persistent_store/fuzz/src/store.rs
+++ b/libraries/persistent_store/fuzz/src/store.rs
@@ -53,6 +53,7 @@ pub fn fuzz(mut data: &[u8], debug: bool, stats: Option<&mut Stats>) {
                 driver.check().unwrap();
             }
             if fuzzer.debug {
+                println!("{:?}", driver.model().content());
                 println!("----------------------------------------------------------------------");
             }
         }

--- a/libraries/persistent_store/src/driver.rs
+++ b/libraries/persistent_store/src/driver.rs
@@ -17,7 +17,7 @@
 //! [`StoreDriver`] wraps a [`Store`] and compares its behavior with its associated [`StoreModel`].
 
 use crate::format::{Format, Position};
-#[cfg(test)]
+#[cfg(feature = "std")]
 use crate::StoreUpdate;
 use crate::{
     BufferCorruptFunction, BufferOptions, BufferStorage, Nat, Store, StoreError, StoreHandle,
@@ -431,7 +431,7 @@ impl StoreDriverOn {
     }
 
     /// Applies an insertion to the store and model without interruption.
-    #[cfg(test)]
+    #[cfg(feature = "std")]
     pub fn insert(&mut self, key: usize, value: &[u8]) -> Result<(), StoreInvariant> {
         let value = value.to_vec();
         let updates = vec![StoreUpdate::Insert { key, value }];
@@ -439,7 +439,7 @@ impl StoreDriverOn {
     }
 
     /// Applies a deletion to the store and model without interruption.
-    #[cfg(test)]
+    #[cfg(feature = "std")]
     pub fn remove(&mut self, key: usize) -> Result<(), StoreInvariant> {
         let updates = vec![StoreUpdate::Remove { key }];
         self.apply(StoreOperation::Transaction { updates })

--- a/libraries/persistent_store/src/driver.rs
+++ b/libraries/persistent_store/src/driver.rs
@@ -200,6 +200,14 @@ impl StoreDriver {
         }
     }
 
+    /// Provides read-only access to the model.
+    pub fn model(&self) -> &StoreModel {
+        match self {
+            StoreDriver::On(x) => x.model(),
+            StoreDriver::Off(x) => x.model(),
+        }
+    }
+
     /// Extracts the power-on version of the driver.
     pub fn on(self) -> Option<StoreDriverOn> {
         match self {

--- a/libraries/persistent_store/src/format.rs
+++ b/libraries/persistent_store/src/format.rs
@@ -266,24 +266,24 @@ impl Format {
 
     /// The total virtual capacity in words, denoted by V.
     ///
-    /// We have V = (N - 1) × (Q - 1) - M.
+    /// We have V = (N - 1) × Q - M - 1.
     ///
-    /// We can show V ≥ (N - 2) × (Q - 1) with the following steps:
-    /// - M ≤ Q - 1 from M < Q from [M](Format::max_prefix_len)'s definition
-    /// - -M ≥ -(Q - 1) from above
-    /// - V ≥ (N - 1) × (Q - 1) - (Q - 1) from V's definition
+    /// We can show V ≥ (N - 2) × Q with the following steps:
+    /// - M + 1 ≤ Q from M < Q from [M](Format::max_prefix_len)'s definition
+    /// - -M - 1 ≥ -Q from above
+    /// - V ≥ (N - 1) × Q - Q from V's definition
     pub fn virt_size(&self) -> Nat {
-        (self.num_pages() - 1) * (self.virt_page_size() - 1) - self.max_prefix_len()
+        (self.num_pages() - 1) * self.virt_page_size() - self.max_prefix_len() - 1
     }
 
     /// The total user capacity in words, denoted by C.
     ///
-    /// We have C = V - N = (N - 1) × (Q - 2) - M - 1.
+    /// We have C = V - N = (N - 1) × (Q - 1) - M - 2.
     ///
-    /// We can show C ≥ (N - 2) × (Q - 2) - 2 with the following steps:
-    /// - V ≥ (N - 2) × (Q - 1) from [V](Format::virt_size)'s definition
-    /// - C ≥ (N - 2) × (Q - 1) - N from C's definition
-    /// - (N - 2) × (Q - 1) - N = (N - 2) × (Q - 2) - 2 by calculus
+    /// We can show C ≥ (N - 2) × (Q - 1) - 2 with the following steps:
+    /// - V ≥ (N - 2) × Q from [V](Format::virt_size)'s definition
+    /// - C ≥ (N - 2) × Q - N from C's definition
+    /// - (N - 2) × Q - N = (N - 2) × (Q - 1) - 2 by calculus
     pub fn total_capacity(&self) -> Nat {
         // From the virtual capacity, we reserve N - 1 words for `Erase` entries and 1 word for a
         // `Clear` entry.

--- a/libraries/persistent_store/src/store.rs
+++ b/libraries/persistent_store/src/store.rs
@@ -354,7 +354,7 @@ impl<S: Storage> Store<S> {
             .build_internal(InternalEntry::Clear { min_key })?;
         // We always have one word available. We can't use `reserve` because this is internal
         // capacity, not user capacity.
-        while self.immediate_capacity()? < 1 {
+        while self.immediate_capacity()?.unwrap_or(0) < 1 {
             self.compact()?;
         }
         let tail = self.tail()?;
@@ -370,8 +370,9 @@ impl<S: Storage> Store<S> {
         if self.capacity()?.remaining() < length {
             return Err(StoreError::NoCapacity);
         }
-        if self.immediate_capacity()? < usize_to_nat(length) {
+        if self.immediate_capacity()?.unwrap_or(0) < usize_to_nat(length) {
             self.compact()?;
+            self.finish_compaction()?;
         }
         Ok(())
     }
@@ -521,10 +522,11 @@ impl<S: Storage> Store<S> {
         self.head = Some(head);
         let head_page = head.page(&self.format);
         match self.parse_compact(head_page)? {
-            WordState::Erased => Ok(()),
-            WordState::Partial => self.compact(),
-            WordState::Valid(_) => self.compact_copy(),
+            WordState::Erased => (),
+            WordState::Partial => self.compact()?,
+            WordState::Valid(_) => self.compact_copy()?,
         }
+        self.finish_compaction()
     }
 
     /// Recover a possible interrupted operation which is not a compaction.
@@ -685,7 +687,7 @@ impl<S: Storage> Store<S> {
         if self.capacity()?.remaining() < length as usize {
             return Err(StoreError::NoCapacity);
         }
-        while self.immediate_capacity()? < length {
+        while self.immediate_capacity()?.unwrap_or(0) < length {
             self.compact()?;
         }
         Ok(())
@@ -782,6 +784,23 @@ impl<S: Storage> Store<S> {
         self.wipe_span(pos, head - pos)?;
         // Mark the erase entry as done.
         self.set_padding(erase)?;
+        Ok(())
+    }
+
+    /// Finish a compaction sequence.
+    ///
+    /// Because compaction may temporarily move the tail outside the virtual window, we must keep
+    /// compacting until that invariant is restored. As such, this function must be called each time
+    /// the store is compacted without checking whether there is immediate capacity.
+    fn finish_compaction(&mut self) -> StoreResult<()> {
+        let mut count = self.format.num_pages() - 2;
+        while count > 0 && self.immediate_capacity()?.is_none() {
+            self.compact()?;
+            count -= 1;
+        }
+        if self.immediate_capacity()?.is_none() {
+            return Err(StoreError::InvalidStorage);
+        }
         Ok(())
     }
 
@@ -926,10 +945,10 @@ impl<S: Storage> Store<S> {
     }
 
     /// Returns the number of words that can be written without compaction.
-    fn immediate_capacity(&self) -> StoreResult<Nat> {
+    fn immediate_capacity(&self) -> StoreResult<Option<Nat>> {
         let tail = self.tail()?;
         let end = or_invalid(self.head)? + self.format.virt_size();
-        Ok(end.get().saturating_sub(tail.get()))
+        Ok(end.get().checked_sub(tail.get()))
     }
 
     /// Returns the position of the first word in the store.
@@ -1394,34 +1413,34 @@ mod tests {
         let mut driver = MINIMAL.new_driver().power_on().unwrap();
 
         // Don't compact if enough immediate capacity.
-        assert_eq!(driver.store().immediate_capacity().unwrap(), 39);
-        assert_eq!(driver.store().capacity().unwrap().remaining(), 34);
+        assert_eq!(driver.store().immediate_capacity().unwrap(), Some(42));
+        assert_eq!(driver.store().capacity().unwrap().remaining(), 37);
         assert_eq!(driver.store().head().unwrap().get(), 0);
-        driver.store_mut().prepare(34).unwrap();
+        driver.store_mut().prepare(37).unwrap();
         assert_eq!(driver.store().head().unwrap().get(), 0);
 
         // Fill the store.
         for key in 0..4 {
-            driver.insert(key, &[0x38; 28]).unwrap();
+            driver.insert(key, &[0x38; 32]).unwrap();
         }
         driver.check().unwrap();
-        assert_eq!(driver.store().immediate_capacity().unwrap(), 7);
-        assert_eq!(driver.store().capacity().unwrap().remaining(), 2);
+        assert_eq!(driver.store().immediate_capacity().unwrap(), Some(6));
+        assert_eq!(driver.store().capacity().unwrap().remaining(), 1);
         // Removing entries increases available capacity but not immediate capacity.
         driver.remove(0).unwrap();
         driver.remove(2).unwrap();
         driver.check().unwrap();
-        assert_eq!(driver.store().immediate_capacity().unwrap(), 7);
-        assert_eq!(driver.store().capacity().unwrap().remaining(), 18);
+        assert_eq!(driver.store().immediate_capacity().unwrap(), Some(6));
+        assert_eq!(driver.store().capacity().unwrap().remaining(), 19);
 
-        // Prepare for next write (7 words data + 1 word overhead).
+        // Prepare for next write (8 words data + 1 word overhead).
         assert_eq!(driver.store().head().unwrap().get(), 0);
-        driver.store_mut().prepare(8).unwrap();
+        driver.store_mut().prepare(9).unwrap();
         driver.check().unwrap();
-        assert_eq!(driver.store().head().unwrap().get(), 16);
+        assert_eq!(driver.store().head().unwrap().get(), 18);
         // The available capacity did not change, but the immediate capacity is above 8.
-        assert_eq!(driver.store().immediate_capacity().unwrap(), 14);
-        assert_eq!(driver.store().capacity().unwrap().remaining(), 18);
+        assert_eq!(driver.store().immediate_capacity().unwrap(), Some(14));
+        assert_eq!(driver.store().capacity().unwrap().remaining(), 19);
     }
 
     #[test]

--- a/libraries/persistent_store/src/test.rs
+++ b/libraries/persistent_store/src/test.rs
@@ -67,13 +67,13 @@ const TITAN: Config = Config {
 #[test]
 fn nordic_capacity() {
     let driver = NORDIC.new_driver().power_on().unwrap();
-    assert_eq!(driver.model().capacity().total, 19123);
+    assert_eq!(driver.model().capacity().total, 19141);
 }
 
 #[test]
 fn titan_capacity() {
     let driver = TITAN.new_driver().power_on().unwrap();
-    assert_eq!(driver.model().capacity().total, 4315);
+    assert_eq!(driver.model().capacity().total, 4323);
 }
 
 #[test]

--- a/libraries/persistent_store/tests/store.rs
+++ b/libraries/persistent_store/tests/store.rs
@@ -1,0 +1,51 @@
+use persistent_store::{BufferOptions, StoreDriverOff, StoreInterruption, StoreOperation};
+
+#[test]
+fn interrupted_overflowing_compaction() {
+    let options = BufferOptions {
+        word_size: 4,
+        page_size: 32,
+        max_word_writes: 2,
+        max_page_erases: 3,
+        strict_mode: true,
+    };
+    let num_pages = 7;
+    let mut driver = StoreDriverOff::new(options, num_pages).power_on().unwrap();
+    let v = driver.model().format().virt_size() as usize;
+    let c = driver.model().format().total_capacity() as usize;
+    let q = driver.model().format().virt_page_size() as usize;
+
+    // We setup the storage such that the next 2 compactions are overflowing. This means they copy 1
+    // more word than the size of a page.
+    let mut k = 0;
+    // Fill the first 2 pages with non-deleted entries.
+    while k < 2 * q {
+        driver.insert(k, &[]).unwrap();
+        k += 1;
+    }
+    // Write enough deleted entries to be able to continue writing without compaction.
+    for _ in c..v {
+        driver.insert(k, &[]).unwrap();
+    }
+    // Fill until the end of the window with deleted entries.
+    while k < c {
+        driver.insert(k, &[]).unwrap();
+        driver.remove(k).unwrap();
+        k += 1;
+    }
+    // Make sure we did not compact and we actually filled until the end of the window.
+    assert_eq!(driver.store().lifetime().unwrap().used(), v);
+
+    // We trigger 2 interrupted overflowing compactions, which would move the last non-deleted entry
+    // out of the window unless additional compactions are done to restore the overflow.
+    for _ in 0..2 {
+        let interruption = StoreInterruption {
+            delay: 0,
+            corrupt: Box::new(|old, new| old.copy_from_slice(new)),
+        };
+        match driver.partial_apply(StoreOperation::Prepare { length: 1 }, interruption) {
+            Ok((None, d)) => driver = d.power_on().unwrap(),
+            _ => unreachable!(),
+        }
+    }
+}


### PR DESCRIPTION
Compaction may temporarily break the invariant that the tail of the store is within the window (i.e. tail <= head + virt_size). This is not a problem while the store is powered because compactions continue until the invariant is restored. However, if a compaction is interrupted (power is lost before 100ms), only that compaction is resumed at boot time and the invariant may stay broken. This change fixes this by continuing compacting until the invariant is restored.

This change also increases the window size. The previous value was too conservative (accounting for erase entries twice).

The consequences of this bug are that entries which header lies in the last K - 1 words of storage are hidden until the next mutable operation, where K is the number of consecutive overflowing compactions (an overflowing compaction is when the compacted page is full of non-deleted entries) from which the last is interrupted. In other words, there must be at least 2 consecutive overflowing compactions to hide an empty entry (e.g. force pin change, enterprise attestation enable, always UV), and 3 to hide an entry of length at most 4 bytes (e.g. pin retries, pin length, signature counter).