### PR TITLE
Enterprise attestation testing

### DIFF
--- a/src/api/customization.rs
+++ b/src/api/customization.rs
@@ -118,12 +118,11 @@ pub trait Customization {
     ///
     /// - If the mode is VendorFacilitated, enterprise_attestation_mode() must be non-empty.
     ///
-    /// This list is only considered if the enterprise attestation mode is
-    /// VendorFacilitated.
+    /// This list is only considered if enterprise attestation is used.
     #[cfg(feature = "std")]
     fn enterprise_rp_id_list(&self) -> Vec<String>;
 
-    // Returns whether the rp_id is contained in enterprise_rp_id_list().
+    /// Returns whether the rp_id is contained in enterprise_rp_id_list().
     fn is_enterprise_rp_id(&self, rp_id: &str) -> bool;
 
     /// Maximum message size send for CTAP commands.
@@ -303,11 +302,18 @@ pub fn is_valid(customization: &impl Customization) -> bool {
         return false;
     }
 
-    // enterprise_rp_id_list() should be non-empty in vendor facilitated mode, and empty otherwise.
+    // enterprise_rp_id_list() should be non-empty in vendor facilitated mode.
     if matches!(
         customization.enterprise_attestation_mode(),
         Some(EnterpriseAttestationMode::VendorFacilitated)
-    ) == customization.enterprise_rp_id_list().is_empty()
+    ) && customization.enterprise_rp_id_list().is_empty()
+    {
+        return false;
+    }
+
+    // enterprise_rp_id_list() should be empty without an enterprise attestation mode.
+    if customization.enterprise_attestation_mode().is_none()
+        && !customization.enterprise_rp_id_list().is_empty()
     {
         return false;
     }

--- a/src/ctap/command.rs
+++ b/src/ctap/command.rs
@@ -230,6 +230,7 @@ impl TryFrom<cbor::Value> for AuthenticatorMakeCredentialParameters {
         let pin_uv_auth_protocol = pin_uv_auth_protocol
             .map(PinUvAuthProtocol::try_from)
             .transpose()?;
+        // We don't convert into EnterpriseAttestationMode to maintain the correct order of errors.
         let enterprise_attestation = enterprise_attestation.map(extract_unsigned).transpose()?;
 
         Ok(AuthenticatorMakeCredentialParameters {

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -577,9 +577,7 @@ pub fn enterprise_attestation(env: &mut impl Env) -> Result<bool, Ctap2StatusCod
 
 /// Marks enterprise attestation as enabled.
 pub fn enable_enterprise_attestation(env: &mut impl Env) -> Result<(), Ctap2StatusCode> {
-    if attestation_private_key(env).unwrap_or(None).is_none()
-        || attestation_certificate(env).unwrap_or(None).is_none()
-    {
+    if attestation_private_key(env)?.is_none() || attestation_certificate(env)?.is_none() {
         return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
     }
     if !enterprise_attestation(env)? {

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -577,6 +577,11 @@ pub fn enterprise_attestation(env: &mut impl Env) -> Result<bool, Ctap2StatusCod
 
 /// Marks enterprise attestation as enabled.
 pub fn enable_enterprise_attestation(env: &mut impl Env) -> Result<(), Ctap2StatusCode> {
+    if attestation_private_key(env).unwrap_or(None).is_none()
+        || attestation_certificate(env).unwrap_or(None).is_none()
+    {
+        return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
+    }
     if !enterprise_attestation(env)? {
         env.store().insert(key::ENTERPRISE_ATTESTATION, &[])?;
     }
@@ -1079,8 +1084,8 @@ mod test {
         init(&mut env).unwrap();
 
         // Make sure the attestation are absent. There is no batch attestation in tests.
-        assert!(attestation_private_key(&mut env,).unwrap().is_none());
-        assert!(attestation_certificate(&mut env,).unwrap().is_none());
+        assert!(attestation_private_key(&mut env).unwrap().is_none());
+        assert!(attestation_certificate(&mut env).unwrap().is_none());
 
         // Make sure the persistent keys are initialized to dummy values.
         let dummy_key = [0x41u8; key_material::ATTESTATION_PRIVATE_KEY_LENGTH];
@@ -1232,6 +1237,18 @@ mod test {
     #[test]
     fn test_enterprise_attestation() {
         let mut env = TestEnv::new();
+
+        assert!(!enterprise_attestation(&mut env).unwrap());
+        assert_eq!(
+            enable_enterprise_attestation(&mut env),
+            Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)
+        );
+        assert!(!enterprise_attestation(&mut env).unwrap());
+
+        let dummy_key = [0x41u8; key_material::ATTESTATION_PRIVATE_KEY_LENGTH];
+        let dummy_cert = [0xddu8; 20];
+        set_attestation_private_key(&mut env, &dummy_key).unwrap();
+        set_attestation_certificate(&mut env, &dummy_cert).unwrap();
 
         assert!(!enterprise_attestation(&mut env).unwrap());
         assert_eq!(enable_enterprise_attestation(&mut env), Ok(()));


### PR DESCRIPTION
Uses @hcyang-google 's PR #463 to add tests for enterprise attestation. Contributions outside of tests:

- Fixes one bug in MakeCredential.
- More permissions with the customization of platform managed enterprise attestation.
- Only allows activating enterprise attestation when the certificate is set, to prevent later vendor errors.