### PR TITLE
Make rng in TestEnv deterministic and seedable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,13 @@ subtle = { version = "2.2", default-features = false, features = ["nightly"] }
 serde_json = { version = "=1.0.69", default-features = false, features = ["alloc"] }
 embedded-time = "0.12.1"
 arbitrary = { version = "0.4.7", features = ["derive"], optional = true }
+rand = { version = "0.8.4", optional = true }
 
 [features]
 debug_allocations = ["lang_items/debug_allocations"]
 debug_ctap = ["libtock_drivers/debug_ctap"]
 panic_console = ["lang_items/panic_console"]
-std = ["crypto/std", "lang_items/std", "persistent_store/std"]
+std = ["crypto/std", "lang_items/std", "persistent_store/std", "rand"]
 verbose = ["debug_ctap", "libtock_drivers/verbose_usb"]
 with_ctap1 = ["crypto/with_ctap1"]
 with_nfc = ["libtock_drivers/with_nfc"]

--- a/fuzz/fuzz_helper/src/lib.rs
+++ b/fuzz/fuzz_helper/src/lib.rs
@@ -174,6 +174,8 @@ pub fn process_ctap_structured(data: &[u8], input_type: InputType) -> arbitrary:
     let mut env = TestEnv::new();
     let mut state = CtapState::new(&mut env, CtapInstant::new(0));
 
+    env.rng().seed_rng_from_u64(u64::arbitrary(unstructured)?);
+
     let command = match input_type {
         InputType::CborMakeCredentialParameter => Command::AuthenticatorMakeCredential(
             AuthenticatorMakeCredentialParameters::arbitrary(unstructured)?,
@@ -188,8 +190,6 @@ pub fn process_ctap_structured(data: &[u8], input_type: InputType) -> arbitrary:
             unimplemented!()
         }
     };
-
-    env.seed_rng_from_u64(u64::arbitrary(unstructured)?);
 
     state
         .process_parsed_command(

--- a/fuzz/fuzz_helper/src/lib.rs
+++ b/fuzz/fuzz_helper/src/lib.rs
@@ -172,9 +172,9 @@ pub fn process_ctap_structured(data: &[u8], input_type: InputType) -> arbitrary:
     let unstructured = &mut Unstructured::new(data);
 
     let mut env = TestEnv::new();
-    let mut state = CtapState::new(&mut env, CtapInstant::new(0));
-
     env.rng().seed_rng_from_u64(u64::arbitrary(unstructured)?);
+
+    let mut state = CtapState::new(&mut env, CtapInstant::new(0));
 
     let command = match input_type {
         InputType::CborMakeCredentialParameter => Command::AuthenticatorMakeCredential(

--- a/fuzz/fuzz_helper/src/lib.rs
+++ b/fuzz/fuzz_helper/src/lib.rs
@@ -189,6 +189,8 @@ pub fn process_ctap_structured(data: &[u8], input_type: InputType) -> arbitrary:
         }
     };
 
+    env.seed_rng_from_u64(u64::arbitrary(unstructured)?);
+
     state
         .process_parsed_command(
             &mut env,

--- a/fuzz/fuzz_targets/fuzz_target_process_ctap1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_process_ctap1.rs
@@ -7,5 +7,5 @@ use libfuzzer_sys::fuzz_target;
 // For a more generic fuzz target including all CTAP commands, you can use
 // fuzz_target_process_ctap_command.
 fuzz_target!(|data: &[u8]| {
-    process_ctap_specific_type(data, InputType::Ctap1);
+    process_ctap_specific_type(data, InputType::Ctap1).ok();
 });

--- a/fuzz/fuzz_targets/fuzz_target_process_ctap2_client_pin.rs
+++ b/fuzz/fuzz_targets/fuzz_target_process_ctap2_client_pin.rs
@@ -7,5 +7,5 @@ use libfuzzer_sys::fuzz_target;
 // For a more generic fuzz target including all CTAP commands, you can use
 // fuzz_target_process_ctap_command.
 fuzz_target!(|data: &[u8]| {
-    process_ctap_specific_type(data, InputType::CborClientPinParameter);
+    process_ctap_specific_type(data, InputType::CborClientPinParameter).ok();
 });

--- a/fuzz/fuzz_targets/fuzz_target_process_ctap2_get_assertion.rs
+++ b/fuzz/fuzz_targets/fuzz_target_process_ctap2_get_assertion.rs
@@ -7,5 +7,5 @@ use libfuzzer_sys::fuzz_target;
 // For a more generic fuzz target including all CTAP commands, you can use
 // fuzz_target_process_ctap_command.
 fuzz_target!(|data: &[u8]| {
-    process_ctap_specific_type(data, InputType::CborGetAssertionParameter);
+    process_ctap_specific_type(data, InputType::CborGetAssertionParameter).ok();
 });

--- a/fuzz/fuzz_targets/fuzz_target_process_ctap2_make_credential.rs
+++ b/fuzz/fuzz_targets/fuzz_target_process_ctap2_make_credential.rs
@@ -7,5 +7,5 @@ use libfuzzer_sys::fuzz_target;
 // For a more generic fuzz target including all CTAP commands, you can use
 // fuzz_target_process_ctap_command.
 fuzz_target!(|data: &[u8]| {
-    process_ctap_specific_type(data, InputType::CborMakeCredentialParameter);
+    process_ctap_specific_type(data, InputType::CborMakeCredentialParameter).ok();
 });

--- a/fuzz/fuzz_targets/fuzz_target_process_ctap_command.rs
+++ b/fuzz/fuzz_targets/fuzz_target_process_ctap_command.rs
@@ -5,5 +5,5 @@ use libfuzzer_sys::fuzz_target;
 
 // Generically fuzz inputs as CTAP commands.
 fuzz_target!(|data: &[u8]| {
-    process_ctap_any_type(data);
+    process_ctap_any_type(data).ok();
 });

--- a/fuzz/fuzz_targets/fuzz_target_split_assemble.rs
+++ b/fuzz/fuzz_targets/fuzz_target_split_assemble.rs
@@ -5,5 +5,5 @@ use libfuzzer_sys::fuzz_target;
 
 // Fuzzing HID packets splitting and assembling functions.
 fuzz_target!(|data: &[u8]| {
-    split_assemble_hid_packets(data);
+    split_assemble_hid_packets(data).ok();
 });

--- a/src/api/customization.rs
+++ b/src/api/customization.rs
@@ -18,6 +18,8 @@
 //! Our deploy script enforces the invariants.
 
 use crate::ctap::data_formats::CredentialProtectionPolicy;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 pub trait Customization {
     // ###########################################################################
@@ -66,7 +68,7 @@ pub trait Customization {
     ///
     /// Only the RP IDs listed in default_min_pin_length_rp_ids are allowed to read
     /// the minimum PIN length with the minPinLength extension.
-    fn default_min_pin_length_rp_ids(&self) -> &[&str];
+    fn default_min_pin_length_rp_ids(&self) -> Vec<String>;
 
     /// Enforces the alwaysUv option.
     ///
@@ -164,8 +166,11 @@ impl Customization for CustomizationImpl {
         self.default_min_pin_length
     }
 
-    fn default_min_pin_length_rp_ids(&self) -> &[&str] {
+    fn default_min_pin_length_rp_ids(&self) -> Vec<String> {
         self.default_min_pin_length_rp_ids
+            .iter()
+            .map(|s| String::from(*s))
+            .collect()
     }
 
     fn enforce_always_uv(&self) -> bool {
@@ -221,7 +226,6 @@ mod test {
     use super::*;
 
     #[test]
-    #[allow(clippy::assertions_on_constants)]
     fn test_invariants() {
         assert!(is_valid(&DEFAULT_CUSTOMIZATION));
     }

--- a/src/api/customization.rs
+++ b/src/api/customization.rs
@@ -50,7 +50,7 @@ pub trait Customization {
     ///
     /// - The minimum PIN length must be at least 4.
     /// - The minimum PIN length must be at most 63.
-    /// - default_min_pin_length_rp_ids() must be non-empty if MAX_RP_IDS_LENGTH is 0.
+    /// - default_min_pin_length_rp_ids() must be non-empty if max_rp_ids_length() is 0.
     ///
     /// Requiring longer PINs can help establish trust between users and relying
     /// parties. It makes user verification harder to break, but less convenient.
@@ -64,7 +64,7 @@ pub trait Customization {
     ///
     /// # Invariant
     ///
-    /// - default_min_pin_length_rp_ids() must be non-empty if MAX_RP_IDS_LENGTH is 0
+    /// - default_min_pin_length_rp_ids() must be non-empty if max_rp_ids_length() is 0
     ///
     /// Only the RP IDs listed in default_min_pin_length_rp_ids are allowed to read
     /// the minimum PIN length with the minPinLength extension.

--- a/src/api/customization.rs
+++ b/src/api/customization.rs
@@ -68,6 +68,16 @@ pub trait Customization {
     /// the minimum PIN length with the minPinLength extension.
     fn default_min_pin_length_rp_ids(&self) -> &[&str];
 
+    /// Enforces the alwaysUv option.
+    ///
+    /// When setting to true, commands require a PIN.
+    /// Also, alwaysUv can not be disabled by commands.
+    ///
+    /// A certification (additional to FIDO Alliance's) might require enforcing
+    /// alwaysUv. Otherwise, users should have the choice to configure alwaysUv.
+    /// Calling toggleAlwaysUv is preferred over enforcing alwaysUv here.
+    fn enforce_always_uv(&self) -> bool;
+
     /// Maximum message size send for CTAP commands.
     ///
     /// The maximum value is 7609, as HID packets can not encode longer messages.
@@ -76,6 +86,28 @@ pub trait Customization {
     /// If long commands are too unreliable on your hardware, consider decreasing
     /// this value.
     fn max_msg_size(&self) -> usize;
+
+    /// Sets the number of consecutive failed PINs before blocking interaction.
+    ///
+    /// # Invariant
+    ///
+    /// - CTAP2.0: Maximum PIN retries must be 8.
+    /// - CTAP2.1: Maximum PIN retries must be 8 at most.
+    ///
+    /// The fail retry counter is reset after entering the correct PIN.
+    fn max_pin_retries(&self) -> u8;
+
+    /// Enables or disables signature counters.
+    ///
+    /// The signature counter is currently implemented as a global counter.
+    /// The specification strongly suggests to have per-credential counters.
+    /// Implementing those means you can't have an infinite amount of server-side
+    /// credentials anymore. Also, since counters need frequent writes on the
+    /// persistent storage, we might need a flash friendly implementation. This
+    /// solution is a compromise to be compatible with U2F and not wasting storage.
+    ///
+    /// https://www.w3.org/TR/webauthn/#signature-counter
+    fn use_signature_counter(&self) -> bool;
 
     // ###########################################################################
     // Constants for performance optimization or adapting to different hardware.
@@ -102,18 +134,24 @@ pub trait Customization {
 
 #[derive(Clone)]
 pub struct CustomizationImpl {
+    pub default_cred_protect: Option<CredentialProtectionPolicy>,
     pub default_min_pin_length: u8,
     pub default_min_pin_length_rp_ids: &'static [&'static str],
-    pub default_cred_protect: Option<CredentialProtectionPolicy>,
+    pub enforce_always_uv: bool,
     pub max_msg_size: usize,
+    pub max_pin_retries: u8,
+    pub use_signature_counter: bool,
     pub max_rp_ids_length: usize,
 }
 
 pub const DEFAULT_CUSTOMIZATION: CustomizationImpl = CustomizationImpl {
     default_min_pin_length: 4,
     default_min_pin_length_rp_ids: &[],
+    enforce_always_uv: false,
     default_cred_protect: None,
     max_msg_size: 7609,
+    max_pin_retries: 8,
+    use_signature_counter: true,
     max_rp_ids_length: 8,
 };
 
@@ -130,8 +168,20 @@ impl Customization for CustomizationImpl {
         self.default_min_pin_length_rp_ids
     }
 
+    fn enforce_always_uv(&self) -> bool {
+        self.enforce_always_uv
+    }
+
     fn max_msg_size(&self) -> usize {
         self.max_msg_size
+    }
+
+    fn max_pin_retries(&self) -> u8 {
+        self.max_pin_retries
+    }
+
+    fn use_signature_counter(&self) -> bool {
+        self.use_signature_counter
     }
 
     fn max_rp_ids_length(&self) -> usize {
@@ -148,6 +198,11 @@ pub fn is_valid(customization: &impl Customization) -> bool {
 
     // Default min pin length must be between 4 and 63.
     if customization.default_min_pin_length() < 4 || customization.default_min_pin_length() > 63 {
+        return false;
+    }
+
+    // Max pin retries must be less or equal than 8.
+    if customization.max_pin_retries() > 8 {
         return false;
     }
 

--- a/src/ctap/config_command.rs
+++ b/src/ctap/config_command.rs
@@ -123,7 +123,7 @@ pub fn process_config(
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::ctap::customization::ENFORCE_ALWAYS_UV;
+    use crate::api::customization::Customization;
     use crate::ctap::data_formats::PinUvAuthProtocol;
     use crate::ctap::pin_protocol::authenticate_pin_uv_auth_token;
     use crate::env::test::TestEnv;
@@ -180,7 +180,7 @@ mod test {
             pin_uv_auth_protocol: None,
         };
         let config_response = process_config(&mut env, &mut client_pin, config_params);
-        if ENFORCE_ALWAYS_UV {
+        if env.customization().enforce_always_uv() {
             assert_eq!(
                 config_response,
                 Err(Ctap2StatusCode::CTAP2_ERR_OPERATION_DENIED)
@@ -210,7 +210,7 @@ mod test {
             pin_uv_auth_protocol: Some(pin_uv_auth_protocol),
         };
         let config_response = process_config(&mut env, &mut client_pin, config_params);
-        if ENFORCE_ALWAYS_UV {
+        if env.customization().enforce_always_uv() {
             assert_eq!(
                 config_response,
                 Err(Ctap2StatusCode::CTAP2_ERR_OPERATION_DENIED)

--- a/src/ctap/credential_management.rs
+++ b/src/ctap/credential_management.rs
@@ -364,7 +364,6 @@ mod test {
     use super::super::CtapState;
     use super::*;
     use crate::env::test::TestEnv;
-    use crate::env::Env;
     use crypto::rng256::Rng256;
 
     const DUMMY_CHANNEL: Channel = Channel::MainHid([0x12, 0x34, 0x56, 0x78]);

--- a/src/ctap/customization.rs
+++ b/src/ctap/customization.rs
@@ -19,16 +19,6 @@
 
 use crate::ctap::data_formats::EnterpriseAttestationMode;
 
-/// Enforces the alwaysUv option.
-///
-/// When setting to true, commands require a PIN.
-/// Also, alwaysUv can not be disabled by commands.
-///
-/// A certification (additional to FIDO Alliance's) might require enforcing
-/// alwaysUv. Otherwise, users should have the choice to configure alwaysUv.
-/// Calling toggleAlwaysUv is preferred over enforcing alwaysUv here.
-pub const ENFORCE_ALWAYS_UV: bool = false;
-
 /// Allows usage of enterprise attestation.
 ///
 /// # Invariant
@@ -71,16 +61,6 @@ pub const ENTERPRISE_ATTESTATION_MODE: Option<EnterpriseAttestationMode> = None;
 /// VendorFacilitated.
 pub const ENTERPRISE_RP_ID_LIST: &[&str] = &[];
 
-/// Sets the number of consecutive failed PINs before blocking interaction.
-///
-/// # Invariant
-///
-/// - CTAP2.0: Maximum PIN retries must be 8.
-/// - CTAP2.1: Maximum PIN retries must be 8 at most.
-///
-/// The fail retry counter is reset after entering the correct PIN.
-pub const MAX_PIN_RETRIES: u8 = 8;
-
 /// Enables or disables basic attestation for FIDO2.
 ///
 /// # Invariant
@@ -96,18 +76,6 @@ pub const MAX_PIN_RETRIES: u8 = 8;
 ///
 /// https://www.w3.org/TR/webauthn/#attestation
 pub const USE_BATCH_ATTESTATION: bool = false;
-
-/// Enables or disables signature counters.
-///
-/// The signature counter is currently implemented as a global counter.
-/// The specification strongly suggests to have per-credential counters.
-/// Implementing those means you can't have an infinite amount of server-side
-/// credentials anymore. Also, since counters need frequent writes on the
-/// persistent storage, we might need a flash friendly implementation. This
-/// solution is a compromise to be compatible with U2F and not wasting storage.
-///
-/// https://www.w3.org/TR/webauthn/#signature-counter
-pub const USE_SIGNATURE_COUNTER: bool = true;
 
 // ###########################################################################
 // Constants for performance optimization or adapting to different hardware.
@@ -178,7 +146,6 @@ mod test {
         } else {
             assert!(ENTERPRISE_RP_ID_LIST.is_empty());
         }
-        assert!(MAX_PIN_RETRIES <= 8);
         assert!(MAX_CRED_BLOB_LENGTH >= 32);
         if let Some(count) = MAX_CREDENTIAL_COUNT_IN_LIST {
             assert!(count >= 1);

--- a/src/ctap/customization.rs
+++ b/src/ctap/customization.rs
@@ -19,36 +19,6 @@
 
 use crate::ctap::data_formats::EnterpriseAttestationMode;
 
-// ###########################################################################
-// Constants for adjusting privacy and protection levels.
-// ###########################################################################
-
-/// Sets the initial minimum PIN length in code points.
-///
-/// # Invariant
-///
-/// - The minimum PIN length must be at least 4.
-/// - The minimum PIN length must be at most 63.
-/// - DEFAULT_MIN_PIN_LENGTH_RP_IDS must be non-empty if MAX_RP_IDS_LENGTH is 0.
-///
-/// Requiring longer PINs can help establish trust between users and relying
-/// parties. It makes user verification harder to break, but less convenient.
-/// NIST recommends at least 6-digit PINs in section 5.1.9.1:
-/// https://pages.nist.gov/800-63-3/sp800-63b.html
-///
-/// Reset reverts the minimum PIN length to this DEFAULT_MIN_PIN_LENGTH.
-pub const DEFAULT_MIN_PIN_LENGTH: u8 = 4;
-
-/// Lists relying parties that can read the minimum PIN length.
-///
-/// # Invariant
-///
-/// - DEFAULT_MIN_PIN_LENGTH_RP_IDS must be non-empty if MAX_RP_IDS_LENGTH is 0
-///
-/// Only the RP IDs listed in DEFAULT_MIN_PIN_LENGTH_RP_IDS are allowed to read
-/// the minimum PIN length with the minPinLength extension.
-pub const DEFAULT_MIN_PIN_LENGTH_RP_IDS: &[&str] = &[];
-
 /// Enforces the alwaysUv option.
 ///
 /// When setting to true, commands require a PIN.
@@ -171,21 +141,6 @@ pub const MAX_CREDENTIAL_COUNT_IN_LIST: Option<usize> = None;
 /// - The array must fit into the shards reserved in storage/key.rs.
 pub const MAX_LARGE_BLOB_ARRAY_SIZE: usize = 2048;
 
-/// Limits the number of RP IDs that can change the minimum PIN length.
-///
-/// # Invariant
-///
-/// - If this value is 0, DEFAULT_MIN_PIN_LENGTH_RP_IDS must be non-empty.
-///
-/// You can use this constant to have an upper limit in storage requirements.
-/// This might be useful if you want to more reliably predict the remaining
-/// storage. Stored string can still be of arbitrary length though, until RP ID
-/// truncation is implemented.
-/// Outside of memory considerations, you can set this value to 0 if only RP IDs
-/// in DEFAULT_MIN_PIN_LENGTH_RP_IDS should be allowed to change the minimum PIN
-/// length.
-pub const MAX_RP_IDS_LENGTH: usize = 8;
-
 /// Sets the number of resident keys you can store.
 ///
 /// # Invariant
@@ -217,8 +172,6 @@ mod test {
         // Two invariants are currently tested in different files:
         // - storage.rs: if MAX_LARGE_BLOB_ARRAY_SIZE fits the shards
         // - storage/key.rs: if MAX_SUPPORTED_RESIDENT_KEYS fits CREDENTIALS
-        assert!(DEFAULT_MIN_PIN_LENGTH >= 4);
-        assert!(DEFAULT_MIN_PIN_LENGTH <= 63);
         assert!(!USE_BATCH_ATTESTATION || ENTERPRISE_ATTESTATION_MODE.is_none());
         if let Some(EnterpriseAttestationMode::VendorFacilitated) = ENTERPRISE_ATTESTATION_MODE {
             assert!(!ENTERPRISE_RP_ID_LIST.is_empty());
@@ -231,8 +184,5 @@ mod test {
             assert!(count >= 1);
         }
         assert!(MAX_LARGE_BLOB_ARRAY_SIZE >= 1024);
-        if MAX_RP_IDS_LENGTH == 0 {
-            assert!(!DEFAULT_MIN_PIN_LENGTH_RP_IDS.is_empty());
-        }
     }
 }

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -45,8 +45,7 @@ use self::credential_management::process_credential_management;
 use self::crypto_wrapper::{aes256_cbc_decrypt, aes256_cbc_encrypt};
 use self::customization::{
     ENTERPRISE_ATTESTATION_MODE, ENTERPRISE_RP_ID_LIST, MAX_CREDENTIAL_COUNT_IN_LIST,
-    MAX_CRED_BLOB_LENGTH, MAX_LARGE_BLOB_ARRAY_SIZE, MAX_RP_IDS_LENGTH, USE_BATCH_ATTESTATION,
-    USE_SIGNATURE_COUNTER,
+    MAX_CRED_BLOB_LENGTH, MAX_LARGE_BLOB_ARRAY_SIZE, USE_BATCH_ATTESTATION, USE_SIGNATURE_COUNTER,
 };
 use self::data_formats::{
     AuthenticatorTransport, CoseKey, CoseSignature, CredentialProtectionPolicy,
@@ -1224,7 +1223,9 @@ impl CtapState {
                 min_pin_length: storage::min_pin_length(env)?,
                 firmware_version: None,
                 max_cred_blob_length: Some(MAX_CRED_BLOB_LENGTH as u64),
-                max_rp_ids_for_set_min_pin_length: Some(MAX_RP_IDS_LENGTH as u64),
+                max_rp_ids_for_set_min_pin_length: Some(
+                    env.customization().max_rp_ids_length() as u64
+                ),
                 certifications: None,
                 remaining_discoverable_credentials: Some(
                     storage::remaining_credentials(env)? as u64
@@ -1531,7 +1532,7 @@ mod test {
             0x0C => false,
             0x0D => storage::min_pin_length(&mut env).unwrap() as u64,
             0x0F => MAX_CRED_BLOB_LENGTH as u64,
-            0x10 => MAX_RP_IDS_LENGTH as u64,
+            0x10 => env.customization().max_rp_ids_length() as u64,
             0x14 => storage::remaining_credentials(&mut env).unwrap() as u64,
         };
 

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -45,7 +45,7 @@ use self::credential_management::process_credential_management;
 use self::crypto_wrapper::{aes256_cbc_decrypt, aes256_cbc_encrypt};
 use self::customization::{
     ENTERPRISE_ATTESTATION_MODE, ENTERPRISE_RP_ID_LIST, MAX_CREDENTIAL_COUNT_IN_LIST,
-    MAX_CRED_BLOB_LENGTH, MAX_LARGE_BLOB_ARRAY_SIZE, USE_BATCH_ATTESTATION, USE_SIGNATURE_COUNTER,
+    MAX_CRED_BLOB_LENGTH, MAX_LARGE_BLOB_ARRAY_SIZE, USE_BATCH_ATTESTATION,
 };
 use self::data_formats::{
     AuthenticatorTransport, CoseKey, CoseSignature, CredentialProtectionPolicy,
@@ -421,7 +421,7 @@ impl CtapState {
         &mut self,
         env: &mut impl Env,
     ) -> Result<(), Ctap2StatusCode> {
-        if USE_SIGNATURE_COUNTER {
+        if env.customization().use_signature_counter() {
             let increment = env.rng().gen_uniform_u32x8()[0] % 8 + 1;
             storage::incr_global_signature_counter(env, increment)?;
         }
@@ -1398,7 +1398,7 @@ impl CtapState {
         let mut auth_data = vec![];
         auth_data.extend(rp_id_hash);
         auth_data.push(flag_byte);
-        // The global counter is only increased if USE_SIGNATURE_COUNTER is true.
+        // The global counter is only increased if use_signature_counter() is true.
         // It uses a big-endian representation.
         let mut signature_counter = [0u8; 4];
         BigEndian::write_u32(

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -726,10 +726,10 @@ mod test {
     use super::*;
     use crate::ctap::data_formats::{PublicKeyCredentialSource, PublicKeyCredentialType};
     use crate::env::test::TestEnv;
-    use crypto::rng256::{Rng256, ThreadRng256};
+    use crypto::rng256::Rng256;
 
     fn create_credential_source(
-        rng: &mut ThreadRng256,
+        rng: &mut impl Rng256,
         rp_id: &str,
         user_handle: Vec<u8>,
     ) -> PublicKeyCredentialSource {

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -397,15 +397,7 @@ pub fn set_min_pin_length(env: &mut impl Env, min_pin_length: u8) -> Result<(), 
 /// allowed.
 pub fn min_pin_length_rp_ids(env: &mut impl Env) -> Result<Vec<String>, Ctap2StatusCode> {
     let rp_ids = env.store().find(key::MIN_PIN_LENGTH_RP_IDS)?.map_or_else(
-        || {
-            Some(
-                env.customization()
-                    .default_min_pin_length_rp_ids()
-                    .iter()
-                    .map(|&s| String::from(s))
-                    .collect(),
-            )
-        },
+        || Some(env.customization().default_min_pin_length_rp_ids()),
         |value| deserialize_min_pin_length_rp_ids(&value),
     );
     debug_assert!(rp_ids.is_some());
@@ -418,8 +410,7 @@ pub fn set_min_pin_length_rp_ids(
     min_pin_length_rp_ids: Vec<String>,
 ) -> Result<(), Ctap2StatusCode> {
     let mut min_pin_length_rp_ids = min_pin_length_rp_ids;
-    for &rp_id in env.customization().default_min_pin_length_rp_ids().iter() {
-        let rp_id = String::from(rp_id);
+    for rp_id in env.customization().default_min_pin_length_rp_ids() {
         if !min_pin_length_rp_ids.contains(&rp_id) {
             min_pin_length_rp_ids.push(rp_id);
         }
@@ -1140,8 +1131,7 @@ mod test {
         // Changes by the setter are reflected by the getter.
         let mut rp_ids = vec![String::from("example.com")];
         assert_eq!(set_min_pin_length_rp_ids(&mut env, rp_ids.clone()), Ok(()));
-        for &rp_id in env.customization().default_min_pin_length_rp_ids().iter() {
-            let rp_id = String::from(rp_id);
+        for rp_id in env.customization().default_min_pin_length_rp_ids() {
             if !rp_ids.contains(&rp_id) {
                 rp_ids.push(rp_id);
             }

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -736,10 +736,10 @@ mod test {
     use super::*;
     use crate::ctap::data_formats::{PublicKeyCredentialSource, PublicKeyCredentialType};
     use crate::env::test::TestEnv;
-    use crypto::rng256::{Rng256, ThreadRng256};
+    use crypto::rng256::Rng256;
 
     fn create_credential_source(
-        rng: &mut ThreadRng256,
+        rng: &mut impl Rng256,
         rp_id: &str,
         user_handle: Vec<u8>,
     ) -> PublicKeyCredentialSource {

--- a/src/ctap/storage/key.rs
+++ b/src/ctap/storage/key.rs
@@ -115,7 +115,7 @@ make_partition! {
 
     /// The number of PIN retries.
     ///
-    /// If the entry is absent, the number of PIN retries is `MAX_PIN_RETRIES`.
+    /// If the entry is absent, the number of PIN retries is `Customization::max_pin_retries()`.
     PIN_RETRIES = 2044;
 
     /// The PIN hash and length.

--- a/src/ctap/storage/key.rs
+++ b/src/ctap/storage/key.rs
@@ -110,7 +110,7 @@ make_partition! {
 
     /// The minimum PIN length.
     ///
-    /// If the entry is absent, the minimum PIN length is `DEFAULT_MIN_PIN_LENGTH`.
+    /// If the entry is absent, the minimum PIN length is `Customization::default_min_pin_length()`.
     MIN_PIN_LENGTH = 2043;
 
     /// The number of PIN retries.

--- a/src/env/test/customization.rs
+++ b/src/env/test/customization.rs
@@ -87,11 +87,14 @@ mod test {
     use crate::api::customization::{is_valid, DEFAULT_CUSTOMIZATION};
 
     #[test]
-    #[allow(clippy::assertions_on_constants)]
     fn test_invariants() {
-        let mut customization = TestCustomization::from(DEFAULT_CUSTOMIZATION.clone());
+        let customization = TestCustomization::from(DEFAULT_CUSTOMIZATION.clone());
         assert!(is_valid(&customization));
+    }
 
+    #[test]
+    fn test_vec_storage_impl() {
+        let mut customization = TestCustomization::from(DEFAULT_CUSTOMIZATION.clone());
         assert!(customization.default_min_pin_length_rp_ids().is_empty());
         customization
             .set_default_min_pin_length_rp_ids(vec!["abc.com".to_owned(), "def.com".to_owned()]);

--- a/src/env/test/customization.rs
+++ b/src/env/test/customization.rs
@@ -80,3 +80,23 @@ impl From<CustomizationImpl> for TestCustomization {
         ret
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::api::customization::{is_valid, DEFAULT_CUSTOMIZATION};
+
+    #[test]
+    #[allow(clippy::assertions_on_constants)]
+    fn test_invariants() {
+        let mut customization = TestCustomization::from(DEFAULT_CUSTOMIZATION.clone());
+        assert!(is_valid(&customization));
+
+        assert!(customization.default_min_pin_length_rp_ids().is_empty());
+        customization
+            .set_default_min_pin_length_rp_ids(vec!["abc.com".to_owned(), "def.com".to_owned()]);
+        assert!(customization.default_min_pin_length_rp_ids() == ["abc.com", "def.com"]);
+        customization.set_default_min_pin_length_rp_ids(vec!["example.com".to_owned()]);
+        assert!(customization.default_min_pin_length_rp_ids() == ["example.com"]);
+    }
+}

--- a/src/env/test/customization.rs
+++ b/src/env/test/customization.rs
@@ -1,29 +1,17 @@
-use std::slice::from_raw_parts;
-
 use crate::api::customization::{Customization, CustomizationImpl};
 use crate::ctap::data_formats::CredentialProtectionPolicy;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 pub struct TestCustomization {
     pub default_cred_protect: Option<CredentialProtectionPolicy>,
     pub default_min_pin_length: u8,
-    default_min_pin_length_rp_ids_backing_store: Vec<String>,
-    default_min_pin_length_rp_ids: Vec<*const str>,
+    pub default_min_pin_length_rp_ids: Vec<String>,
     pub enforce_always_uv: bool,
     pub max_msg_size: usize,
     pub max_pin_retries: u8,
     pub use_signature_counter: bool,
     pub max_rp_ids_length: usize,
-}
-
-impl TestCustomization {
-    pub fn set_default_min_pin_length_rp_ids(&mut self, rp_ids: Vec<String>) {
-        self.default_min_pin_length_rp_ids_backing_store = rp_ids;
-        self.default_min_pin_length_rp_ids = self
-            .default_min_pin_length_rp_ids_backing_store
-            .iter()
-            .map(|s| s.as_ref() as *const str)
-            .collect::<Vec<_>>();
-    }
 }
 
 impl Customization for TestCustomization {
@@ -35,10 +23,8 @@ impl Customization for TestCustomization {
         self.default_min_pin_length
     }
 
-    fn default_min_pin_length_rp_ids(&self) -> &[&str] {
-        let length = self.default_min_pin_length_rp_ids.len();
-        let rp_ids = self.default_min_pin_length_rp_ids.as_ptr() as *const &str;
-        unsafe { from_raw_parts(rp_ids, length) }
+    fn default_min_pin_length_rp_ids(&self) -> Vec<String> {
+        self.default_min_pin_length_rp_ids.clone()
     }
 
     fn enforce_always_uv(&self) -> bool {
@@ -75,30 +61,21 @@ impl From<CustomizationImpl> for TestCustomization {
             max_rp_ids_length,
         } = c;
 
-        let default_min_pin_length_rp_ids_backing_store = default_min_pin_length_rp_ids
+        let default_min_pin_length_rp_ids = default_min_pin_length_rp_ids
             .iter()
-            .map(|s| (*s).to_owned())
+            .map(|s| String::from(*s))
             .collect::<Vec<_>>();
 
-        let mut ret = Self {
+        Self {
             default_cred_protect,
             default_min_pin_length,
-            default_min_pin_length_rp_ids_backing_store,
-            default_min_pin_length_rp_ids: vec![],
+            default_min_pin_length_rp_ids,
             enforce_always_uv,
             max_msg_size,
             max_pin_retries,
             use_signature_counter,
             max_rp_ids_length,
-        };
-
-        ret.default_min_pin_length_rp_ids = ret
-            .default_min_pin_length_rp_ids_backing_store
-            .iter()
-            .map(|s| s.as_ref() as *const str)
-            .collect::<Vec<_>>();
-
-        ret
+        }
     }
 }
 
@@ -111,22 +88,5 @@ mod test {
     fn test_invariants() {
         let customization = TestCustomization::from(DEFAULT_CUSTOMIZATION.clone());
         assert!(is_valid(&customization));
-    }
-
-    #[test]
-    fn test_vec_storage_impl() {
-        let mut customization = TestCustomization::from(DEFAULT_CUSTOMIZATION.clone());
-        assert!(customization.default_min_pin_length_rp_ids().is_empty());
-        customization
-            .set_default_min_pin_length_rp_ids(vec!["abc.com".to_owned(), "def.com".to_owned()]);
-        assert_eq!(
-            customization.default_min_pin_length_rp_ids(),
-            ["abc.com", "def.com"]
-        );
-        customization.set_default_min_pin_length_rp_ids(vec!["example.com".to_owned()]);
-        assert_eq!(
-            customization.default_min_pin_length_rp_ids(),
-            ["example.com"]
-        );
     }
 }

--- a/src/env/test/customization.rs
+++ b/src/env/test/customization.rs
@@ -95,8 +95,14 @@ mod test {
         assert!(customization.default_min_pin_length_rp_ids().is_empty());
         customization
             .set_default_min_pin_length_rp_ids(vec!["abc.com".to_owned(), "def.com".to_owned()]);
-        assert!(customization.default_min_pin_length_rp_ids() == ["abc.com", "def.com"]);
+        assert_eq!(
+            customization.default_min_pin_length_rp_ids(),
+            ["abc.com", "def.com"]
+        );
         customization.set_default_min_pin_length_rp_ids(vec!["example.com".to_owned()]);
-        assert!(customization.default_min_pin_length_rp_ids() == ["example.com"]);
+        assert_eq!(
+            customization.default_min_pin_length_rp_ids(),
+            ["example.com"]
+        );
     }
 }

--- a/src/env/test/customization.rs
+++ b/src/env/test/customization.rs
@@ -1,0 +1,82 @@
+use std::slice::from_raw_parts;
+
+use crate::api::customization::{Customization, CustomizationImpl};
+use crate::ctap::data_formats::CredentialProtectionPolicy;
+
+pub struct TestCustomization {
+    pub default_min_pin_length: u8,
+    default_min_pin_length_rp_ids_backing_store: Vec<String>,
+    default_min_pin_length_rp_ids: Vec<*const str>,
+    pub default_cred_protect: Option<CredentialProtectionPolicy>,
+    pub max_msg_size: usize,
+    pub max_rp_ids_length: usize,
+}
+
+impl TestCustomization {
+    pub fn set_default_min_pin_length_rp_ids(&mut self, rp_ids: Vec<String>) {
+        self.default_min_pin_length_rp_ids_backing_store = rp_ids;
+        self.default_min_pin_length_rp_ids = self
+            .default_min_pin_length_rp_ids_backing_store
+            .iter()
+            .map(|s| s.as_ref() as *const str)
+            .collect::<Vec<_>>();
+    }
+}
+
+impl Customization for TestCustomization {
+    fn default_cred_protect(&self) -> Option<CredentialProtectionPolicy> {
+        self.default_cred_protect
+    }
+
+    fn default_min_pin_length(&self) -> u8 {
+        self.default_min_pin_length
+    }
+
+    fn default_min_pin_length_rp_ids(&self) -> &[&str] {
+        let length = self.default_min_pin_length_rp_ids.len();
+        let rp_ids = self.default_min_pin_length_rp_ids.as_ptr() as *const &str;
+        unsafe { from_raw_parts(rp_ids, length) }
+    }
+
+    fn max_msg_size(&self) -> usize {
+        self.max_msg_size
+    }
+
+    fn max_rp_ids_length(&self) -> usize {
+        self.max_rp_ids_length
+    }
+}
+
+impl From<CustomizationImpl> for TestCustomization {
+    fn from(c: CustomizationImpl) -> Self {
+        let CustomizationImpl {
+            default_min_pin_length,
+            default_min_pin_length_rp_ids,
+            default_cred_protect,
+            max_msg_size,
+            max_rp_ids_length,
+        } = c;
+
+        let default_min_pin_length_rp_ids_backing_store = default_min_pin_length_rp_ids
+            .iter()
+            .map(|s| (*s).to_owned())
+            .collect::<Vec<_>>();
+
+        let mut ret = Self {
+            default_min_pin_length,
+            default_min_pin_length_rp_ids_backing_store,
+            default_min_pin_length_rp_ids: vec![],
+            default_cred_protect,
+            max_msg_size,
+            max_rp_ids_length,
+        };
+
+        ret.default_min_pin_length_rp_ids = ret
+            .default_min_pin_length_rp_ids_backing_store
+            .iter()
+            .map(|s| s.as_ref() as *const str)
+            .collect::<Vec<_>>();
+
+        ret
+    }
+}

--- a/src/env/test/customization.rs
+++ b/src/env/test/customization.rs
@@ -4,11 +4,14 @@ use crate::api::customization::{Customization, CustomizationImpl};
 use crate::ctap::data_formats::CredentialProtectionPolicy;
 
 pub struct TestCustomization {
+    pub default_cred_protect: Option<CredentialProtectionPolicy>,
     pub default_min_pin_length: u8,
     default_min_pin_length_rp_ids_backing_store: Vec<String>,
     default_min_pin_length_rp_ids: Vec<*const str>,
-    pub default_cred_protect: Option<CredentialProtectionPolicy>,
+    pub enforce_always_uv: bool,
     pub max_msg_size: usize,
+    pub max_pin_retries: u8,
+    pub use_signature_counter: bool,
     pub max_rp_ids_length: usize,
 }
 
@@ -38,8 +41,20 @@ impl Customization for TestCustomization {
         unsafe { from_raw_parts(rp_ids, length) }
     }
 
+    fn enforce_always_uv(&self) -> bool {
+        self.enforce_always_uv
+    }
+
     fn max_msg_size(&self) -> usize {
         self.max_msg_size
+    }
+
+    fn max_pin_retries(&self) -> u8 {
+        self.max_pin_retries
+    }
+
+    fn use_signature_counter(&self) -> bool {
+        self.use_signature_counter
     }
 
     fn max_rp_ids_length(&self) -> usize {
@@ -50,10 +65,13 @@ impl Customization for TestCustomization {
 impl From<CustomizationImpl> for TestCustomization {
     fn from(c: CustomizationImpl) -> Self {
         let CustomizationImpl {
+            default_cred_protect,
             default_min_pin_length,
             default_min_pin_length_rp_ids,
-            default_cred_protect,
+            enforce_always_uv,
             max_msg_size,
+            max_pin_retries,
+            use_signature_counter,
             max_rp_ids_length,
         } = c;
 
@@ -63,11 +81,14 @@ impl From<CustomizationImpl> for TestCustomization {
             .collect::<Vec<_>>();
 
         let mut ret = Self {
+            default_cred_protect,
             default_min_pin_length,
             default_min_pin_length_rp_ids_backing_store,
             default_min_pin_length_rp_ids: vec![],
-            default_cred_protect,
+            enforce_always_uv,
             max_msg_size,
+            max_pin_retries,
+            use_signature_counter,
             max_rp_ids_length,
         };
 

--- a/src/env/test/mod.rs
+++ b/src/env/test/mod.rs
@@ -23,6 +23,12 @@ pub struct TestRng256 {
     rng: StdRng,
 }
 
+impl TestRng256 {
+    pub fn seed_rng_from_u64(&mut self, state: u64) {
+        self.rng = StdRng::seed_from_u64(state);
+    }
+}
+
 impl Rng256 for TestRng256 {
     fn gen_uniform_u8x32(&mut self) -> [u8; 32] {
         let mut result = [Default::default(); 32];
@@ -87,10 +93,8 @@ impl TestEnv {
         &mut self.customization
     }
 
-    pub fn seed_rng_from_u64(&mut self, state: u64) {
-        self.rng = TestRng256 {
-            rng: StdRng::seed_from_u64(state),
-        };
+    pub fn rng(&mut self) -> &mut TestRng256 {
+        &mut self.rng
     }
 }
 

--- a/src/env/test/mod.rs
+++ b/src/env/test/mod.rs
@@ -39,24 +39,6 @@ impl Rng256 for TestRng256 {
     }
 }
 
-pub struct TestRng256 {
-    rng: StdRng,
-}
-
-impl TestRng256 {
-    pub fn seed_rng_from_u64(&mut self, state: u64) {
-        self.rng = StdRng::seed_from_u64(state);
-    }
-}
-
-impl Rng256 for TestRng256 {
-    fn gen_uniform_u8x32(&mut self) -> [u8; 32] {
-        let mut result = [Default::default(); 32];
-        self.rng.fill(&mut result);
-        result
-    }
-}
-
 pub struct TestUserPresence {
     check: Box<dyn Fn(Channel) -> Result<(), Ctap2StatusCode>>,
 }

--- a/src/env/test/mod.rs
+++ b/src/env/test/mod.rs
@@ -25,6 +25,12 @@ pub struct TestRng256 {
     rng: StdRng,
 }
 
+impl TestRng256 {
+    pub fn seed_rng_from_u64(&mut self, state: u64) {
+        self.rng = StdRng::seed_from_u64(state);
+    }
+}
+
 impl Rng256 for TestRng256 {
     fn gen_uniform_u8x32(&mut self) -> [u8; 32] {
         let mut result = [Default::default(); 32];
@@ -89,10 +95,8 @@ impl TestEnv {
         &mut self.customization
     }
 
-    pub fn seed_rng_from_u64(&mut self, state: u64) {
-        self.rng = TestRng256 {
-            rng: StdRng::seed_from_u64(state),
-        };
+    pub fn rng(&mut self) -> &mut TestRng256 {
+        &mut self.rng
     }
 }
 

--- a/src/env/test/mod.rs
+++ b/src/env/test/mod.rs
@@ -1,12 +1,14 @@
 use self::upgrade_storage::BufferUpgradeStorage;
-use crate::api::customization::{CustomizationImpl, DEFAULT_CUSTOMIZATION};
+use crate::api::customization::DEFAULT_CUSTOMIZATION;
 use crate::api::firmware_protection::FirmwareProtection;
 use crate::ctap::status_code::Ctap2StatusCode;
 use crate::ctap::Channel;
 use crate::env::{Env, UserPresence};
 use crypto::rng256::ThreadRng256;
+use customization::TestCustomization;
 use persistent_store::{BufferOptions, BufferStorage, Store};
 
+mod customization;
 mod upgrade_storage;
 
 pub struct TestEnv {
@@ -14,7 +16,7 @@ pub struct TestEnv {
     user_presence: TestUserPresence,
     store: Store<BufferStorage>,
     upgrade_storage: Option<BufferUpgradeStorage>,
-    customization: CustomizationImpl,
+    customization: TestCustomization,
 }
 
 pub struct TestUserPresence {
@@ -53,7 +55,7 @@ impl TestEnv {
         let storage = new_storage();
         let store = Store::new(storage).ok().unwrap();
         let upgrade_storage = Some(BufferUpgradeStorage::new().unwrap());
-        let customization = DEFAULT_CUSTOMIZATION.clone();
+        let customization = DEFAULT_CUSTOMIZATION.into();
         TestEnv {
             rng,
             user_presence,
@@ -67,7 +69,7 @@ impl TestEnv {
         self.upgrade_storage = None;
     }
 
-    pub fn customization_mut(&mut self) -> &mut CustomizationImpl {
+    pub fn customization_mut(&mut self) -> &mut TestCustomization {
         &mut self.customization
     }
 }
@@ -97,7 +99,7 @@ impl Env for TestEnv {
     type UpgradeStorage = BufferUpgradeStorage;
     type FirmwareProtection = Self;
     type Write = TestWrite;
-    type Customization = CustomizationImpl;
+    type Customization = TestCustomization;
 
     fn rng(&mut self) -> &mut Self::Rng {
         &mut self.rng

--- a/src/env/test/mod.rs
+++ b/src/env/test/mod.rs
@@ -4,17 +4,31 @@ use crate::api::firmware_protection::FirmwareProtection;
 use crate::ctap::status_code::Ctap2StatusCode;
 use crate::ctap::Channel;
 use crate::env::{Env, UserPresence};
-use crypto::rng256::ThreadRng256;
+use crypto::rng256::Rng256;
 use persistent_store::{BufferOptions, BufferStorage, Store};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
 
 mod upgrade_storage;
 
 pub struct TestEnv {
-    rng: ThreadRng256,
+    rng: TestRng256,
     user_presence: TestUserPresence,
     store: Store<BufferStorage>,
     upgrade_storage: Option<BufferUpgradeStorage>,
     customization: CustomizationImpl,
+}
+
+pub struct TestRng256 {
+    rng: StdRng,
+}
+
+impl Rng256 for TestRng256 {
+    fn gen_uniform_u8x32(&mut self) -> [u8; 32] {
+        let mut result = [Default::default(); 32];
+        self.rng.fill(&mut result);
+        result
+    }
 }
 
 pub struct TestUserPresence {
@@ -46,7 +60,9 @@ fn new_storage() -> BufferStorage {
 
 impl TestEnv {
     pub fn new() -> Self {
-        let rng = ThreadRng256 {};
+        let rng = TestRng256 {
+            rng: StdRng::seed_from_u64(0),
+        };
         let user_presence = TestUserPresence {
             check: Box::new(|_| Ok(())),
         };
@@ -70,6 +86,12 @@ impl TestEnv {
     pub fn customization_mut(&mut self) -> &mut CustomizationImpl {
         &mut self.customization
     }
+
+    pub fn seed_rng_from_u64(&mut self, state: u64) {
+        self.rng = TestRng256 {
+            rng: StdRng::seed_from_u64(state),
+        };
+    }
 }
 
 impl TestUserPresence {
@@ -91,7 +113,7 @@ impl FirmwareProtection for TestEnv {
 }
 
 impl Env for TestEnv {
-    type Rng = ThreadRng256;
+    type Rng = TestRng256;
     type UserPresence = TestUserPresence;
     type Storage = BufferStorage;
     type UpgradeStorage = BufferUpgradeStorage;


### PR DESCRIPTION
@ia0 , I want to try take some bytes (a u64) in fuzz data in our process_* fuzz targets to seed the rng, but that will affect the corpus's effectiveness right? Because after taken the bytes the valid cbor formats in corpus might become invalid.