### PR TITLE
ThreadRng cleanup

### DIFF
--- a/src/ctap/command.rs
+++ b/src/ctap/command.rs
@@ -636,8 +636,8 @@ mod test {
     };
     use super::super::ES256_CRED_PARAM;
     use super::*;
+    use crate::env::test::TestEnv;
     use cbor::{cbor_array, cbor_map};
-    use crypto::rng256::ThreadRng256;
 
     #[test]
     fn test_from_cbor_make_credential_parameters() {
@@ -749,8 +749,8 @@ mod test {
 
     #[test]
     fn test_from_cbor_client_pin_parameters() {
-        let mut rng = ThreadRng256 {};
-        let sk = crypto::ecdh::SecKey::gensk(&mut rng);
+        let mut env = TestEnv::new();
+        let sk = crypto::ecdh::SecKey::gensk(env.rng());
         let pk = sk.genpk();
         let cose_key = CoseKey::from(pk);
 

--- a/src/ctap/crypto_wrapper.rs
+++ b/src/ctap/crypto_wrapper.rs
@@ -65,35 +65,35 @@ pub fn aes256_cbc_decrypt(
 #[cfg(test)]
 mod test {
     use super::*;
-    use crypto::rng256::ThreadRng256;
+    use crate::env::test::TestEnv;
 
     #[test]
     fn test_encrypt_decrypt_with_iv() {
-        let mut rng = ThreadRng256 {};
+        let mut env = TestEnv::new();
         let aes_enc_key = crypto::aes256::EncryptionKey::new(&[0xC2; 32]);
         let plaintext = vec![0xAA; 64];
-        let ciphertext = aes256_cbc_encrypt(&mut rng, &aes_enc_key, &plaintext, true).unwrap();
+        let ciphertext = aes256_cbc_encrypt(env.rng(), &aes_enc_key, &plaintext, true).unwrap();
         let decrypted = aes256_cbc_decrypt(&aes_enc_key, &ciphertext, true).unwrap();
         assert_eq!(decrypted, plaintext);
     }
 
     #[test]
     fn test_encrypt_decrypt_without_iv() {
-        let mut rng = ThreadRng256 {};
+        let mut env = TestEnv::new();
         let aes_enc_key = crypto::aes256::EncryptionKey::new(&[0xC2; 32]);
         let plaintext = vec![0xAA; 64];
-        let ciphertext = aes256_cbc_encrypt(&mut rng, &aes_enc_key, &plaintext, false).unwrap();
+        let ciphertext = aes256_cbc_encrypt(env.rng(), &aes_enc_key, &plaintext, false).unwrap();
         let decrypted = aes256_cbc_decrypt(&aes_enc_key, &ciphertext, false).unwrap();
         assert_eq!(decrypted, plaintext);
     }
 
     #[test]
     fn test_correct_iv_usage() {
-        let mut rng = ThreadRng256 {};
+        let mut env = TestEnv::new();
         let aes_enc_key = crypto::aes256::EncryptionKey::new(&[0xC2; 32]);
         let plaintext = vec![0xAA; 64];
         let mut ciphertext_no_iv =
-            aes256_cbc_encrypt(&mut rng, &aes_enc_key, &plaintext, false).unwrap();
+            aes256_cbc_encrypt(env.rng(), &aes_enc_key, &plaintext, false).unwrap();
         let mut ciphertext_with_iv = vec![0u8; 16];
         ciphertext_with_iv.append(&mut ciphertext_no_iv);
         let decrypted = aes256_cbc_decrypt(&aes_enc_key, &ciphertext_with_iv, true).unwrap();
@@ -102,10 +102,10 @@ mod test {
 
     #[test]
     fn test_iv_manipulation_property() {
-        let mut rng = ThreadRng256 {};
+        let mut env = TestEnv::new();
         let aes_enc_key = crypto::aes256::EncryptionKey::new(&[0xC2; 32]);
         let plaintext = vec![0xAA; 64];
-        let mut ciphertext = aes256_cbc_encrypt(&mut rng, &aes_enc_key, &plaintext, true).unwrap();
+        let mut ciphertext = aes256_cbc_encrypt(env.rng(), &aes_enc_key, &plaintext, true).unwrap();
         let mut expected_plaintext = plaintext;
         for i in 0..16 {
             ciphertext[i] ^= 0xBB;
@@ -117,11 +117,11 @@ mod test {
 
     #[test]
     fn test_chaining() {
-        let mut rng = ThreadRng256 {};
+        let mut env = TestEnv::new();
         let aes_enc_key = crypto::aes256::EncryptionKey::new(&[0xC2; 32]);
         let plaintext = vec![0xAA; 64];
-        let ciphertext1 = aes256_cbc_encrypt(&mut rng, &aes_enc_key, &plaintext, true).unwrap();
-        let ciphertext2 = aes256_cbc_encrypt(&mut rng, &aes_enc_key, &plaintext, true).unwrap();
+        let ciphertext1 = aes256_cbc_encrypt(env.rng(), &aes_enc_key, &plaintext, true).unwrap();
+        let ciphertext2 = aes256_cbc_encrypt(env.rng(), &aes_enc_key, &plaintext, true).unwrap();
         assert_eq!(ciphertext1.len(), 80);
         assert_eq!(ciphertext2.len(), 80);
         // The ciphertext should mutate in all blocks with a different IV.

--- a/src/ctap/data_formats.rs
+++ b/src/ctap/data_formats.rs
@@ -1221,11 +1221,12 @@ pub(super) fn ok_or_missing<T>(value_option: Option<T>) -> Result<T, Ctap2Status
 mod test {
     use self::Ctap2StatusCode::CTAP2_ERR_CBOR_UNEXPECTED_TYPE;
     use super::*;
+    use crate::env::test::TestEnv;
     use cbor::{
         cbor_array, cbor_bool, cbor_bytes, cbor_bytes_lit, cbor_false, cbor_int, cbor_null,
         cbor_text, cbor_unsigned,
     };
-    use crypto::rng256::{Rng256, ThreadRng256};
+    use crypto::rng256::Rng256;
     use crypto::sha256::Sha256;
 
     #[test]
@@ -1672,8 +1673,8 @@ mod test {
 
     #[test]
     fn test_from_get_assertion_extensions_default_protocol() {
-        let mut rng = ThreadRng256 {};
-        let sk = crypto::ecdh::SecKey::gensk(&mut rng);
+        let mut env = TestEnv::new();
+        let sk = crypto::ecdh::SecKey::gensk(env.rng());
         let pk = sk.genpk();
         let cose_key = CoseKey::from(pk);
         let cbor_extensions = cbor_map! {
@@ -1702,8 +1703,8 @@ mod test {
 
     #[test]
     fn test_from_get_assertion_extensions_with_protocol() {
-        let mut rng = ThreadRng256 {};
-        let sk = crypto::ecdh::SecKey::gensk(&mut rng);
+        let mut env = TestEnv::new();
+        let sk = crypto::ecdh::SecKey::gensk(env.rng());
         let pk = sk.genpk();
         let cose_key = CoseKey::from(pk);
         let cbor_extensions = cbor_map! {
@@ -1877,8 +1878,8 @@ mod test {
 
     #[test]
     fn test_from_into_cose_key_ecdh() {
-        let mut rng = ThreadRng256 {};
-        let sk = crypto::ecdh::SecKey::gensk(&mut rng);
+        let mut env = TestEnv::new();
+        let sk = crypto::ecdh::SecKey::gensk(env.rng());
         let pk = sk.genpk();
         let cose_key = CoseKey::from(pk.clone());
         let created_pk = ecdh::PubKey::try_from(cose_key);
@@ -1887,8 +1888,8 @@ mod test {
 
     #[test]
     fn test_into_cose_key_ecdsa() {
-        let mut rng = ThreadRng256 {};
-        let sk = crypto::ecdsa::SecKey::gensk(&mut rng);
+        let mut env = TestEnv::new();
+        let sk = crypto::ecdsa::SecKey::gensk(env.rng());
         let pk = sk.genpk();
         let cose_key = CoseKey::from(pk);
         assert_eq!(cose_key.algorithm, ES256_ALGORITHM);
@@ -1896,8 +1897,8 @@ mod test {
 
     #[test]
     fn test_from_into_cose_signature() {
-        let mut rng = ThreadRng256 {};
-        let sk = crypto::ecdsa::SecKey::gensk(&mut rng);
+        let mut env = TestEnv::new();
+        let sk = crypto::ecdsa::SecKey::gensk(env.rng());
         let dummy_signature = sk.sign_rfc6979::<Sha256>(&[]);
         let mut bytes = [0; ecdsa::Signature::BYTES_LENGTH];
         dummy_signature.to_bytes(&mut bytes);
@@ -1914,8 +1915,8 @@ mod test {
 
     #[test]
     fn test_cose_signature_wrong_algorithm() {
-        let mut rng = ThreadRng256 {};
-        let sk = crypto::ecdsa::SecKey::gensk(&mut rng);
+        let mut env = TestEnv::new();
+        let sk = crypto::ecdsa::SecKey::gensk(env.rng());
         let dummy_signature = sk.sign_rfc6979::<Sha256>(&[]);
         let mut bytes = [0; ecdsa::Signature::BYTES_LENGTH];
         dummy_signature.to_bytes(&mut bytes);
@@ -2105,11 +2106,11 @@ mod test {
 
     #[test]
     fn test_credential_source_cbor_round_trip() {
-        let mut rng = ThreadRng256 {};
+        let mut env = TestEnv::new();
         let credential = PublicKeyCredentialSource {
             key_type: PublicKeyCredentialType::PublicKey,
-            credential_id: rng.gen_uniform_u8x32().to_vec(),
-            private_key: crypto::ecdsa::SecKey::gensk(&mut rng),
+            credential_id: env.rng().gen_uniform_u8x32().to_vec(),
+            private_key: crypto::ecdsa::SecKey::gensk(env.rng()),
             rp_id: "example.com".to_string(),
             user_handle: b"foo".to_vec(),
             user_display_name: None,

--- a/src/ctap/response.rs
+++ b/src/ctap/response.rs
@@ -343,8 +343,8 @@ mod test {
     use super::super::data_formats::{PackedAttestationStatement, PublicKeyCredentialType};
     use super::super::ES256_CRED_PARAM;
     use super::*;
+    use crate::env::test::TestEnv;
     use cbor::{cbor_array, cbor_bytes, cbor_map};
-    use crypto::rng256::ThreadRng256;
 
     #[test]
     fn test_make_credential_into_cbor() {
@@ -506,8 +506,8 @@ mod test {
 
     #[test]
     fn test_used_client_pin_into_cbor() {
-        let mut rng = ThreadRng256 {};
-        let sk = crypto::ecdh::SecKey::gensk(&mut rng);
+        let mut env = TestEnv::new();
+        let sk = crypto::ecdh::SecKey::gensk(env.rng());
         let pk = sk.genpk();
         let cose_key = CoseKey::from(pk);
         let client_pin_response = AuthenticatorClientPinResponse {
@@ -550,8 +550,8 @@ mod test {
 
     #[test]
     fn test_used_credential_management_optionals_into_cbor() {
-        let mut rng = ThreadRng256 {};
-        let sk = crypto::ecdh::SecKey::gensk(&mut rng);
+        let mut env = TestEnv::new();
+        let sk = crypto::ecdh::SecKey::gensk(env.rng());
         let rp = PublicKeyCredentialRpEntity {
             rp_id: String::from("example.com"),
             rp_name: None,


### PR DESCRIPTION
Some of our tests still used `ThreadRng` directly instead of calling `env.rng()`. This PR removes all mentions of concrete `Rng256` implementations from `src/ctap`. @shilingwangggg FYI