### PR TITLE
Generate valid structure for MakeCredential params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+fuzz/artifacts
 fuzz/corpus
+fuzz/coverage
 target/
 Cargo.lock
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ subtle = { version = "2.2", default-features = false, features = ["nightly"] }
 # This import explicitly locks the version.
 serde_json = { version = "=1.0.69", default-features = false, features = ["alloc"] }
 embedded-time = "0.12.1"
+arbitrary = { version = "0.4.7", features = ["derive"], optional = true }
 
 [features]
 debug_allocations = ["lang_items/debug_allocations"]
@@ -32,6 +33,7 @@ verbose = ["debug_ctap", "libtock_drivers/verbose_usb"]
 with_ctap1 = ["crypto/with_ctap1"]
 with_nfc = ["libtock_drivers/with_nfc"]
 vendor_hid = []
+fuzz = ["arbitrary", "std"]
 
 [dev-dependencies]
 enum-iterator = "0.6.0"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -49,6 +49,12 @@ test = false
 doc = false
 
 [[bin]]
+name = "fuzz_target_process_ctap2_make_credential_structured"
+path = "fuzz_targets/fuzz_target_process_ctap2_make_credential_structured.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "fuzz_target_split_assemble"
 path = "fuzz_targets/fuzz_target_split_assemble.rs"
 test = false

--- a/fuzz/fuzz_helper/Cargo.toml
+++ b/fuzz/fuzz_helper/Cargo.toml
@@ -11,5 +11,6 @@ embedded-time = "0.12.1"
 libtock_drivers = { path = "../../third_party/libtock-drivers" }
 crypto = { path = "../../libraries/crypto", features = ['std'] }
 sk-cbor = { path = "../../libraries/cbor" }
-ctap2 = { path = "../..", features = ['std'] }
+ctap2 = { path = "../..", features = ["fuzz"] }
 lang_items = { path = "../../third_party/lang-items", features = ['std'] }
+arbitrary = { version = "0.4.7", features = ["derive"] }

--- a/fuzz/fuzz_targets/fuzz_target_process_ctap2_make_credential_structured.rs
+++ b/fuzz/fuzz_targets/fuzz_target_process_ctap2_make_credential_structured.rs
@@ -1,0 +1,10 @@
+#![no_main]
+
+use fuzz_helper::{process_ctap_structured, InputType};
+use libfuzzer_sys::fuzz_target;
+
+// Fuzz inputs as CTAP2 make credential command parameters.
+// The inputs will used to construct arbitrary make credential parameters.
+fuzz_target!(|data: &[u8]| {
+    process_ctap_structured(data, InputType::CborMakeCredentialParameter).ok();
+});

--- a/libraries/cbor/src/values.rs
+++ b/libraries/cbor/src/values.rs
@@ -225,6 +225,12 @@ impl From<&str> for Value {
     }
 }
 
