### PR TITLE
Introduce window size and use it to do #386 correctly

### DIFF
--- a/libraries/persistent_store/src/driver.rs
+++ b/libraries/persistent_store/src/driver.rs
@@ -453,6 +453,12 @@ impl StoreDriverOn {
         self.apply(StoreOperation::Transaction { updates })
     }
 
+    /// Applies a clear operation to the store and model without interruption.
+    #[cfg(feature = "std")]
+    pub fn clear(&mut self, min_key: usize) -> Result<(), StoreInvariant> {
+        self.apply(StoreOperation::Clear { min_key })
+    }
+
     /// Checks that the store and model are in sync.
     pub fn check(&self) -> Result<(), StoreInvariant> {
         self.recover_check(&[])
@@ -607,6 +613,14 @@ impl<'a> StoreInterruption<'a> {
     pub fn none() -> StoreInterruption<'a> {
         StoreInterruption {
             delay: usize::max_value(),
+            corrupt: Box::new(|_, _| {}),
+        }
+    }
+
+    /// Builds an interruption without corruption.
+    pub fn pure(delay: usize) -> StoreInterruption<'a> {
+        StoreInterruption {
+            delay,
             corrupt: Box::new(|_, _| {}),
         }
     }

--- a/libraries/persistent_store/src/format.rs
+++ b/libraries/persistent_store/src/format.rs
@@ -266,24 +266,24 @@ impl Format {
 
     /// The total virtual capacity in words, denoted by V.
     ///
-    /// We have V = (N - 1) × Q - M - 1.
+    /// We have V = (N - 1) × (Q - 1) - M.
     ///
-    /// We can show V ≥ (N - 2) × Q with the following steps:
-    /// - M + 1 ≤ Q from M < Q from [M](Format::max_prefix_len)'s definition
-    /// - -M - 1 ≥ -Q from above
-    /// - V ≥ (N - 1) × Q - Q from V's definition
+    /// We can show V ≥ (N - 2) × (Q - 1) with the following steps:
+    /// - M ≤ Q - 1 from M < Q from [M](Format::max_prefix_len)'s definition
+    /// - -M ≥ -(Q - 1) from above
+    /// - V ≥ (N - 1) × (Q - 1) - (Q - 1) from V's definition
     pub fn virt_size(&self) -> Nat {
-        (self.num_pages() - 1) * self.virt_page_size() - self.max_prefix_len() - 1
+        (self.num_pages() - 1) * (self.virt_page_size() - 1) - self.max_prefix_len()
     }
 
     /// The total user capacity in words, denoted by C.
     ///
-    /// We have C = V - N = (N - 1) × (Q - 1) - M - 2.
+    /// We have C = V - N = (N - 1) × (Q - 2) - M - 1.
     ///
-    /// We can show C ≥ (N - 2) × (Q - 1) - 2 with the following steps:
-    /// - V ≥ (N - 2) × Q from [V](Format::virt_size)'s definition
-    /// - C ≥ (N - 2) × Q - N from C's definition
-    /// - (N - 2) × Q - N = (N - 2) × (Q - 1) - 2 by calculus
+    /// We can show C ≥ (N - 2) × (Q - 2) - 2 with the following steps:
+    /// - V ≥ (N - 2) × (Q - 1) from [V](Format::virt_size)'s definition
+    /// - C ≥ (N - 2) × (Q - 1) - N from C's definition
+    /// - (N - 2) × (Q - 1) - N = (N - 2) × (Q - 2) - 2 by calculus
     pub fn total_capacity(&self) -> Nat {
         // From the virtual capacity, we reserve N - 1 words for `Erase` entries and 1 word for a
         // `Clear` entry.

--- a/libraries/persistent_store/src/format.rs
+++ b/libraries/persistent_store/src/format.rs
@@ -264,14 +264,23 @@ impl Format {
         self.bytes_to_words(self.max_value_len())
     }
 
+    /// The virtual window size in words, denoted by W.
+    ///
+    /// This is the span of virtual storage that is accessible. In particular, all store content
+    /// fits within this window.
+    ///
+    /// We have W = (N - 1) × Q - M.
+    pub fn window_size(&self) -> Nat {
+        (self.num_pages() - 1) * self.virt_page_size() - self.max_prefix_len()
+    }
+
     /// The total virtual capacity in words, denoted by V.
     ///
-    /// We have V = (N - 1) × (Q - 1) - M.
+    /// This is the span of virtual storage after which we trigger a compaction. This is smaller
+    /// than the virtual window because compaction may transiently overflow out of this virtual
+    /// capacity.
     ///
-    /// We can show V ≥ (N - 2) × (Q - 1) with the following steps:
-    /// - M ≤ Q - 1 from M < Q from [M](Format::max_prefix_len)'s definition
-    /// - -M ≥ -(Q - 1) from above
-    /// - V ≥ (N - 1) × (Q - 1) - (Q - 1) from V's definition
+    /// We have V = W - (N - 1) = (N - 1) × (Q - 1) - M.
     pub fn virt_size(&self) -> Nat {
         (self.num_pages() - 1) * (self.virt_page_size() - 1) - self.max_prefix_len()
     }
@@ -281,9 +290,9 @@ impl Format {
     /// We have C = V - N = (N - 1) × (Q - 2) - M - 1.
     ///
     /// We can show C ≥ (N - 2) × (Q - 2) - 2 with the following steps:
-    /// - V ≥ (N - 2) × (Q - 1) from [V](Format::virt_size)'s definition
-    /// - C ≥ (N - 2) × (Q - 1) - N from C's definition
-    /// - (N - 2) × (Q - 1) - N = (N - 2) × (Q - 2) - 2 by calculus
+    /// - M ≤ Q - 1 from M < Q from [M](Format::max_prefix_len)'s definition
+    /// - C ≥ (N - 1) × (Q - 2) - (Q - 1) - 1 from C's definition
+    /// - C ≥ (N - 2) × (Q - 2) - 2 by calculus
     pub fn total_capacity(&self) -> Nat {
         // From the virtual capacity, we reserve N - 1 words for `Erase` entries and 1 word for a
         // `Clear` entry.
@@ -353,7 +362,7 @@ impl Format {
             WordState::Partial
         } else {
             let tail = COMPACT_TAIL.get(word);
-            if tail > self.virt_size() + self.max_prefix_len() {
+            if tail > self.window_size() {
                 return Err(StoreError::InvalidStorage);
             }
             WordState::Valid(CompactInfo { tail })

--- a/libraries/persistent_store/src/store.rs
+++ b/libraries/persistent_store/src/store.rs
@@ -532,7 +532,7 @@ impl<S: Storage> Store<S> {
         self.entries = Some(Vec::new());
         let mut pos = or_invalid(self.head)?;
         let mut prev_pos = pos;
-        let end = pos + self.format.virt_size();
+        let end = pos + self.format.window_size();
         while pos < end {
             let entry_pos = pos;
             match self.parse_entry(&mut pos)? {
@@ -789,7 +789,7 @@ impl<S: Storage> Store<S> {
     fn transaction_apply(&mut self, sorted_keys: &[Nat], marker: Position) -> StoreResult<()> {
         self.delete_keys(&sorted_keys, marker)?;
         self.set_padding(marker)?;
-        let end = or_invalid(self.head)? + self.format.virt_size();
+        let end = or_invalid(self.head)? + self.format.window_size();
         let mut pos = marker + 1;
         while pos < end {
             let entry_pos = pos;

--- a/libraries/persistent_store/src/test.rs
+++ b/libraries/persistent_store/src/test.rs
@@ -67,13 +67,13 @@ const TITAN: Config = Config {
 #[test]
 fn nordic_capacity() {
     let driver = NORDIC.new_driver().power_on().unwrap();
-    assert_eq!(driver.model().capacity().total, 19141);
+    assert_eq!(driver.model().capacity().total, 19123);
 }
 
 #[test]
 fn titan_capacity() {
     let driver = TITAN.new_driver().power_on().unwrap();
-    assert_eq!(driver.model().capacity().total, 4323);
+    assert_eq!(driver.model().capacity().total, 4315);
 }
 
 #[test]

--- a/libraries/persistent_store/tests/store.rs
+++ b/libraries/persistent_store/tests/store.rs
@@ -46,7 +46,10 @@ fn interrupted_overflowing_compaction() {
             StoreInterruption::pure(1),
         ) {
             Ok((None, d)) => driver = d.power_on().unwrap(),
-            _ => unreachable!(),
+            _ => {
+                assert!(false);
+                return;
+            }
         }
     }
 }
@@ -114,7 +117,10 @@ fn full_compaction_with_max_prefix() {
             StoreInterruption::pure(1),
         ) {
             Ok((None, d)) => driver = d.power_on().unwrap(),
-            _ => unreachable!(),
+            _ => {
+                assert!(false);
+                return;
+            }
         }
     }
     check_lifetime(&mut driver, c + n - 1);

--- a/libraries/persistent_store/tests/store.rs
+++ b/libraries/persistent_store/tests/store.rs
@@ -1,7 +1,10 @@
-use persistent_store::{BufferOptions, StoreDriverOff, StoreInterruption, StoreOperation};
+use persistent_store::{
+    BufferOptions, StoreDriverOff, StoreDriverOn, StoreInterruption, StoreOperation,
+};
 
 #[test]
 fn interrupted_overflowing_compaction() {
+    let num_pages = 7;
     let options = BufferOptions {
         word_size: 4,
         page_size: 32,
@@ -9,7 +12,6 @@ fn interrupted_overflowing_compaction() {
         max_page_erases: 3,
         strict_mode: true,
     };
-    let num_pages = 7;
     let mut driver = StoreDriverOff::new(options, num_pages).power_on().unwrap();
     let v = driver.model().format().virt_size() as usize;
     let c = driver.model().format().total_capacity() as usize;
@@ -39,13 +41,81 @@ fn interrupted_overflowing_compaction() {
     // We trigger 2 interrupted overflowing compactions, which would move the last non-deleted entry
     // out of the window unless additional compactions are done to restore the overflow.
     for _ in 0..2 {
-        let interruption = StoreInterruption {
-            delay: 0,
-            corrupt: Box::new(|old, new| old.copy_from_slice(new)),
-        };
-        match driver.partial_apply(StoreOperation::Prepare { length: 1 }, interruption) {
+        match driver.partial_apply(
+            StoreOperation::Prepare { length: 1 },
+            StoreInterruption::pure(1),
+        ) {
             Ok((None, d)) => driver = d.power_on().unwrap(),
             _ => unreachable!(),
         }
     }
+}
+
+#[test]
+fn full_compaction_with_max_prefix() {
+    let num_pages = 7;
+    let options = BufferOptions {
+        word_size: 4,
+        page_size: 32,
+        max_word_writes: 2,
+        max_page_erases: 3,
+        strict_mode: true,
+    };
+    let mut driver = StoreDriverOff::new(options, num_pages).power_on().unwrap();
+    let max_key = driver.model().format().max_key() as usize;
+    let max_value_len = driver.model().format().max_value_len() as usize;
+    let n = driver.model().format().num_pages() as usize;
+    let v = driver.model().format().virt_size() as usize;
+    let c = driver.model().format().total_capacity() as usize;
+    let q = driver.model().format().virt_page_size() as usize;
+    let m = driver.model().format().max_prefix_len() as usize;
+    let get_tail = |driver: &StoreDriverOn| driver.store().lifetime().unwrap().used();
+    let mut last_tail = 0;
+    let mut check_lifetime = |driver: &StoreDriverOn, used| {
+        last_tail += used;
+        assert_eq!(get_tail(driver), last_tail);
+    };
+
+    // We fill the first page with q + m words of padding. In particular, the last entry overlaps
+    // the next page with m words.
+    for _ in 0..q - 1 {
+        driver.clear(max_key).unwrap();
+    }
+    driver.insert(0, &vec![0; max_value_len]).unwrap();
+    driver.remove(0).unwrap();
+    check_lifetime(&driver, q + m);
+
+    // We fill the store with non-deleted entries making sure the last entry always overlaps the
+    // next page with m words for the first 3 pages.
+    let mut k = 0;
+    for _ in 0..c {
+        let tail = get_tail(&driver);
+        if tail % q == q - 1 && tail < 4 * q {
+            driver.insert(k, &vec![0; max_value_len]).unwrap();
+        } else {
+            driver.insert(k, &[]).unwrap();
+        }
+        k += 1;
+    }
+    // We lost 1 word of lifetime because of compacting the first page.
+    check_lifetime(&driver, c + 1);
+
+    // We fill the store with padding until compaction would trigger.
+    for _ in 0..n - 1 {
+        driver.clear(max_key).unwrap();
+    }
+    check_lifetime(&driver, n - 1);
+    assert_eq!(get_tail(&driver), q + m + v);
+
+    // We interrupt all compactions to check the invariant between each compaction.
+    for _ in 0..n - 1 {
+        match driver.partial_apply(
+            StoreOperation::Clear { min_key: max_key },
+            StoreInterruption::pure(1),
+        ) {
+            Ok((None, d)) => driver = d.power_on().unwrap(),
+            _ => unreachable!(),
+        }
+    }
+    check_lifetime(&mut driver, c + n - 1);
 }


### PR DESCRIPTION
After thinking about #386, I've found out that extending the virtual size is wrong and there's a better fix than continuing the compactions during recovery.

This PR is split in 3 commits:
1. Adds a test showing the issue with the extended virtual size.
2. Reverts the 3rd commit of #386 (the only non test-only commit).
3. Introduces the window size (with the same value as the extended virtual size of #386) and keeps the virtual size the same. Also updates the proofs to mention the window size. The proofs are essentially the same though. The only change compared to before #386 is that when reading the store content, we use the window size instead of the virtual size which means we can see the entries that would have been hidden otherwise.

As such this PR is much easily reviewed by looking at commits separately.