### PR TITLE
Freeze cargo fuzz's version and add fuzz corpus to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+fuzz/corpus
 target/
 Cargo.lock
 

--- a/fuzzing_setup.sh
+++ b/fuzzing_setup.sh
@@ -20,4 +20,4 @@ done_text="$(tput bold)DONE.$(tput sgr0)"
 set -e
 
 # Install cargo-fuzz library.
-cargo +stable install cargo-fuzz
+cargo +stable install cargo-fuzz --version 0.10.2


### PR DESCRIPTION
Freeze cargo fuzz's version since newer versions require newer nightly toolchain.