### PR TITLE
Source-based coverage

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,9 +1,0 @@
-branch: true
-ignore-not-existing: true
-llvm: true
-filter: covered
-output-type: lcov
-output-path: ./lcov.info
-ignore:
-  - "third_party/*"
-  - "/*"

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -39,7 +39,7 @@ jobs:
           RUSTFLAGS: "-Zinstrument-coverage"
           LLVM_PROFILE_FILE: "opensk-%p-%m.profraw"
       - name: Run grcov
-        run: grcov . --binary-path ./target/debug/ -s . -t lcov --ignore-not-existing -o ./lcov.info --ignore "/*" --ignore "examples/*" --ignore "third_party/*"
+        run: grcov . --binary-path ./target/debug/ --source-dir . --output-type lcov --ignore-not-existing ---output-path ./lcov.info --ignore "/*" --ignore "examples/*" --ignore "third_party/*"
       - uses: coverallsapp/github-action@1.1.3
         name: upload report to coveralls
         with:

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -38,8 +38,12 @@ jobs:
         env:
           RUSTFLAGS: "-Zinstrument-coverage"
           LLVM_PROFILE_FILE: "opensk-%p-%m.profraw"
+      - name: Branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: branch_name
       - name: Run grcov
-        run: grcov . --binary-path ./target/debug/ --source-dir . --output-type lcov --ignore-not-existing ---output-path ./lcov.info --ignore "/*" --ignore "examples/*" --ignore "third_party/*"
+        run: grcov . --binary-path ./target/debug/ --source-dir . --output-type lcov --ignore-not-existing ---output-path ./lcov.info --ignore "/*" --ignore "examples/*" --ignore "third_party/*" --vcs-branch ${{ steps.branch_name.outputs.branch }}
       - uses: coverallsapp/github-action@1.1.3
         name: upload report to coveralls
         with:

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -26,6 +26,8 @@ jobs:
         run: python -m pip install --upgrade pip setuptools wheel
       - name: Set up OpenSK
         run: ./setup.sh
+      - name: Install llvm tools
+        run: rustup component add llvm-tools-preview
 
       - name: Install grcov
         run: if [[ ! -e ~/.cargo/bin/grcov ]]; then cargo +stable install grcov; fi
@@ -34,14 +36,13 @@ jobs:
           command: test
           args: --features "with_ctap1,with_nfc,std" --no-fail-fast
         env:
-          CARGO_INCREMENTAL: '0'
-          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-          RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-      - uses: actions-rs/grcov@v0.1.5
-        id: coverage
+          RUSTFLAGS: "-Zinstrument-coverage"
+          LLVM_PROFILE_FILE: "opensk-%p-%m.profraw"
+      - name: Run grcov
+        run: grcov . --binary-path ./target/debug/ -s . -t lcov --ignore-not-existing -o ./lcov.info --ignore "/*" --ignore "examples/*" --ignore "third_party/*"
       - uses: coverallsapp/github-action@1.1.3
         name: upload report to coveralls
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ${{ steps.coverage.outputs.report }}
+          path-to-lcov: "./lcov.info"
 

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -38,12 +38,8 @@ jobs:
         env:
           RUSTFLAGS: "-Zinstrument-coverage"
           LLVM_PROFILE_FILE: "opensk-%p-%m.profraw"
-      - name: Branch name
-        shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: branch_name
       - name: Run grcov
-        run: grcov . --binary-path ./target/debug/ --source-dir . --output-type lcov --ignore-not-existing ---output-path ./lcov.info --ignore "/*" --ignore "examples/*" --ignore "third_party/*" --vcs-branch ${{ steps.branch_name.outputs.branch }}
+        run: grcov . --binary-path ./target/debug/ --source-dir . --output-type lcov --ignore-not-existing ---output-path ./lcov.info --ignore "/*" --ignore "examples/*" --ignore "third_party/*"
       - uses: coverallsapp/github-action@1.1.3
         name: upload report to coveralls
         with:


### PR DESCRIPTION
The coveralls workflow used gcov-based coverage, but the produced information was not precise enough to help improve coverage:

> However, since LLVM doesn’t know exactly how Rust code is structured, there’s a lot lost in the translation between Rust source and LLVM IR. [1]

Instead, we switch to source-based coverage. The generation and upload to coveralls is tested locally and on my branch [2]. Locally produced html looks reasonable and should appear on [3].

I did not include `examples/` in the report. They are our own code, but probably not meant to be tested.

[1] https://blog.rust-lang.org/inside-rust/2020/11/12/source-based-code-coverage.html
[2] https://coveralls.io/builds/44481040
[3] https://coveralls.io/github/google/OpenSK?branch=develop