### PR TITLE
fixes the serde version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ persistent_store = { path = "libraries/persistent_store" }
 byteorder = { version = "1", default-features = false }
 arrayref = "0.3.6"
 subtle = { version = "2.2", default-features = false, features = ["nightly"] }
+# This import explicitly locks the version.
+serde_json = { version = "=1.0.69", default-features = false, features = ["alloc"] }
 
 [features]
 debug_allocations = ["lang_items/debug_allocations"]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -9,8 +9,9 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = { version = "0.3"}
+libfuzzer-sys = { version = "0.3" }
 fuzz_helper = { path = "fuzz_helper" }
+serde_json = { version = "=1.0.69" }
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,6 +11,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = { version = "0.3" }
 fuzz_helper = { path = "fuzz_helper" }
+# This import explicitly locks the version.
 serde_json = { version = "=1.0.69" }
 
 # Prevent this from interfering with workspaces


### PR DESCRIPTION
Desktop tests and workflows started failing with new nightly features in `serde_json` due to [this release](https://github.com/serde-rs/json/releases/tag/v1.0.70). To fix it, we either have to upgrade to a new nightly compiler or fix the serde_json version to <= 1.0.69.