### PR TITLE
Forward desktop test fixes

### DIFF
--- a/examples/store_latency.rs
+++ b/examples/store_latency.rs
@@ -54,7 +54,7 @@ unsafe fn boot_store(erase: bool) -> Store<Storage> {
 
 #[derive(Debug)]
 struct StorageConfig {
-    page_size: usize,
+    _page_size: usize,
     num_pages: usize,
 }
 
@@ -62,7 +62,7 @@ fn storage_config() -> StorageConfig {
     use persistent_store::Storage;
     let storage = new_storage().unwrap();
     StorageConfig {
-        page_size: storage.page_size(),
+        _page_size: storage.page_size(),
         num_pages: storage.num_pages(),
     }
 }
@@ -120,7 +120,7 @@ fn compute_latency(
 
     // Measure latency of insert.
     let key = 1 + key_increment * count;
-    let ((), time) = measure(&timer, || {
+    let ((), time) = measure(timer, || {
         store.insert(key, &vec![0; 4 * word_length]).unwrap()
     });
     writeln!(console, "Insert: {:.1}ms.", time.ms()).unwrap();
@@ -131,12 +131,12 @@ fn compute_latency(
     );
 
     // Measure latency of boot.
-    let (mut store, time) = measure(&timer, || unsafe { boot_store(false) });
+    let (mut store, time) = measure(timer, || unsafe { boot_store(false) });
     writeln!(console, "Boot: {:.1}ms.", time.ms()).unwrap();
     stat.boot_ms = time.ms();
 
     // Measure latency of remove.
-    let ((), time) = measure(&timer, || store.remove(key).unwrap());
+    let ((), time) = measure(timer, || store.remove(key).unwrap());
     writeln!(console, "Remove: {:.1}ms.", time.ms()).unwrap();
     stat.remove_ms = time.ms();
 

--- a/examples/store_latency.rs
+++ b/examples/store_latency.rs
@@ -54,7 +54,6 @@ unsafe fn boot_store(erase: bool) -> Store<Storage> {
 
 #[derive(Debug)]
 struct StorageConfig {
-    _page_size: usize,
     num_pages: usize,
 }
 
@@ -62,7 +61,6 @@ fn storage_config() -> StorageConfig {
     use persistent_store::Storage;
     let storage = new_storage().unwrap();
     StorageConfig {
-        _page_size: storage.page_size(),
         num_pages: storage.num_pages(),
     }
 }

--- a/libraries/crypto/Cargo.toml
+++ b/libraries/crypto/Cargo.toml
@@ -19,7 +19,7 @@ ring = { version = "0.16.11", optional = true }
 untrusted = { version = "0.7.0", optional = true }
 rand = { version = "0.6.5", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
-serde_json = { version = "1.0", optional = true }
+serde_json = { version = "=1.0.69", optional = true }
 regex = { version = "1", optional = true }
 
 [features]

--- a/src/ctap/client_pin.rs
+++ b/src/ctap/client_pin.rs
@@ -1553,16 +1553,16 @@ mod test {
             .get_pin_protocol(PinUvAuthProtocol::V1)
             .get_pin_uv_auth_token();
         let pin_uv_auth_param_v1 =
-            authenticate_pin_uv_auth_token(&pin_uv_auth_token_v1, &message, PinUvAuthProtocol::V1);
+            authenticate_pin_uv_auth_token(pin_uv_auth_token_v1, &message, PinUvAuthProtocol::V1);
         let pin_uv_auth_token_v2 = client_pin
             .get_pin_protocol(PinUvAuthProtocol::V2)
             .get_pin_uv_auth_token();
         let pin_uv_auth_param_v2 =
-            authenticate_pin_uv_auth_token(&pin_uv_auth_token_v2, &message, PinUvAuthProtocol::V2);
+            authenticate_pin_uv_auth_token(pin_uv_auth_token_v2, &message, PinUvAuthProtocol::V2);
         let pin_uv_auth_param_v1_from_v2_token =
-            authenticate_pin_uv_auth_token(&pin_uv_auth_token_v2, &message, PinUvAuthProtocol::V1);
+            authenticate_pin_uv_auth_token(pin_uv_auth_token_v2, &message, PinUvAuthProtocol::V1);
         let pin_uv_auth_param_v2_from_v1_token =
-            authenticate_pin_uv_auth_token(&pin_uv_auth_token_v1, &message, PinUvAuthProtocol::V2);
+            authenticate_pin_uv_auth_token(pin_uv_auth_token_v1, &message, PinUvAuthProtocol::V2);
 
         assert_eq!(
             client_pin.verify_pin_uv_auth_token(
@@ -1624,7 +1624,7 @@ mod test {
             .get_pin_protocol(PinUvAuthProtocol::V1)
             .get_pin_uv_auth_token();
         let pin_uv_auth_param_v1 =
-            authenticate_pin_uv_auth_token(&pin_uv_auth_token_v1, &message, PinUvAuthProtocol::V1);
+            authenticate_pin_uv_auth_token(pin_uv_auth_token_v1, &message, PinUvAuthProtocol::V1);
 
         assert_eq!(
             client_pin.verify_pin_uv_auth_token(

--- a/src/ctap/command.rs
+++ b/src/ctap/command.rs
@@ -37,6 +37,7 @@ const MIN_LARGE_BLOB_LEN: usize = 17;
 
 // CTAP specification (version 20190130) section 6.1
 #[derive(Debug, PartialEq)]
+#[allow(clippy::enum_variant_names)]
 pub enum Command {
     AuthenticatorMakeCredential(AuthenticatorMakeCredentialParameters),
     AuthenticatorGetAssertion(AuthenticatorGetAssertionParameters),

--- a/src/ctap/data_formats.rs
+++ b/src/ctap/data_formats.rs
@@ -515,6 +515,7 @@ impl TryFrom<cbor::Value> for SignatureAlgorithm {
 /// The credProtect extension's policies for resident credentials.
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
 #[cfg_attr(test, derive(IntoEnumIterator))]
+#[allow(clippy::enum_variant_names)]
 pub enum CredentialProtectionPolicy {
     /// The credential is always discoverable, as if it had no protection level.
     UserVerificationOptional = 0x01,
@@ -1983,7 +1984,7 @@ mod test {
         assert_eq!(created_cbor, cbor_sub_command);
 
         for command in ConfigSubCommand::into_enum_iter() {
-            let created_cbor: cbor::Value = command.clone().into();
+            let created_cbor: cbor::Value = command.into();
             let reconstructed = ConfigSubCommand::try_from(created_cbor).unwrap();
             assert_eq!(command, reconstructed);
         }
@@ -2053,7 +2054,7 @@ mod test {
         assert_eq!(created_cbor, cbor_sub_command);
 
         for command in CredentialManagementSubCommand::into_enum_iter() {
-            let created_cbor: cbor::Value = command.clone().into();
+            let created_cbor: cbor::Value = command.into();
             let reconstructed = CredentialManagementSubCommand::try_from(created_cbor).unwrap();
             assert_eq!(command, reconstructed);
         }

--- a/src/ctap/hid/mod.rs
+++ b/src/ctap/hid/mod.rs
@@ -607,7 +607,7 @@ mod test {
         let mut assembler_reply = MessageAssembler::new();
         for pkt_request in &[packet1, packet2] {
             for pkt_reply in
-                ctap_hid.process_hid_packet(&pkt_request, DUMMY_CLOCK_VALUE, &mut ctap_state)
+                ctap_hid.process_hid_packet(pkt_request, DUMMY_CLOCK_VALUE, &mut ctap_state)
             {
                 if let Some(message) = assembler_reply
                     .parse_packet(&pkt_reply, DUMMY_TIMESTAMP)

--- a/src/ctap/hid/receive.rs
+++ b/src/ctap/hid/receive.rs
@@ -91,7 +91,7 @@ impl MessageAssembler {
     ) -> Result<Option<Message>, (ChannelID, Error)> {
         // TODO: Support non-full-speed devices (i.e. packet len != 64)? This isn't recommended by
         // section 8.8.1
-        let (cid, processed_packet) = CtapHid::process_single_packet(&packet);
+        let (cid, processed_packet) = CtapHid::process_single_packet(packet);
 
         if !self.idle && timestamp - self.last_timestamp >= CtapHid::TIMEOUT_DURATION {
             // The current channel timed out.

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -131,8 +131,8 @@ pub fn cbor_read(encoded_cbor: &[u8]) -> Result<cbor::Value, Ctap2StatusCode> {
         .map_err(|_e| Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR)
 }
 
-fn cbor_write(value: cbor::Value, mut encoded_cbor: &mut Vec<u8>) -> Result<(), Ctap2StatusCode> {
-    cbor::writer::write_nested(value, &mut encoded_cbor, Some(MAX_CBOR_NESTING_DEPTH))
+fn cbor_write(value: cbor::Value, encoded_cbor: &mut Vec<u8>) -> Result<(), Ctap2StatusCode> {
+    cbor::writer::write_nested(value, encoded_cbor, Some(MAX_CBOR_NESTING_DEPTH))
         .map_err(|_e| Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)
 }
 
@@ -939,7 +939,7 @@ where
                 return Ok(credential);
             }
             let credential =
-                self.decrypt_credential_source(allowed_credential.key_id, &rp_id_hash)?;
+                self.decrypt_credential_source(allowed_credential.key_id, rp_id_hash)?;
             if credential.is_some() {
                 return Ok(credential);
             }

--- a/src/ctap/response.rs
+++ b/src/ctap/response.rs
@@ -25,6 +25,7 @@ use sk_cbor::{
 };
 
 #[derive(Debug, PartialEq)]
+#[allow(clippy::enum_variant_names)]
 pub enum ResponseData {
     AuthenticatorMakeCredential(AuthenticatorMakeCredentialResponse),
     AuthenticatorGetAssertion(AuthenticatorGetAssertionResponse),

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -709,7 +709,7 @@ impl<'a> Iterator for IterCredentials<'a> {
             if !key::CREDENTIALS.contains(&key) {
                 continue;
             }
-            let value = self.unwrap(handle.get_value(&self.store).ok())?;
+            let value = self.unwrap(handle.get_value(self.store).ok())?;
             let credential = self.unwrap(deserialize_credential(&value))?;
             return Some((key, credential));
         }


### PR DESCRIPTION
This commit fixes clippy warnings of nightly compilers until 2021-11-25. This helps users who experiment with versions newer than our current 2021-03-25, and also can't hurt out style. Additionally, the second commit is a fix for `run_desktop_tests.sh` that sometimes fails with a similar problem as #407.

I decided to ignore some of the clippy warnings, instead of renaming the enum variants. This is to stay closer to names in the specification, e.g. command "authenticatorMakeCredential".