### PR TITLE
Introduce Customization struct

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -473,8 +473,6 @@ class OpenSKInstaller:
     print("Testing invariants in customization.rs...")
     self.checked_command_output(
         ["cargo", "test", "--features=std", "--lib", "customization"])
-    self.checked_command_output(
-        ["cargo", "test", "--features=std", "--lib", "api::customization"])
 
   def generate_crypto_materials(self, force_regenerate: bool):
     """Calls a shell script that generates cryptographic material."""

--- a/deploy.py
+++ b/deploy.py
@@ -473,6 +473,8 @@ class OpenSKInstaller:
     print("Testing invariants in customization.rs...")
     self.checked_command_output(
         ["cargo", "test", "--features=std", "--lib", "customization"])
+    self.checked_command_output(
+        ["cargo", "test", "--features=std", "--lib", "api::customization"])
 
   def generate_crypto_materials(self, force_regenerate: bool):
     """Calls a shell script that generates cryptographic material."""

--- a/src/api/customization.rs
+++ b/src/api/customization.rs
@@ -1,0 +1,62 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This file contains all customizable constants.
+//!
+//! If you adapt them, make sure to run the tests before flashing the firmware.
+//! Our deploy script enforces the invariants.
+
+pub trait Customization {
+    /// Maximum message size send for CTAP commands.
+    ///
+    /// The maximum value is 7609, as HID packets can not encode longer messages.
+    /// 1024 is the default mentioned in the authenticatorLargeBlobs commands.
+    /// Larger values are preferred, as that allows more parameters in commands.
+    /// If long commands are too unreliable on your hardware, consider decreasing
+    /// this value.
+    fn max_msg_size(&self) -> usize;
+}
+
+#[derive(Clone)]
+pub struct CustomizationImpl {
+    pub max_msg_size: usize,
+}
+
+pub const DEFAULT_CUSTOMIZATION: CustomizationImpl = CustomizationImpl { max_msg_size: 7609 };
+
+impl Customization for CustomizationImpl {
+    fn max_msg_size(&self) -> usize {
+        self.max_msg_size
+    }
+}
+
+#[cfg(test)]
+fn is_valid(customization: &impl Customization) -> bool {
+    // Max message size must be between 1024 and 7609.
+    if customization.max_msg_size() < 1024 || customization.max_msg_size() > 7609 {
+        return false;
+    }
+    true
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    #[allow(clippy::assertions_on_constants)]
+    fn test_invariants() {
+        assert!(is_valid(&DEFAULT_CUSTOMIZATION));
+    }
+}

--- a/src/api/customization.rs
+++ b/src/api/customization.rs
@@ -41,8 +41,8 @@ impl Customization for CustomizationImpl {
     }
 }
 
