### PR TITLE
Fail when no devices are found to configure

### DIFF
--- a/tools/configure.py
+++ b/tools/configure.py
@@ -124,7 +124,10 @@ def main(args):
                 length=32, byteorder='big', signed=False)
     }
 
-  for authenticator in tqdm(get_opensk_devices(args.batch)):
+  devices = get_opensk_devices(args.batch)
+  if not devices:
+    fatal("No devices found.")
+  for authenticator in tqdm(devices):
     # If the device supports it, wink to show which device
     # we're going to program.
     if authenticator.device.capabilities & hid.CAPABILITY.WINK:


### PR DESCRIPTION
Fixes  #397

Example output:

```
$ ./tools/configure.py --certificate=crypto_data/opensk_cert.pem --private-key=crypto_data/opensk.key
info: Private key is valid.
info: Certificate is valid.
fatal: No devices found.

$ echo $?
1
```


- [ x] Tests pass
- [ x] Appropriate changes to README are included in PR