### PR TITLE
Transports and Channels

### DIFF
--- a/fuzz/fuzz_helper/src/lib.rs
+++ b/fuzz/fuzz_helper/src/lib.rs
@@ -28,7 +28,7 @@ use ctap2::ctap::hid::{
     ChannelID, CtapHidCommand, HidPacket, HidPacketIterator, Message, MessageAssembler,
 };
 use ctap2::env::test::TestEnv;
-use ctap2::Ctap;
+use ctap2::{Ctap, Transport};
 
 const CHANNEL_BROADCAST: ChannelID = [0xFF, 0xFF, 0xFF, 0xFF];
 
@@ -72,7 +72,9 @@ fn initialize(ctap: &mut Ctap<TestEnv>) -> ChannelID {
     let mut assembler_reply = MessageAssembler::new();
     let mut result_cid: ChannelID = Default::default();
     for pkt_request in HidPacketIterator::new(message).unwrap() {
-        for pkt_reply in ctap.process_hid_packet(&pkt_request, CtapInstant::new(0)) {
+        for pkt_reply in
+            ctap.process_hid_packet(&pkt_request, Transport::MainHid, CtapInstant::new(0))
+        {
             if let Ok(Some(result)) = assembler_reply.parse_packet(&pkt_reply, CtapInstant::new(0))
             {
                 result_cid.copy_from_slice(&result.payload[8..12]);
@@ -111,7 +113,9 @@ fn process_message(data: &[u8], ctap: &mut Ctap<TestEnv>) {
     if let Some(hid_packet_iterator) = HidPacketIterator::new(message) {
         let mut assembler_reply = MessageAssembler::new();
         for pkt_request in hid_packet_iterator {
-            for pkt_reply in ctap.process_hid_packet(&pkt_request, CtapInstant::new(0)) {
+            for pkt_reply in
+                ctap.process_hid_packet(&pkt_request, Transport::MainHid, CtapInstant::new(0))
+            {
                 // Only checks for assembling crashes, not for semantics.
                 let _ = assembler_reply.parse_packet(&pkt_reply, CtapInstant::new(0));
             }

--- a/src/ctap/main_hid.rs
+++ b/src/ctap/main_hid.rs
@@ -21,7 +21,7 @@ use crate::ctap::hid::ChannelID;
 use crate::ctap::hid::{
     CtapHid, CtapHidCommand, CtapHidError, HidPacket, HidPacketIterator, Message,
 };
-use crate::ctap::TimedPermission;
+use crate::ctap::{Channel, TimedPermission};
 use crate::env::Env;
 use embedded_time::duration::Milliseconds;
 
@@ -91,7 +91,8 @@ impl MainHid {
                 // Each transaction is atomic, so we process the command directly here and
                 // don't handle any other packet in the meantime.
                 // TODO: Send "Processing" type keep-alive packets in the meantime.
-                let response = ctap_state.process_command(env, &message.payload, cid, now);
+                let response =
+                    ctap_state.process_command(env, &message.payload, Channel::MainHid(cid), now);
                 Message {
                     cid,
                     cmd: CtapHidCommand::Cbor,

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -1,7 +1,7 @@
 use crate::api::firmware_protection::FirmwareProtection;
 use crate::api::upgrade_storage::UpgradeStorage;
-use crate::ctap::hid::ChannelID;
 use crate::ctap::status_code::Ctap2StatusCode;
+use crate::ctap::Channel;
 use crypto::rng256::Rng256;
 use persistent_store::{Storage, Store};
 
@@ -13,7 +13,7 @@ pub trait UserPresence {
     /// Blocks for user presence.
     ///
     /// Returns an error in case of timeout or keepalive error.
-    fn check(&mut self, cid: ChannelID) -> Result<(), Ctap2StatusCode>;
+    fn check(&mut self, channel: Channel) -> Result<(), Ctap2StatusCode>;
 }
 
 /// Describes what CTAP needs to function.

--- a/src/env/test/mod.rs
+++ b/src/env/test/mod.rs
@@ -1,7 +1,7 @@
 use self::upgrade_storage::BufferUpgradeStorage;
 use crate::api::firmware_protection::FirmwareProtection;
-use crate::ctap::hid::ChannelID;
 use crate::ctap::status_code::Ctap2StatusCode;
+use crate::ctap::Channel;
 use crate::env::{Env, UserPresence};
 use crypto::rng256::ThreadRng256;
 use persistent_store::{BufferOptions, BufferStorage, Store};
@@ -16,7 +16,7 @@ pub struct TestEnv {
 }
 
 pub struct TestUserPresence {
-    check: Box<dyn Fn(ChannelID) -> Result<(), Ctap2StatusCode>>,
+    check: Box<dyn Fn(Channel) -> Result<(), Ctap2StatusCode>>,
 }
 
 pub struct TestWrite;
@@ -65,14 +65,14 @@ impl TestEnv {
 }
 
 impl TestUserPresence {
-    pub fn set(&mut self, check: impl Fn(ChannelID) -> Result<(), Ctap2StatusCode> + 'static) {
+    pub fn set(&mut self, check: impl Fn(Channel) -> Result<(), Ctap2StatusCode> + 'static) {
         self.check = Box::new(check);
     }
 }
 
 impl UserPresence for TestUserPresence {
-    fn check(&mut self, cid: ChannelID) -> Result<(), Ctap2StatusCode> {
-        (self.check)(cid)
+    fn check(&mut self, channel: Channel) -> Result<(), Ctap2StatusCode> {
+        (self.check)(channel)
     }
 }
 

--- a/src/env/tock/mod.rs
+++ b/src/env/tock/mod.rs
@@ -2,6 +2,7 @@ pub use self::storage::{TockStorage, TockUpgradeStorage};
 use crate::api::firmware_protection::FirmwareProtection;
 use crate::ctap::hid::{ChannelID, CtapHid, CtapHidCommand, KeepaliveStatus, ProcessedPacket};
 use crate::ctap::status_code::Ctap2StatusCode;
+use crate::ctap::Channel;
 use crate::env::{Env, UserPresence};
 use core::cell::Cell;
 use core::sync::atomic::{AtomicBool, Ordering};
@@ -54,8 +55,11 @@ pub fn take_storage() -> StorageResult<TockStorage> {
 }
 
 impl UserPresence for TockEnv {
-    fn check(&mut self, cid: ChannelID) -> Result<(), Ctap2StatusCode> {
-        check_user_presence(self, cid)
+    fn check(&mut self, channel: Channel) -> Result<(), Ctap2StatusCode> {
+        match channel {
+            Channel::MainHid(cid) => check_user_presence(self, cid),
+            Channel::VendorHid(cid) => check_user_presence(self, cid),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ extern crate arrayref;
 use crate::ctap::hid::{HidPacket, HidPacketIterator};
 use crate::ctap::main_hid::MainHid;
 use crate::ctap::CtapState;
+pub use crate::ctap::Transport;
 use crate::env::Env;
 use clock::CtapInstant;
 
@@ -78,10 +79,16 @@ impl<E: Env> Ctap<E> {
     pub fn process_hid_packet(
         &mut self,
         packet: &HidPacket,
+        transport: Transport,
         now: CtapInstant,
     ) -> HidPacketIterator {
-        self.hid
-            .process_hid_packet(&mut self.env, packet, now, &mut self.state)
+        match transport {
+            Transport::MainHid => {
+                self.hid
+                    .process_hid_packet(&mut self.env, packet, now, &mut self.state)
+            }
+            Transport::VendorHid => HidPacketIterator::none(),
+        }
     }
 
     pub fn update_timeouts(&mut self, now: CtapInstant) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ use ctap2::clock::{new_clock, Clock, ClockInt, KEEPALIVE_DELAY};
 #[cfg(feature = "with_ctap1")]
 use ctap2::env::tock::blink_leds;
 use ctap2::env::tock::{switch_off_leds, wink_leds, TockEnv, KEEPALIVE_DELAY_TOCK};
+use ctap2::Transport;
 #[cfg(feature = "debug_ctap")]
 use embedded_time::duration::Microseconds;
 use embedded_time::duration::Milliseconds;
@@ -120,7 +121,7 @@ fn main() {
         ctap.update_timeouts(now);
 
         if has_packet {
-            let reply = ctap.process_hid_packet(&pkt_request, now);
+            let reply = ctap.process_hid_packet(&pkt_request, Transport::MainHid, now);
             // This block handles sending packets.
             for mut pkt_reply in reply {
                 let status = usb_ctap_hid::send_or_recv_with_timeout(&mut pkt_reply, SEND_TIMEOUT);


### PR DESCRIPTION
This PR introduces Transport and Channel as a concept to CTAP.

- A transport describes the physical layer where the data comes from that is passed into CTAP.
- A channel is a connection to a client.

This PR is simple, and does not contain any logic changes. It adds the MainHid transport to be passed from external, and then learns the channel from the packet data to be used internally, replacing the `ChannelID` with a container.

In the future, NFC can be added as Transport and Channel (without a `ChannelID`). `VendorHid` is currently unused.