### PR TITLE
Remove useless retry-loop

### DIFF
--- a/examples/store_latency.rs
+++ b/examples/store_latency.rs
@@ -113,11 +113,7 @@ fn compute_latency(
     let ((), time) = measure(timer, || {
         for i in 0..count {
             let key = 1 + key_increment * i;
-            // For some reason the kernel sometimes fails.
-            while store.insert(key, &vec![0; 4 * word_length]).is_err() {
-                // We never enter this loop in practice, but we still need it for the kernel.
-                writeln!(console, "Retry insert.").unwrap();
-            }
+            store.insert(key, &vec![0; 4 * word_length]).unwrap();
         }
     });
     writeln!(console, "Setup: {:.1}ms for {} entries.", time.ms(), count).unwrap();


### PR DESCRIPTION
This was needed in the past although we would never entered the loop (calling unwrap directly would fail though). Not sure if the issue was on the kernel or the compiler.