### PR TITLE
Speed up crypto library unit tests

### DIFF
--- a/libraries/crypto/src/ec/exponent256.rs
+++ b/libraries/crypto/src/ec/exponent256.rs
@@ -197,6 +197,8 @@ pub mod test {
             .iter()
             .flatten()
             .flatten()
+            // The original array is 2x15x2, we try to skip irregularly.
+            .step_by(7)
             .map(|x| {
                 ExponentP256::modn(x.montgomery_to_field().to_int())
                     .non_zero()

--- a/libraries/crypto/src/ec/int256.rs
+++ b/libraries/crypto/src/ec/int256.rs
@@ -664,31 +664,13 @@ pub mod test {
         ],
     };
 
-    // Generate all 256-bit integers that have exactly one bit set to 1.
+    /// Generates some 256-bit integers that have exactly one bit set to 1.
     pub fn get_1bit_one_test_values() -> Vec<Int256> {
         let mut values = Vec::new();
-        for &byte in &[0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80] {
+        for &byte in &[0x01, 0x80] {
             for &int in &[byte, byte << 8, byte << 16, byte << 24] {
                 values.push(Int256 {
                     digits: [int, 0, 0, 0, 0, 0, 0, 0],
-                });
-                values.push(Int256 {
-                    digits: [0, int, 0, 0, 0, 0, 0, 0],
-                });
-                values.push(Int256 {
-                    digits: [0, 0, int, 0, 0, 0, 0, 0],
-                });
-                values.push(Int256 {
-                    digits: [0, 0, 0, int, 0, 0, 0, 0],
-                });
-                values.push(Int256 {
-                    digits: [0, 0, 0, 0, int, 0, 0, 0],
-                });
-                values.push(Int256 {
-                    digits: [0, 0, 0, 0, 0, int, 0, 0],
-                });
-                values.push(Int256 {
-                    digits: [0, 0, 0, 0, 0, 0, int, 0],
                 });
                 values.push(Int256 {
                     digits: [0, 0, 0, 0, 0, 0, 0, int],
@@ -698,7 +680,7 @@ pub mod test {
         values
     }
 
-    // Generate all 256-bit integers that have exactly one bit set to 0.
+    /// Generates some 256-bit integers that have exactly one bit set to 0.
     pub fn get_1bit_zero_test_values() -> Vec<Int256> {
         let values: Vec<Int256> = get_1bit_one_test_values()
             .iter()
@@ -718,6 +700,8 @@ pub mod test {
             .iter()
             .flatten()
             .flatten()
+            // The original array is 2x15x2, we try to skip irregularly.
+            .step_by(7)
             .map(|x| x.montgomery_to_field().to_int())
             .collect();
         values.append(&mut get_1bit_one_test_values());
@@ -737,7 +721,6 @@ pub mod test {
     #[test]
     fn test_1bit_one() {
         let values = get_1bit_one_test_values();
-        assert_eq!(values.len(), 256);
         for x in &values {
             assert_eq!(x.hamming_weight(), 1);
         }
@@ -746,7 +729,6 @@ pub mod test {
     #[test]
     fn test_1bit_zero() {
         let values = get_1bit_zero_test_values();
-        assert_eq!(values.len(), 256);
         for x in &values {
             assert_eq!(x.hamming_weight(), 255);
         }
@@ -1021,11 +1003,7 @@ pub mod test {
             let mut result = Int256::ONE;
             let mut power = Int256::ZERO;
 
-            // This test is super slow with debug assertions enabled.
-            #[cfg(not(debug_assertions))]
-            const ITERATIONS: u32 = 100;
-            #[cfg(debug_assertions)]
-            const ITERATIONS: u32 = 5;
+            const ITERATIONS: u32 = 3;
 
             for _ in 0..ITERATIONS {
                 assert_eq!(x.modpow(&power, &MODULUS), result);
@@ -1103,10 +1081,6 @@ pub mod test {
                 let mut result = *x;
                 let mut carries = 0;
 
-                // This test is super slow with debug assertions enabled.
-                #[cfg(not(debug_assertions))]
-                const ITERATIONS: u32 = 1000;
-                #[cfg(debug_assertions)]
                 const ITERATIONS: u32 = 5;
 
                 for factor in 0..ITERATIONS {

--- a/libraries/crypto/src/ec/montgomery.rs
+++ b/libraries/crypto/src/ec/montgomery.rs
@@ -781,6 +781,8 @@ pub mod test {
             .iter()
             .flatten()
             .flatten()
+            // The original array is 2x15x2, we try to skip irregularly.
+            .step_by(7)
             .cloned()
             .collect();
         values.push(Montgomery::ONE);

--- a/libraries/crypto/src/ec/point.rs
+++ b/libraries/crypto/src/ec/point.rs
@@ -601,7 +601,7 @@ pub mod test {
     fn get_test_values_affine() -> Vec<PointAffine> {
         let mut values = Vec::new();
         for table in 0..2 {
-            for index in 0..15 {
+            for index in (0..15).step_by(3) {
                 values.push(precomputed(table, index));
             }
         }
@@ -1005,7 +1005,10 @@ pub mod test {
     fn test_scalar_base_mul_is_scalar_mul_generator() {
         let gen = precomputed(0, 0);
         // TODO: more scalars
-        for scalar in &super::super::exponent256::test::get_test_values() {
+        for scalar in super::super::exponent256::test::get_test_values()
+            .iter()
+            .step_by(3)
+        {
             assert_eq!(
                 PointProjective::scalar_base_mul(scalar),
                 gen.scalar_mul(scalar)
@@ -1017,7 +1020,10 @@ pub mod test {
     fn test_base_point_mul_is_mul_generator() {
         let gen = precomputed(0, 0);
         // TODO: more scalars
-        for scalar in &super::super::exponent256::test::get_test_values() {
+        for scalar in super::super::exponent256::test::get_test_values()
+            .iter()
+            .step_by(3)
+        {
             assert_eq!(
                 PointP256::base_point_mul(scalar),
                 PointP256::from_affine(&gen).mul(scalar)

--- a/libraries/crypto/src/ecdh.rs
+++ b/libraries/crypto/src/ecdh.rs
@@ -101,11 +101,7 @@ mod test {
     use super::super::rng256::ThreadRng256;
     use super::*;
 
-    // Run more test iterations in release mode, as the code should be faster.
-    #[cfg(not(debug_assertions))]
-    const ITERATIONS: u32 = 10000;
-    #[cfg(debug_assertions)]
-    const ITERATIONS: u32 = 500;
+    const ITERATIONS: u32 = 10;
 
     /** Test that key generation creates valid keys **/
     #[test]

--- a/libraries/crypto/src/ecdsa.rs
+++ b/libraries/crypto/src/ecdsa.rs
@@ -351,11 +351,7 @@ mod test {
     use super::super::sha256::Sha256;
     use super::*;
 
-    // Run more test iterations in release mode, as the code should be faster.
-    #[cfg(not(debug_assertions))]
-    const ITERATIONS: u32 = 10000;
-    #[cfg(debug_assertions)]
-    const ITERATIONS: u32 = 500;
+    const ITERATIONS: u32 = 10;
 
     /** Test that key generation creates valid keys **/
     #[test]

--- a/libraries/crypto/src/sha256.rs
+++ b/libraries/crypto/src/sha256.rs
@@ -266,8 +266,8 @@ mod test {
         let hash = hex::decode("32beecb58a128af8248504600bd203dcc676adf41045300485655e6b8780a01d")
             .unwrap();
 
-        for i in 0..512 {
-            for j in i..512 {
+        for i in (0..512).step_by(16) {
+            for j in (i..512).step_by(16) {
                 let mut h = Sha256::new();
                 h.update(&input[..i]);
                 h.update(&input[i..j]);


### PR DESCRIPTION
Local testing (`run_desktop_tests.sh`) is unnecessarily slow, in part because of the slow unit tests in the crypto library. Some unit tests took over a minute to complete.

This PR reduces the number of iterations for these tests. No test should take longer than a second. `--report-time` helps finding slow tests. This PR is a 50x reduction in CPU load for these tests.

Before:
```
$ time cargo test --features=std  -- -Zunstable-options --report-time
...
real	2m10.315s
user	12m6.005s
sys	0m2.419s
```

After:
```
$ time cargo test --features=std  -- -Zunstable-options --report-time
...
real	0m5.148s
user	0m13.719s
sys	0m0.100s
```