### PR TITLE
erase unused flash pages so hashes matches

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -353,7 +353,7 @@ class OpenSKInstaller:
     return cmd_output.decode()
 
   def update_rustc_if_needed(self):
-    """Updates the Rust and install the necessary target toolchain."""
+    """Updates the Rust and installs the necessary target toolchain."""
     target_toolchain_fullstring = "stable"
     with open("rust-toolchain", "r", encoding="utf-8") as f:
       content = f.readlines()
@@ -658,7 +658,7 @@ class OpenSKInstaller:
 
   # pylint: disable=protected-access
   def verify_flashed_app(self, expected_app: str) -> bool:
-    """Uses Tockloader check if an app of the expected name was written."""
+    """Uses Tockloader to check if an app of the expected name was written."""
     if self.args.programmer not in ("jlink", "openocd"):
       return False
     tock = loader.TockLoader(self.tockloader_default_args)


### PR DESCRIPTION
The bootloader failed when unused firmware page were not erased. This can happen when firmware images become smaller or spurious data is still on flash.

The PR generalizes the `clear_stoarge` function to take address and size, and uses that before writing kernel and app to make sure the setup is correct.