### PR TITLE
Channels logic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,10 +31,10 @@ use clock::CtapInstant;
 // adding either the defmt or log feature and crate dependency.
 #[cfg(feature = "debug_ctap")]
 macro_rules! debug_ctap {
-    ($env: expr, $($rest:tt)*) => {
+    ($env: expr, $($rest:tt)*) => {{
         use core::fmt::Write;
         writeln!($env.write(), $($rest)*).unwrap();
-    };
+    }};
 }
 #[cfg(not(feature = "debug_ctap"))]
 macro_rules! debug_ctap {


### PR DESCRIPTION
The vendor HID and channels introduced in #444 and #446 are now used. To do that, I refactored the `process_command` function heavily into:
- a small and slightly improved outer function for reading and writing CBOR
- an inner function that only calls command logic minus CBOR
- one function for all FIDO commands
- once function for all vendor commands

Stateful commands are now assigned to the channel, and their state gets cleared on timeout or channel switch. (Some reasoning is in the comments in code.) This is slightly more correct and simpler than before, where commands check timeouts individually. That was not really necessary, as a timed out stateful commands is equivalent to never having called the command to create the state.

I added a bunch of tests to check the new logic, and... found a bug where GetNextAssertion actually answers as GetAssertion. None of the test tools check this I believe. I decided to fix it right away, so the PR got a bit bigger. Can split up if desired.

Also I fix a tiny bug with the debug print macro.