+impl From<Vec<Value>> for Value {
+    fn from(array: Vec<Value>) -> Self {
+        Value::Array(array)
+    }
+}
+
 impl From<Vec<(Value, Value)>> for Value {
     fn from(map: Vec<(Value, Value)>) -> Self {
         Value::Map(map)

--- a/src/ctap/command.rs
+++ b/src/ctap/command.rs
@@ -26,6 +26,8 @@ use super::status_code::Ctap2StatusCode;
 use super::{cbor_read, key_material};
 use alloc::string::String;
 use alloc::vec::Vec;
+#[cfg(feature = "fuzz")]
+use arbitrary::Arbitrary;
 use arrayref::array_ref;
 use core::convert::TryFrom;
 use sk_cbor as cbor;
@@ -155,6 +157,7 @@ impl Command {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct AuthenticatorMakeCredentialParameters {
     pub client_data_hash: Vec<u8>,
     pub rp: PublicKeyCredentialRpEntity,

--- a/src/ctap/data_formats.rs
+++ b/src/ctap/data_formats.rs
@@ -15,6 +15,8 @@
 use super::status_code::Ctap2StatusCode;
 use alloc::string::String;
 use alloc::vec::Vec;
+#[cfg(feature = "fuzz")]
+use arbitrary::Arbitrary;
 use arrayref::array_ref;
 use core::convert::TryFrom;
 use crypto::{ecdh, ecdsa};
@@ -28,6 +30,7 @@ const ES256_ALGORITHM: i64 = -7;
 
 // https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialrpentity
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct PublicKeyCredentialRpEntity {
     pub rp_id: String,
     pub rp_name: Option<String>,
@@ -70,6 +73,7 @@ impl From<PublicKeyCredentialRpEntity> for cbor::Value {
 
 // https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialuserentity
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct PublicKeyCredentialUserEntity {
     pub user_id: Vec<u8>,
     pub user_name: Option<String>,
@@ -117,6 +121,7 @@ impl From<PublicKeyCredentialUserEntity> for cbor::Value {
 
 // https://www.w3.org/TR/webauthn/#enumdef-publickeycredentialtype
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub enum PublicKeyCredentialType {
     PublicKey,
     // This is the default for all strings not covered above.
@@ -149,6 +154,7 @@ impl TryFrom<cbor::Value> for PublicKeyCredentialType {
 
 // https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialparameters
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct PublicKeyCredentialParameter {
     pub cred_type: PublicKeyCredentialType,
     pub alg: SignatureAlgorithm,
@@ -183,6 +189,7 @@ impl From<PublicKeyCredentialParameter> for cbor::Value {
 // https://www.w3.org/TR/webauthn/#enumdef-authenticatortransport
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(test, derive(IntoEnumIterator))]
+#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub enum AuthenticatorTransport {
     Usb,
     Nfc,
@@ -219,6 +226,7 @@ impl TryFrom<cbor::Value> for AuthenticatorTransport {
 
 // https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialdescriptor
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct PublicKeyCredentialDescriptor {
     pub key_type: PublicKeyCredentialType,
     pub key_id: Vec<u8>,
@@ -270,6 +278,7 @@ impl From<PublicKeyCredentialDescriptor> for cbor::Value {
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct MakeCredentialExtensions {
     pub hmac_secret: bool,
     pub cred_protect: Option<CredentialProtectionPolicy>,
@@ -388,6 +397,7 @@ impl TryFrom<cbor::Value> for GetAssertionHmacSecretInput {
 
 // Even though options are optional, we can use the default if not present.
 #[derive(Clone, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct MakeCredentialOptions {
     pub rk: bool,
     pub uv: bool,
@@ -488,6 +498,7 @@ impl From<PackedAttestationStatement> for cbor::Value {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub enum SignatureAlgorithm {
     ES256 = ES256_ALGORITHM as isize,
     // This is the default for all numbers not covered above.
@@ -516,6 +527,7 @@ impl TryFrom<cbor::Value> for SignatureAlgorithm {
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
 #[cfg_attr(test, derive(IntoEnumIterator))]
 #[allow(clippy::enum_variant_names)]
+#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub enum CredentialProtectionPolicy {
     /// The credential is always discoverable, as if it had no protection level.
     UserVerificationOptional = 0x01,
@@ -884,6 +896,7 @@ impl TryFrom<CoseSignature> for ecdsa::Signature {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub enum PinUvAuthProtocol {
     V1 = 1,
     V2 = 2,

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -532,7 +532,7 @@ impl CtapState {
     ///
     /// This function contains the logic of `parse_command`, minus all CBOR encoding and decoding.
     /// It should make command parsing easier to test.
-    fn process_parsed_command(
+    pub fn process_parsed_command(
         &mut self,
         env: &mut impl Env,
         command: Command,


### PR DESCRIPTION
The fuzzers are not working well currently because the logic is to parse random bytes as cbor value and parse them as specific command format. If the format doesn't match, it returns and goes to the next round. With random inputs, this has ~0% probability of generating valid input, so we're only fuzzing the command parsing (ineffectively too, as the bytes can't be interpreted as cbor maps most of the time). We should generate valid inputs in each fuzzing round with high probability.

To do that, we need to generate valid cbor maps that can be parsed into specific parameters (like AuthenticatorMakeCredentialParameters). Here, I mostly take use of the arbitrary crate that is the default choice for Rust fuzzing. I decided to put the extra code in the ctap package itself behind a feature flag because otherwise we'll have to bring many extra dependency and make many types/functions public to implement it in the fuzz package. Even if we do that it's not enough, because we can't implement foreign traits on foreign types, so we'll likely have to rewrite our own arbitrary library as well. I feel that the way I add the fuzz-related code to the ctap library doesn't really complicates the code base so it should be fine. If you have better suggestions please tell me, let us first fix this CL to an acceptable format before we implement similar logic to other fuzz targets.

After this CL, we have 91.67% function coverage in ctap/hid/mod.rs (compared to 0%), and decently covers main logic in ctap/mod.rs for MakeCredential command processing. Main limitation of coverage is crypto-related checks, like we return an error if PubKeyCredentialsParams doesn't include ES256. These implementation-specific improvements can be added later.

Finally, I want to discuss our attitudes toward introducing probability in fuzzing. Theoretically as long as the inputs are reachable, we should let the fuzzer find its paths, and not choosing some specific paths for very high probability. But in practice we need to use probabilities or else fuzzing is very ineffective or even useless. I used 95% for valid structure, but for other cases (like whether PubKeyCredentialsParams include ES256), do we want to set higher probabilities for those "more interesting" paths too?