### PR TITLE
cifuzz: add integration

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,28 @@
+name: CIFuzz
+on: 
+  pull_request:
+    branches:
+      - develop
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'opensk'
+        dry-run: false
+        language: rust
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'opensk'
+        fuzz-seconds: 600
+        dry-run: false
+    - name: Upload Crash
+      uses: actions/upload-artifact@v1
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
Signed-off-by: David Korczynski <david@adalogics.com>

This adds CI integration with CIFuzz. CIFuzz will run the OpenSK OSS-Fuzz fuzzers for a short period of time for each PR. The benefit is that regressions and bugs has a chance of being captured early in the development process.

Referencing: https://github.com/google/OpenSK/pull/417#issuecomment-979889594