### PR TITLE
Clean public HID interface

### DIFF
--- a/fuzz/fuzz_helper/src/lib.rs
+++ b/fuzz/fuzz_helper/src/lib.rs
@@ -24,9 +24,9 @@ use ctap2::ctap::command::{
     AuthenticatorClientPinParameters, AuthenticatorGetAssertionParameters,
     AuthenticatorMakeCredentialParameters,
 };
-use ctap2::ctap::hid::receive::MessageAssembler;
-use ctap2::ctap::hid::send::HidPacketIterator;
-use ctap2::ctap::hid::{ChannelID, CtapHidCommand, HidPacket, Message};
+use ctap2::ctap::hid::{
+    ChannelID, CtapHidCommand, HidPacket, HidPacketIterator, Message, MessageAssembler,
+};
 use ctap2::env::test::TestEnv;
 use ctap2::Ctap;
 

--- a/src/ctap/hid/mod.rs
+++ b/src/ctap/hid/mod.rs
@@ -108,7 +108,7 @@ pub enum CtapHidError {
 /// Describes the structure of a parsed HID packet.
 ///
 /// A packet is either an Init or a Continuation packet.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ProcessedPacket<'a> {
     InitPacket {
         cmd: u8,
@@ -767,9 +767,9 @@ mod test {
 
     #[test]
     fn test_keepalive() {
-        for status in [KeepaliveStatus::Processing, KeepaliveStatus::UpNeeded].iter() {
+        for &status in [KeepaliveStatus::Processing, KeepaliveStatus::UpNeeded].iter() {
             let cid = [0x12, 0x34, 0x56, 0x78];
-            let mut response = CtapHid::keepalive(cid, *status);
+            let mut response = CtapHid::keepalive(cid, status);
             let mut expected_packet = [0x00; 64];
             expected_packet[..8].copy_from_slice(&[
                 0x12,
@@ -779,7 +779,7 @@ mod test {
                 0xBB,
                 0x00,
                 0x01,
-                *status as u8,
+                status as u8,
             ]);
             assert_eq!(response.next(), Some(expected_packet));
             assert_eq!(response.next(), None);

--- a/src/ctap/hid/send.rs
+++ b/src/ctap/hid/send.rs
@@ -45,7 +45,7 @@ impl Iterator for HidPacketIterator {
     }
 }
 
-pub struct MessageSplitter {
+struct MessageSplitter {
     message: Message,
     packet: HidPacket,
     seq: Option<u8>,
@@ -292,6 +292,4 @@ mod test {
         };
         assert!(HidPacketIterator::new(message).is_none());
     }
-
-    // TODO(kaczmarczyck) implement and test limits (maximum bytes and packets)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,7 @@ extern crate alloc;
 #[macro_use]
 extern crate arrayref;
 
-use crate::ctap::hid::send::HidPacketIterator;
-use crate::ctap::hid::{CtapHid, HidPacket};
+use crate::ctap::hid::{CtapHid, HidPacket, HidPacketIterator};
 use crate::ctap::CtapState;
 use crate::env::Env;
 use clock::CtapInstant;


### PR DESCRIPTION
This PR further prepares the `hid` mod for its future move:

- Clean up the duplicate internal error data type.
- Refactor and add tests. Note that most don't rely on `CtapState` anymore with the new API.
- You can import from this module now directly, `send.rs` and `receive.rs` became implementation details.

There is only a fraction of the code that relies on `CtapState` now. Plan is to split all of that out, and have a clean `hid` mod afterwards.