### PR TITLE
Introduce a trait to abstract the CTAP environment

### DIFF
--- a/src/ctap/credential_management.rs
+++ b/src/ctap/credential_management.rs
@@ -359,7 +359,9 @@ mod test {
     use super::super::pin_protocol::authenticate_pin_uv_auth_token;
     use super::super::CtapState;
     use super::*;
-    use crypto::rng256::{Rng256, ThreadRng256};
+    use crate::env::test::TestEnv;
+    use crate::env::Env;
+    use crypto::rng256::Rng256;
 
     const CLOCK_FREQUENCY_HZ: usize = 32768;
     const DUMMY_CLOCK_VALUE: ClockValue = ClockValue::new(0, CLOCK_FREQUENCY_HZ);
@@ -383,15 +385,14 @@ mod test {
     }
 
     fn test_helper_process_get_creds_metadata(pin_uv_auth_protocol: PinUvAuthProtocol) {
-        let mut rng = ThreadRng256 {};
-        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let mut env = TestEnv::new();
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let client_pin =
             ClientPin::new_test(key_agreement_key, pin_uv_auth_token, pin_uv_auth_protocol);
-        let credential_source = create_credential_source(&mut rng);
+        let credential_source = create_credential_source(env.rng());
 
-        let user_immediately_present = |_| Ok(());
-        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        let mut ctap_state = CtapState::new(&mut env, DUMMY_CLOCK_VALUE);
         ctap_state.client_pin = client_pin;
 
         ctap_state.persistent_store.set_pin(&[0u8; 16], 4).unwrap();
@@ -467,17 +468,16 @@ mod test {
 
     #[test]
     fn test_process_enumerate_rps_with_uv() {
-        let mut rng = ThreadRng256 {};
-        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let mut env = TestEnv::new();
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let client_pin =
             ClientPin::new_test(key_agreement_key, pin_uv_auth_token, PinUvAuthProtocol::V1);
-        let credential_source1 = create_credential_source(&mut rng);
-        let mut credential_source2 = create_credential_source(&mut rng);
+        let credential_source1 = create_credential_source(env.rng());
+        let mut credential_source2 = create_credential_source(env.rng());
         credential_source2.rp_id = "another.example.com".to_string();
 
-        let user_immediately_present = |_| Ok(());
-        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        let mut ctap_state = CtapState::new(&mut env, DUMMY_CLOCK_VALUE);
         ctap_state.client_pin = client_pin;
 
         ctap_state
@@ -565,15 +565,14 @@ mod test {
 
     #[test]
     fn test_process_enumerate_rps_completeness() {
-        let mut rng = ThreadRng256 {};
-        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let mut env = TestEnv::new();
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let client_pin =
             ClientPin::new_test(key_agreement_key, pin_uv_auth_token, PinUvAuthProtocol::V1);
-        let credential_source = create_credential_source(&mut rng);
+        let credential_source = create_credential_source(env.rng());
 
-        let user_immediately_present = |_| Ok(());
-        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        let mut ctap_state = CtapState::new(&mut env, DUMMY_CLOCK_VALUE);
         ctap_state.client_pin = client_pin;
 
         const NUM_CREDENTIALS: usize = 20;
@@ -648,20 +647,19 @@ mod test {
 
     #[test]
     fn test_process_enumerate_credentials_with_uv() {
-        let mut rng = ThreadRng256 {};
-        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let mut env = TestEnv::new();
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let client_pin =
             ClientPin::new_test(key_agreement_key, pin_uv_auth_token, PinUvAuthProtocol::V1);
-        let credential_source1 = create_credential_source(&mut rng);
-        let mut credential_source2 = create_credential_source(&mut rng);
+        let credential_source1 = create_credential_source(env.rng());
+        let mut credential_source2 = create_credential_source(env.rng());
         credential_source2.user_handle = vec![0x02];
         credential_source2.user_name = Some("user2".to_string());
         credential_source2.user_display_name = Some("User Two".to_string());
         credential_source2.user_icon = Some("icon2".to_string());
 
-        let user_immediately_present = |_| Ok(());
-        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        let mut ctap_state = CtapState::new(&mut env, DUMMY_CLOCK_VALUE);
         ctap_state.client_pin = client_pin;
 
         ctap_state
@@ -754,16 +752,15 @@ mod test {
 
     #[test]
     fn test_process_delete_credential() {
-        let mut rng = ThreadRng256 {};
-        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let mut env = TestEnv::new();
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let client_pin =
             ClientPin::new_test(key_agreement_key, pin_uv_auth_token, PinUvAuthProtocol::V1);
-        let mut credential_source = create_credential_source(&mut rng);
+        let mut credential_source = create_credential_source(env.rng());
         credential_source.credential_id = vec![0x1D; 32];
 
-        let user_immediately_present = |_| Ok(());
-        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        let mut ctap_state = CtapState::new(&mut env, DUMMY_CLOCK_VALUE);
         ctap_state.client_pin = client_pin;
 
         ctap_state
@@ -826,16 +823,15 @@ mod test {
 
     #[test]
     fn test_process_update_user_information() {
-        let mut rng = ThreadRng256 {};
-        let key_agreement_key = crypto::ecdh::SecKey::gensk(&mut rng);
+        let mut env = TestEnv::new();
+        let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let client_pin =
             ClientPin::new_test(key_agreement_key, pin_uv_auth_token, PinUvAuthProtocol::V1);
-        let mut credential_source = create_credential_source(&mut rng);
+        let mut credential_source = create_credential_source(env.rng());
         credential_source.credential_id = vec![0x1D; 32];
 
-        let user_immediately_present = |_| Ok(());
-        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        let mut ctap_state = CtapState::new(&mut env, DUMMY_CLOCK_VALUE);
         ctap_state.client_pin = client_pin;
 
         ctap_state
@@ -899,9 +895,8 @@ mod test {
 
     #[test]
     fn test_process_credential_management_invalid_pin_uv_auth_param() {
-        let mut rng = ThreadRng256 {};
-        let user_immediately_present = |_| Ok(());
-        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        let mut env = TestEnv::new();
+        let mut ctap_state = CtapState::new(&mut env, DUMMY_CLOCK_VALUE);
 
         ctap_state.persistent_store.set_pin(&[0u8; 16], 4).unwrap();
 

--- a/src/ctap/hid/mod.rs
+++ b/src/ctap/hid/mod.rs
@@ -22,12 +22,12 @@ use super::ctap1;
 use super::status_code::Ctap2StatusCode;
 use super::timed_permission::TimedPermission;
 use super::CtapState;
+use crate::env::Env;
 use alloc::vec;
 use alloc::vec::Vec;
 use arrayref::{array_ref, array_refs};
 #[cfg(feature = "debug_ctap")]
 use core::fmt::Write;
-use crypto::rng256::Rng256;
 #[cfg(feature = "debug_ctap")]
 use libtock_drivers::console::Console;
 use libtock_drivers::timer::{ClockValue, Duration, Timestamp};
@@ -146,16 +146,13 @@ impl CtapHid {
 
     // Process an incoming USB HID packet, and optionally returns a list of outgoing packets to
     // send as a reply.
-    pub fn process_hid_packet<R, CheckUserPresence>(
+    pub fn process_hid_packet(
         &mut self,
+        env: &mut impl Env,
         packet: &HidPacket,
         clock_value: ClockValue,
-        ctap_state: &mut CtapState<R, CheckUserPresence>,
-    ) -> HidPacketIterator
-    where
-        R: Rng256,
-        CheckUserPresence: Fn(ChannelID) -> Result<(), Ctap2StatusCode>,
-    {
+        ctap_state: &mut CtapState,
+    ) -> HidPacketIterator {
         // TODO: Send COMMAND_KEEPALIVE every 100ms?
         match self
             .assembler
@@ -183,6 +180,7 @@ impl CtapHid {
 
                         #[cfg(feature = "with_ctap1")]
                         match ctap1::Ctap1Command::process_command(
+                            env,
                             &message.payload,
                             ctap_state,
                             clock_value,
@@ -200,7 +198,7 @@ impl CtapHid {
                         // don't handle any other packet in the meantime.
                         // TODO: Send keep-alive packets in the meantime.
                         let response =
-                            ctap_state.process_command(&message.payload, cid, clock_value);
+                            ctap_state.process_command(env, &message.payload, cid, clock_value);
                         if let Some(iterator) = CtapHid::split_message(Message {
                             cid,
                             cmd: CtapHid::COMMAND_CBOR,
@@ -433,27 +431,25 @@ impl CtapHid {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crypto::rng256::ThreadRng256;
+    use crate::env::test::TestEnv;
 
     const CLOCK_FREQUENCY_HZ: usize = 32768;
     // Except for tests for timeouts (done in ctap1.rs), transactions are time independant.
     const DUMMY_CLOCK_VALUE: ClockValue = ClockValue::new(0, CLOCK_FREQUENCY_HZ);
     const DUMMY_TIMESTAMP: Timestamp<isize> = Timestamp::from_ms(0);
 
-    fn process_messages<CheckUserPresence>(
+    fn process_messages(
+        env: &mut impl Env,
         ctap_hid: &mut CtapHid,
-        ctap_state: &mut CtapState<ThreadRng256, CheckUserPresence>,
+        ctap_state: &mut CtapState,
         request: Vec<Message>,
-    ) -> Option<Vec<Message>>
-    where
-        CheckUserPresence: Fn(ChannelID) -> Result<(), Ctap2StatusCode>,
-    {
+    ) -> Option<Vec<Message>> {
         let mut result = Vec::new();
         let mut assembler_reply = MessageAssembler::new();
         for msg_request in request {
             for pkt_request in HidPacketIterator::new(msg_request).unwrap() {
                 for pkt_reply in
-                    ctap_hid.process_hid_packet(&pkt_request, DUMMY_CLOCK_VALUE, ctap_state)
+                    ctap_hid.process_hid_packet(env, &pkt_request, DUMMY_CLOCK_VALUE, ctap_state)
                 {
                     match assembler_reply.parse_packet(&pkt_reply, DUMMY_TIMESTAMP) {
                         Ok(Some(message)) => result.push(message),
@@ -466,15 +462,14 @@ mod test {
         Some(result)
     }
 
-    fn cid_from_init<CheckUserPresence>(
+    fn cid_from_init(
+        env: &mut impl Env,
         ctap_hid: &mut CtapHid,
-        ctap_state: &mut CtapState<ThreadRng256, CheckUserPresence>,
-    ) -> ChannelID
-    where
-        CheckUserPresence: Fn(ChannelID) -> Result<(), Ctap2StatusCode>,
-    {
+        ctap_state: &mut CtapState,
+    ) -> ChannelID {
         let nonce = vec![0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0];
         let reply = process_messages(
+            env,
             ctap_hid,
             ctap_state,
             vec![Message {
@@ -521,15 +516,16 @@ mod test {
 
     #[test]
     fn test_spurious_continuation_packet() {
-        let mut rng = ThreadRng256 {};
-        let user_immediately_present = |_| Ok(());
-        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        let mut env = TestEnv::new();
+        let mut ctap_state = CtapState::new(&mut env, DUMMY_CLOCK_VALUE);
         let mut ctap_hid = CtapHid::new();
 
         let mut packet = [0x00; 64];
         packet[0..7].copy_from_slice(&[0xC1, 0xC1, 0xC1, 0xC1, 0x00, 0x51, 0x51]);
         let mut assembler_reply = MessageAssembler::new();
-        for pkt_reply in ctap_hid.process_hid_packet(&packet, DUMMY_CLOCK_VALUE, &mut ctap_state) {
+        for pkt_reply in
+            ctap_hid.process_hid_packet(&mut env, &packet, DUMMY_CLOCK_VALUE, &mut ctap_state)
+        {
             // Continuation packets are silently ignored.
             assert_eq!(
                 assembler_reply
@@ -542,12 +538,12 @@ mod test {
 
     #[test]
     fn test_command_init() {
-        let mut rng = ThreadRng256 {};
-        let user_immediately_present = |_| Ok(());
-        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        let mut env = TestEnv::new();
+        let mut ctap_state = CtapState::new(&mut env, DUMMY_CLOCK_VALUE);
         let mut ctap_hid = CtapHid::new();
 
         let reply = process_messages(
+            &mut env,
             &mut ctap_hid,
             &mut ctap_state,
             vec![Message {
@@ -587,11 +583,10 @@ mod test {
 
     #[test]
     fn test_command_init_for_sync() {
-        let mut rng = ThreadRng256 {};
-        let user_immediately_present = |_| Ok(());
-        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        let mut env = TestEnv::new();
+        let mut ctap_state = CtapState::new(&mut env, DUMMY_CLOCK_VALUE);
         let mut ctap_hid = CtapHid::new();
-        let cid = cid_from_init(&mut ctap_hid, &mut ctap_state);
+        let cid = cid_from_init(&mut env, &mut ctap_hid, &mut ctap_state);
 
         // Ping packet with a length longer than one packet.
         let mut packet1 = [0x51; 64];
@@ -606,9 +601,12 @@ mod test {
         let mut result = Vec::new();
         let mut assembler_reply = MessageAssembler::new();
         for pkt_request in &[packet1, packet2] {
-            for pkt_reply in
-                ctap_hid.process_hid_packet(pkt_request, DUMMY_CLOCK_VALUE, &mut ctap_state)
-            {
+            for pkt_reply in ctap_hid.process_hid_packet(
+                &mut env,
+                pkt_request,
+                DUMMY_CLOCK_VALUE,
+                &mut ctap_state,
+            ) {
                 if let Some(message) = assembler_reply
                     .parse_packet(&pkt_reply, DUMMY_TIMESTAMP)
                     .unwrap()
@@ -647,13 +645,13 @@ mod test {
 
     #[test]
     fn test_command_ping() {
-        let mut rng = ThreadRng256 {};
-        let user_immediately_present = |_| Ok(());
-        let mut ctap_state = CtapState::new(&mut rng, user_immediately_present, DUMMY_CLOCK_VALUE);
+        let mut env = TestEnv::new();
+        let mut ctap_state = CtapState::new(&mut env, DUMMY_CLOCK_VALUE);
         let mut ctap_hid = CtapHid::new();
-        let cid = cid_from_init(&mut ctap_hid, &mut ctap_state);
+        let cid = cid_from_init(&mut env, &mut ctap_hid, &mut ctap_state);
 
         let reply = process_messages(
+            &mut env,
             &mut ctap_hid,
             &mut ctap_state,
             vec![Message {

--- a/src/ctap/status_code.rs
+++ b/src/ctap/status_code.rs
@@ -16,7 +16,7 @@
 // For now, only the CTAP2 codes are here, the CTAP1 are not included.
 #[allow(non_camel_case_types)]
 #[allow(dead_code)]
-#[derive(Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Ctap2StatusCode {
     CTAP2_OK = 0x00,
     CTAP1_ERR_INVALID_COMMAND = 0x01,

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -4,6 +4,7 @@ use crypto::rng256::Rng256;
 
 #[cfg(feature = "std")]
 pub mod test;
+pub mod tock;
 
 pub trait UserPresence {
     /// Blocks for user presence.

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -6,9 +6,13 @@ use crypto::rng256::Rng256;
 pub mod test;
 
 pub trait UserPresence {
+    /// Blocks for user presence.
+    ///
+    /// Returns an error in case of timeout or keepalive error.
     fn check(&self, cid: ChannelID) -> Result<(), Ctap2StatusCode>;
 }
 
+/// Describes what CTAP needs to function.
 pub trait Env {
     type Rng: Rng256;
     type UserPresence: UserPresence;

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -1,0 +1,18 @@
+use crate::ctap::hid::ChannelID;
+use crate::ctap::status_code::Ctap2StatusCode;
+use crypto::rng256::Rng256;
+
+#[cfg(feature = "std")]
+pub mod test;
+
+pub trait UserPresence {
+    fn check(&self, cid: ChannelID) -> Result<(), Ctap2StatusCode>;
+}
+
+pub trait Env {
+    type Rng: Rng256;
+    type UserPresence: UserPresence;
+
+    fn rng(&mut self) -> &mut Self::Rng;
+    fn user_presence(&mut self) -> &mut Self::UserPresence;
+}

--- a/src/env/test.rs
+++ b/src/env/test.rs
@@ -1,0 +1,48 @@
+use crate::ctap::hid::ChannelID;
+use crate::ctap::status_code::Ctap2StatusCode;
+use crate::env::{Env, UserPresence};
+use crypto::rng256::ThreadRng256;
+
+pub struct TestEnv {
+    rng: ThreadRng256,
+    user_presence: TestUserPresence,
+}
+
+pub struct TestUserPresence {
+    check: Box<dyn Fn(ChannelID) -> Result<(), Ctap2StatusCode>>,
+}
+
+impl TestEnv {
+    pub fn new() -> Self {
+        let rng = ThreadRng256 {};
+        let user_presence = TestUserPresence {
+            check: Box::new(|_| Ok(())),
+        };
+        TestEnv { rng, user_presence }
+    }
+}
+
+impl TestUserPresence {
+    pub fn set(&mut self, check: impl Fn(ChannelID) -> Result<(), Ctap2StatusCode> + 'static) {
+        self.check = Box::new(check);
+    }
+}
+
+impl UserPresence for TestUserPresence {
+    fn check(&self, cid: ChannelID) -> Result<(), Ctap2StatusCode> {
+        (self.check)(cid)
+    }
+}
+
+impl Env for TestEnv {
+    type Rng = ThreadRng256;
+    type UserPresence = TestUserPresence;
+
+    fn rng(&mut self) -> &mut Self::Rng {
+        &mut self.rng
+    }
+
+    fn user_presence(&mut self) -> &mut Self::UserPresence {
+        &mut self.user_presence
+    }
+}

--- a/src/env/tock.rs
+++ b/src/env/tock.rs
@@ -1,0 +1,43 @@
+use crypto::rng256::TockRng256;
+
+use crate::ctap::hid::ChannelID;
+use crate::ctap::status_code::Ctap2StatusCode;
+use crate::env::{Env, UserPresence};
+
+pub struct TockEnv<CheckUserPresence: Fn(ChannelID) -> Result<(), Ctap2StatusCode>> {
+    rng: TockRng256,
+    check_user_presence: CheckUserPresence,
+}
+
+impl<CheckUserPresence: Fn(ChannelID) -> Result<(), Ctap2StatusCode>> TockEnv<CheckUserPresence> {
+    pub fn new(check_user_presence: CheckUserPresence) -> Self {
+        let rng = TockRng256 {};
+        TockEnv {
+            rng,
+            check_user_presence,
+        }
+    }
+}
+
+impl<CheckUserPresence: Fn(ChannelID) -> Result<(), Ctap2StatusCode>> UserPresence
+    for TockEnv<CheckUserPresence>
+{
+    fn check(&self, cid: ChannelID) -> Result<(), Ctap2StatusCode> {
+        (self.check_user_presence)(cid)
+    }
+}
+
+impl<CheckUserPresence: Fn(ChannelID) -> Result<(), Ctap2StatusCode>> Env
+    for TockEnv<CheckUserPresence>
+{
+    type Rng = TockRng256;
+    type UserPresence = Self;
+
+    fn rng(&mut self) -> &mut Self::Rng {
+        &mut self.rng
+    }
+
+    fn user_presence(&mut self) -> &mut Self::UserPresence {
+        self
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod ctap;
 pub mod embedded_flash;
 pub mod env;
 
+/// CTAP implementation parameterized by its environment.
 pub struct Ctap<E: Env> {
     env: E,
     state: CtapState,
@@ -35,6 +36,7 @@ pub struct Ctap<E: Env> {
 }
 
 impl<E: Env> Ctap<E> {
+    /// Instantiates a CTAP implementation given its environment.
     // This should only take the environment, but it temporarily takes the boot time until the
     // clock is part of the environment.
     pub fn new(mut env: E, now: ClockValue) -> Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,23 +15,19 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
+extern crate arrayref;
+extern crate byteorder;
 #[cfg(feature = "std")]
 extern crate core;
 extern crate lang_items;
-#[macro_use]
-extern crate arrayref;
-extern crate byteorder;
-
-mod ctap;
-pub mod embedded_flash;
 
 use core::cell::Cell;
 #[cfg(feature = "debug_ctap")]
 use core::fmt::Write;
 use crypto::rng256::TockRng256;
-use ctap::hid::{ChannelID, CtapHid, KeepaliveStatus, ProcessedPacket};
-use ctap::status_code::Ctap2StatusCode;
-use ctap::CtapState;
+use ctap2::ctap::hid::{ChannelID, CtapHid, KeepaliveStatus, ProcessedPacket};
+use ctap2::ctap::status_code::Ctap2StatusCode;
+use ctap2::env;
 use libtock_core::result::{CommandError, EALREADY};
 use libtock_drivers::buttons;
 use libtock_drivers::buttons::ButtonState;
@@ -53,6 +49,31 @@ const KEEPALIVE_DELAY_MS: isize = 100;
 const KEEPALIVE_DELAY: Duration<isize> = Duration::from_ms(KEEPALIVE_DELAY_MS);
 const SEND_TIMEOUT: Duration<isize> = Duration::from_ms(1000);
 
+struct TockEnv {
+    rng: TockRng256,
+    user_presence: UserPresence,
+}
+
+struct UserPresence;
+impl env::UserPresence for UserPresence {
+    fn check(&self, cid: ChannelID) -> Result<(), Ctap2StatusCode> {
+        check_user_presence(cid)
+    }
+}
+
+impl env::Env for TockEnv {
+    type Rng = TockRng256;
+    type UserPresence = UserPresence;
+
+    fn rng(&mut self) -> &mut Self::Rng {
+        &mut self.rng
+    }
+
+    fn user_presence(&mut self) -> &mut Self::UserPresence {
+        &mut self.user_presence
+    }
+}
+
 fn main() {
     // Setup the timer with a dummy callback (we only care about reading the current time, but the
     // API forces us to set an alarm callback too).
@@ -65,9 +86,11 @@ fn main() {
     }
 
     let boot_time = timer.get_current_clock().flex_unwrap();
-    let mut rng = TockRng256 {};
-    let mut ctap_state = CtapState::new(&mut rng, check_user_presence, boot_time);
-    let mut ctap_hid = CtapHid::new();
+    let env = TockEnv {
+        rng: TockRng256 {},
+        user_presence: UserPresence,
+    };
+    let mut ctap = ctap2::Ctap::new(env, boot_time);
 
     let mut led_counter = 0;
     let mut last_led_increment = boot_time;
@@ -109,7 +132,7 @@ fn main() {
         #[cfg(feature = "with_ctap1")]
         {
             if button_touched.get() {
-                ctap_state.u2f_up_state.grant_up(now);
+                ctap.state().u2f_up_state.grant_up(now);
             }
             // Cleanup button callbacks. We miss button presses while processing though.
             // Heavy computation mostly follows a registered touch luckily. Unregistering
@@ -123,11 +146,11 @@ fn main() {
 
         // These calls are making sure that even for long inactivity, wrapping clock values
         // don't cause problems with timers.
-        ctap_state.update_timeouts(now);
-        ctap_hid.wink_permission = ctap_hid.wink_permission.check_expiration(now);
+        ctap.state().update_timeouts(now);
+        ctap.hid().wink_permission = ctap.hid().wink_permission.check_expiration(now);
 
         if has_packet {
-            let reply = ctap_hid.process_hid_packet(&pkt_request, now, &mut ctap_state);
+            let reply = ctap.process_hid_packet(&pkt_request, now);
             // This block handles sending packets.
             for mut pkt_reply in reply {
                 let status = usb_ctap_hid::send_or_recv_with_timeout(&mut pkt_reply, SEND_TIMEOUT);
@@ -167,14 +190,14 @@ fn main() {
             last_led_increment = now;
         }
 
-        if ctap_hid.wink_permission.is_granted(now) {
+        if ctap.hid().wink_permission.is_granted(now) {
             wink_leds(led_counter);
         } else {
             #[cfg(not(feature = "with_ctap1"))]
             switch_off_leds();
             #[cfg(feature = "with_ctap1")]
             {
-                if ctap_state.u2f_up_state.is_up_needed(now) {
+                if ctap.state().u2f_up_state.is_up_needed(now) {
                     // Flash the LEDs with an almost regular pattern. The inaccuracy comes from
                     // delay caused by processing and sending of packets.
                     blink_leds(led_counter);
@@ -315,7 +338,8 @@ fn switch_off_leds() {
 
 fn check_user_presence(cid: ChannelID) -> Result<(), Ctap2StatusCode> {
     // The timeout is N times the keepalive delay.
-    const TIMEOUT_ITERATIONS: usize = ctap::TOUCH_TIMEOUT_MS as usize / KEEPALIVE_DELAY_MS as usize;
+    const TIMEOUT_ITERATIONS: usize =
+        ctap2::ctap::TOUCH_TIMEOUT_MS as usize / KEEPALIVE_DELAY_MS as usize;
 
     // First, send a keep-alive packet to notify that the keep-alive status has changed.
     send_keepalive_up_needed(cid, KEEPALIVE_DELAY)?;


### PR DESCRIPTION
The end goal is to provide users with:
- the `Env` trait that they should implement
- the `Ctap` struct that they can use

The change is mostly boilerplate threading the environment through all functions needing it.