### PR TITLE
No crypto tests on desktop

### DIFF
--- a/run_desktop_tests.sh
+++ b/run_desktop_tests.sh
@@ -100,9 +100,6 @@ then
   cd libraries/cbor
   cargo test --release
   cd ../..
-  cd libraries/crypto
-  RUSTFLAGS='-C target-feature=+aes' cargo test --release --features std
-  cd ../..
   cd libraries/persistent_store
   cargo test --release --features std
   cd ../..
@@ -111,9 +108,6 @@ then
   echo "Running unit tests on the desktop (debug mode)..."
   cd libraries/cbor
   cargo test
-  cd ../..
-  cd libraries/crypto
-  RUSTFLAGS='-C target-feature=+aes' cargo test --features std
   cd ../..
   cd libraries/persistent_store
   cargo test --features std


### PR DESCRIPTION
Removes `cargo test` for `crypto` from `run_desktop_tests.sh`. Replaces #466 as a more direct solution. Tests for the `crypto` library take minutes, and since it's not under active development, only slow down local development.