-#[cfg(test)]
-fn is_valid(customization: &impl Customization) -> bool {
+#[cfg(feature = "std")]
+pub fn is_valid(customization: &impl Customization) -> bool {
     // Max message size must be between 1024 and 7609.
     if customization.max_msg_size() < 1024 || customization.max_msg_size() > 7609 {
         return false;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3,5 +3,6 @@
 //! The [environment](crate::env::Env) is split into components. Each component has an API described
 //! by a trait. This module gathers the API of those components.
 
+pub mod customization;
 pub mod firmware_protection;
 pub mod upgrade_storage;

--- a/src/ctap/customization.rs
+++ b/src/ctap/customization.rs
@@ -119,15 +119,6 @@ pub const ENTERPRISE_ATTESTATION_MODE: Option<EnterpriseAttestationMode> = None;
 /// VendorFacilitated.
 pub const ENTERPRISE_RP_ID_LIST: &[&str] = &[];
 
-/// Maximum message size send for CTAP commands.
-///
-/// The maximum value is 7609, as HID packets can not encode longer messages.
-/// 1024 is the default mentioned in the authenticatorLargeBlobs commands.
-/// Larger values are preferred, as that allows more parameters in commands.
-/// If long commands are too unreliable on your hardware, consider decreasing
-/// this value.
-pub const MAX_MSG_SIZE: usize = 7609;
-
 /// Sets the number of consecutive failed PINs before blocking interaction.
 ///
 /// # Invariant
@@ -252,8 +243,6 @@ mod test {
         } else {
             assert!(ENTERPRISE_RP_ID_LIST.is_empty());
         }
-        assert!(MAX_MSG_SIZE >= 1024);
-        assert!(MAX_MSG_SIZE <= 7609);
         assert!(MAX_PIN_RETRIES <= 8);
         assert!(MAX_CRED_BLOB_LENGTH >= 32);
         if let Some(count) = MAX_CREDENTIAL_COUNT_IN_LIST {

--- a/src/ctap/hid/mod.rs
+++ b/src/ctap/hid/mod.rs
@@ -235,7 +235,7 @@ impl CtapHid {
         packet: &HidPacket,
         clock_value: CtapInstant,
     ) -> Option<Message> {
-        match self.assembler.parse_packet(packet, clock_value) {
+        match self.assembler.parse_packet(env, packet, clock_value) {
             Ok(Some(message)) => {
                 debug_ctap!(env, "Received message: {:02x?}", message);
                 self.preprocess_message(message)
@@ -420,6 +420,7 @@ mod test {
 
     #[test]
     fn test_split_assemble() {
+        let mut env = TestEnv::new();
         for payload_len in 0..7609 {
             let message = Message {
                 cid: [0x12, 0x34, 0x56, 0x78],
@@ -430,7 +431,7 @@ mod test {
             let mut messages = Vec::new();
             let mut assembler = MessageAssembler::new();
             for packet in HidPacketIterator::new(message.clone()).unwrap() {
-                match assembler.parse_packet(&packet, CtapInstant::new(0)) {
+                match assembler.parse_packet(&mut env, &packet, CtapInstant::new(0)) {
                     Ok(Some(msg)) => messages.push(msg),
                     Ok(None) => (),
                     Err(_) => panic!("Couldn't assemble packet: {:02x?}", &packet as &[u8]),

--- a/src/ctap/large_blobs.rs
+++ b/src/ctap/large_blobs.rs
@@ -14,9 +14,9 @@
 
 use super::client_pin::{ClientPin, PinPermission};
 use super::command::AuthenticatorLargeBlobsParameters;
-use super::customization::MAX_MSG_SIZE;
 use super::response::{AuthenticatorLargeBlobsResponse, ResponseData};
 use super::status_code::Ctap2StatusCode;
+use crate::api::customization::Customization;
 use crate::ctap::storage;
 use crate::env::Env;
 use alloc::vec;
@@ -60,10 +60,10 @@ impl LargeBlobs {
             pin_uv_auth_protocol,
         } = large_blobs_params;
 
-        const MAX_FRAGMENT_LENGTH: usize = MAX_MSG_SIZE - 64;
+        let max_fragment_size = env.customization().max_msg_size() - 64;
 
         if let Some(get) = get {
-            if get > MAX_FRAGMENT_LENGTH || offset.checked_add(get).is_none() {
+            if get > max_fragment_size || offset.checked_add(get).is_none() {
                 return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_LENGTH);
             }
             let config = storage::get_large_blob_array(env, offset, get)?;
@@ -73,7 +73,7 @@ impl LargeBlobs {
         }
 
         if let Some(mut set) = set {
-            if set.len() > MAX_FRAGMENT_LENGTH {
+            if set.len() > max_fragment_size {
                 return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_LENGTH);
             }
             if offset == 0 {

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -20,7 +20,7 @@ mod credential_management;
 mod crypto_wrapper;
 #[cfg(feature = "with_ctap1")]
 mod ctap1;
-mod customization;
+pub mod customization;
 pub mod data_formats;
 pub mod hid;
 mod key_material;
@@ -45,7 +45,7 @@ use self::credential_management::process_credential_management;
 use self::crypto_wrapper::{aes256_cbc_decrypt, aes256_cbc_encrypt};
 use self::customization::{
     DEFAULT_CRED_PROTECT, ENTERPRISE_ATTESTATION_MODE, ENTERPRISE_RP_ID_LIST,
-    MAX_CREDENTIAL_COUNT_IN_LIST, MAX_CRED_BLOB_LENGTH, MAX_LARGE_BLOB_ARRAY_SIZE, MAX_MSG_SIZE,
+    MAX_CREDENTIAL_COUNT_IN_LIST, MAX_CRED_BLOB_LENGTH, MAX_LARGE_BLOB_ARRAY_SIZE,
     MAX_RP_IDS_LENGTH, USE_BATCH_ATTESTATION, USE_SIGNATURE_COUNTER,
 };
 use self::data_formats::{
@@ -66,6 +66,7 @@ use self::status_code::Ctap2StatusCode;
 use self::timed_permission::TimedPermission;
 #[cfg(feature = "with_ctap1")]
 use self::timed_permission::U2fUserPresenceState;
+use crate::api::customization::Customization;
 use crate::api::firmware_protection::FirmwareProtection;
 use crate::api::upgrade_storage::UpgradeStorage;
 use crate::clock::{ClockInt, CtapInstant};
@@ -1207,7 +1208,7 @@ impl CtapState {
                 ]),
                 aaguid: storage::aaguid(env)?,
                 options: Some(options),
-                max_msg_size: Some(MAX_MSG_SIZE as u64),
+                max_msg_size: Some(env.customization().max_msg_size() as u64),
                 // The order implies preference. We favor the new V2.
                 pin_protocols: Some(vec![
                     PinUvAuthProtocol::V2 as u64,
@@ -1519,7 +1520,7 @@ mod test {
                 "setMinPINLength" => true,
                 "makeCredUvNotRqd" => true,
             },
-            0x05 => MAX_MSG_SIZE as u64,
+            0x05 => env.customization().max_msg_size() as u64,
             0x06 => cbor_array![2, 1],
             0x07 => MAX_CREDENTIAL_COUNT_IN_LIST.map(|c| c as u64),
             0x08 => CREDENTIAL_ID_SIZE as u64,

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -1,3 +1,4 @@
+use crate::api::customization::Customization;
 use crate::api::firmware_protection::FirmwareProtection;
 use crate::api::upgrade_storage::UpgradeStorage;
 use crate::ctap::status_code::Ctap2StatusCode;
@@ -24,6 +25,7 @@ pub trait Env {
     type UpgradeStorage: UpgradeStorage;
     type FirmwareProtection: FirmwareProtection;
     type Write: core::fmt::Write;
+    type Customization: Customization;
 
     fn rng(&mut self) -> &mut Self::Rng;
     fn user_presence(&mut self) -> &mut Self::UserPresence;
@@ -44,4 +46,6 @@ pub trait Env {
     /// using the defmt crate) and ignore this API. Non-embedded environments may either use this
     /// API or use the log feature (to be implemented using the log crate).
     fn write(&mut self) -> Self::Write;
+
+    fn customization(&self) -> &Self::Customization;
 }

--- a/src/env/test/mod.rs
+++ b/src/env/test/mod.rs
@@ -1,4 +1,5 @@
 use self::upgrade_storage::BufferUpgradeStorage;
+use crate::api::customization::{CustomizationImpl, DEFAULT_CUSTOMIZATION};
 use crate::api::firmware_protection::FirmwareProtection;
 use crate::ctap::status_code::Ctap2StatusCode;
 use crate::ctap::Channel;
@@ -13,6 +14,7 @@ pub struct TestEnv {
     user_presence: TestUserPresence,
     store: Store<BufferStorage>,
     upgrade_storage: Option<BufferUpgradeStorage>,
+    customization: CustomizationImpl,
 }
 
 pub struct TestUserPresence {
@@ -51,16 +53,22 @@ impl TestEnv {
         let storage = new_storage();
         let store = Store::new(storage).ok().unwrap();
         let upgrade_storage = Some(BufferUpgradeStorage::new().unwrap());
+        let customization = DEFAULT_CUSTOMIZATION.clone();
         TestEnv {
             rng,
             user_presence,
             store,
             upgrade_storage,
+            customization,
         }
     }
 
     pub fn disable_upgrade_storage(&mut self) {
         self.upgrade_storage = None;
+    }
+
+    pub fn customization_mut(&mut self) -> &mut CustomizationImpl {
+        &mut self.customization
     }
 }
 
@@ -89,6 +97,7 @@ impl Env for TestEnv {
     type UpgradeStorage = BufferUpgradeStorage;
     type FirmwareProtection = Self;
     type Write = TestWrite;
+    type Customization = CustomizationImpl;
 
     fn rng(&mut self) -> &mut Self::Rng {
         &mut self.rng
@@ -112,5 +121,9 @@ impl Env for TestEnv {
 
     fn write(&mut self) -> Self::Write {
         TestWrite
+    }
+
+    fn customization(&self) -> &Self::Customization {
+        &self.customization
     }
 }

--- a/src/env/tock/mod.rs
+++ b/src/env/tock/mod.rs
@@ -1,4 +1,5 @@
 pub use self::storage::{TockStorage, TockUpgradeStorage};
+use crate::api::customization::{CustomizationImpl, DEFAULT_CUSTOMIZATION};
 use crate::api::firmware_protection::FirmwareProtection;
 use crate::ctap::hid::{CtapHid, CtapHidCommand, KeepaliveStatus, ProcessedPacket};
 use crate::ctap::status_code::Ctap2StatusCode;
@@ -80,6 +81,7 @@ impl Env for TockEnv {
     type UpgradeStorage = TockUpgradeStorage;
     type FirmwareProtection = Self;
     type Write = Console;
+    type Customization = CustomizationImpl;
 
     fn rng(&mut self) -> &mut Self::Rng {
         &mut self.rng
@@ -103,6 +105,10 @@ impl Env for TockEnv {
 
     fn write(&mut self) -> Self::Write {
         Console::new()
+    }
+
+    fn customization(&self) -> &Self::Customization {
+        &DEFAULT_CUSTOMIZATION
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,11 @@ impl<E: Env> Ctap<E> {
         &mut self.hid
     }
 
+    #[cfg(feature = "std")]
+    pub fn env(&mut self) -> &mut E {
+        &mut self.env
+    }
+
     pub fn process_hid_packet(
         &mut self,
         packet: &HidPacket,


### PR DESCRIPTION
* Introduce Customization struct including the customizations that
  control various behaviors.

* Expose Customization through a getter API in Env, and make the code
  that directly access the constants currently switch to accessing the
  customizations via Env.

* TockEnv's customization getter implementation directly returns the
  reference of the global DEFAULT_CUSTOMIZATION constant, so the
  constant values are still inlined and dead code won't be compiled.

* We'll add the customizations from global constants to the struct
  one-by-one, only MAX_MSG_SIZE in this commit.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR