### PR TITLE
Workflow for cargo bloat

### DIFF
--- a/.github/workflows/bloat_formatter.sh
+++ b/.github/workflows/bloat_formatter.sh
@@ -20,25 +20,22 @@ cd "$(dirname "$0")"
 # Result file is $3
 
 WARNING="Note: numbers above are a result of guesswork. They are not 100% correct and never will be."
-
 NEW_SIZE=$(cat "$1" | sed -nr 's/.*100.0% (.*)KiB .text.*/\1/p')
 OLD_SIZE=$(cat "$2" | sed -nr 's/.*100.0% (.*)KiB .text.*/\1/p')
-echo "Binary size:
-\`\`\`diff
-- $OLD_SIZE kiB
-+ $NEW_SIZE kiB
-\`\`\`" > "$3"
-
-echo "<details>
-<summary>Output for cargo bloat</summary>
-<br>
-<pre>" >> "$3"
-
-echo "<h3>Including PR</h3>" >> "$3"
-cat "$1" | sed "s/$WARNING//" >> "$3"
-echo "<h3>Base branch</h3>" >> "$3"
-cat "$2" | sed "s/$WARNING//" >> "$3"
 
 echo "
-</pre>
-</details>" >> "$3"
+OLD $OLD_SIZE kiB
+NEW $NEW_SIZE kiB" > "$3"
+
+echo "
+Output of cargo bloat
+======================
+" >> "$3"
+
+echo "Including PR" >> "$3"
+cat "$1" >> "$3"
+echo "Base branch" >> "$3"
+cat "$2" >> "$3"
+
+COMMENT="$(cat $3 | sed "s/$WARNING//g" | sed 's/%/%25/g' | sed -z 's/\n/%0A/g')"
+echo "$COMMENT" > "$3"

--- a/.github/workflows/bloat_formatter.sh
+++ b/.github/workflows/bloat_formatter.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cd "$(dirname "$0")"
+
+# New output file is $1
+# Old output file is $2
+# Result file is $3
+
+WARNING="Note: numbers above are a result of guesswork. They are not 100% correct and never will be."
+
+NEW_SIZE=$(cat "$1" | sed -nr 's/.*100.0% (.*)KiB .text.*/\1/p')
+OLD_SIZE=$(cat "$2" | sed -nr 's/.*100.0% (.*)KiB .text.*/\1/p')
+echo "Binary size:
+\`\`\`diff
+- $OLD_SIZE kiB
++ $NEW_SIZE kiB
+\`\`\`" > "$3"
+
+echo "<details>
+<summary>Output for cargo bloat</summary>
+<br>
+<pre>" >> "$3"
+
+echo "<h3>Including PR</h3>" >> "$3"
+cat "$1" | sed "s/$WARNING//" >> "$3"
+echo "<h3>Base branch</h3>" >> "$3"
+cat "$2" | sed "s/$WARNING//" >> "$3"
+
+echo "
+</pre>
+</details>" >> "$3"

--- a/.github/workflows/cargo_bloat.yml
+++ b/.github/workflows/cargo_bloat.yml
@@ -3,10 +3,6 @@ on: pull_request
 
 jobs:
   cargo_bloat:
-    permissions:
-      contents: write 
-      issues: write
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       # Setup
@@ -48,10 +44,6 @@ jobs:
         run: RUSTFLAGS="-C link-arg=-icf=all -C force-frame-pointers=no" cargo bloat --release --target=thumbv7em-none-eabi --features=with_ctap1,vendor_hid --crates >> "$GITHUB_WORKSPACE/.github/workflows/bloat_output_old.txt"
 
       - name: Run output formatter
-        run: ./.github/workflows/bloat_formatter.sh bloat_output_new.txt bloat_output_old.txt comment.txt
-      - name: Comment bloat output
-        uses: NejcZdovc/comment-pr@v1
-        with:
-          file: "comment.txt"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./.github/workflows/bloat_formatter.sh bloat_output_new.txt bloat_output_old.txt bloat_comment.md
+      - name: Run workflow command
+        run: echo "::notice file=.github/workflows/cargo_bloat.yml,title=Binary size::$(cat .github/workflows/bloat_comment.md)"

--- a/.github/workflows/cargo_bloat.yml
+++ b/.github/workflows/cargo_bloat.yml
@@ -1,0 +1,57 @@
+name: Binary size report
+on: pull_request
+
+jobs:
+  cargo_bloat:
+    permissions:
+      contents: write 
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      # Setup
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install Python dependencies
+        run: python -m pip install --upgrade pip setuptools wheel
+      - uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-bloat
+
+      # First run: PR
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Install Rust toolchain
+        run: rustup show
+      - name: Set up OpenSK
+        run: ./setup.sh
+      - name: Run bloat on the PR
+        run: RUSTFLAGS="-C link-arg=-icf=all -C force-frame-pointers=no" cargo bloat --release --target=thumbv7em-none-eabi --features=with_ctap1,vendor_hid --crates >> .github/workflows/bloat_output_new.txt
+
+      # Second run: PR
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          ref: ${{ github.base_ref }}
+          path: OpenSK_base
+      - name: Install old Rust toolchain
+        working-directory: ./OpenSK_base
+        run: rustup show
+      - name: Set up OpenSK
+        working-directory: ./OpenSK_base
+        run: ./setup.sh
+      - name: Run bloat on base
+        working-directory: ./OpenSK_base
+        run: RUSTFLAGS="-C link-arg=-icf=all -C force-frame-pointers=no" cargo bloat --release --target=thumbv7em-none-eabi --features=with_ctap1,vendor_hid --crates >> "$GITHUB_WORKSPACE/.github/workflows/bloat_output_old.txt"
+
+      - name: Run output formatter
+        run: ./.github/workflows/bloat_formatter.sh bloat_output_new.txt bloat_output_old.txt comment.txt
+      - name: Comment bloat output
+        uses: NejcZdovc/comment-pr@v1
+        with:
+          file: "comment.txt"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cargo_bloat.yml
+++ b/.github/workflows/cargo_bloat.yml
@@ -43,7 +43,5 @@ jobs:
         working-directory: ./OpenSK_base
         run: RUSTFLAGS="-C link-arg=-icf=all -C force-frame-pointers=no" cargo bloat --release --target=thumbv7em-none-eabi --features=with_ctap1,vendor_hid --crates >> "$GITHUB_WORKSPACE/.github/workflows/bloat_output_old.txt"
 
-      - name: Run output formatter
+      - name: Run output formatter to echo workflow command
         run: ./.github/workflows/bloat_formatter.sh bloat_output_new.txt bloat_output_old.txt bloat_comment.md
-      - name: Run workflow command
-        run: echo "::notice file=.github/workflows/cargo_bloat.yml,title=Binary size::$(cat .github/workflows/bloat_comment.md)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,5 +50,5 @@ lto = true # Link Time Optimization usually reduces size of binaries and static 
 [profile.release]
 panic = "abort"
 lto = true # Link Time Optimization usually reduces size of binaries and static libraries
-opt-level = 3
+opt-level = "z"
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,5 +50,5 @@ lto = true # Link Time Optimization usually reduces size of binaries and static 
 [profile.release]
 panic = "abort"
 lto = true # Link Time Optimization usually reduces size of binaries and static libraries
-opt-level = "z"
+opt-level = 3
 codegen-units = 1


### PR DESCRIPTION
We often had to manually add binary size comparisons in PRs before, now we get a quick overview of what we usually care about automatically.

Important details:
- The binary is compiled with the most likely feature set: `with_ctap, vendor_hid`
- The reported size is the actual size of the app from Tock's perspective.