### PR TITLE
Add track_caller for flex_unwrap in libtock-drivers

### DIFF
--- a/third_party/libtock-drivers/src/result.rs
+++ b/third_party/libtock-drivers/src/result.rs
@@ -15,6 +15,7 @@ pub type TockResult<T> = Result<T, TockError>;
 // This trait allows to flexibly use `Result::unwrap` or `Option::unwrap` and is configured to do
 // so depending on the `debug_ctap` feature.
 pub trait FlexUnwrap<T> {
+    #[track_caller]
     fn flex_unwrap(self) -> T;
 }
 


### PR DESCRIPTION
This permits to get useful panic information. See [documentation](https://doc.rust-lang.org/reference/attributes/codegen.html#the-track_caller-attribute).

Binary size change (text size only since the rest didn't change):
| deploy flags | before | after | diff |
| --- | --- | --- | --- |
| `--board=nrf52840dk_opensk --opensk --panic-console` | 136428 | 137020 | +592 |
| `--board=nrf52840dk_opensk --opensk` | 120264 | 120264 | 0 |

So this probably only has impact for development/debugging and this is actually something useful for development/debugging.