### PR TITLE
Add configure-only mode to deploy.py script

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -760,7 +760,7 @@ class OpenSKInstaller:
     self.update_rustc_if_needed()
 
     if not (self.args.tockos or self.args.application or
-            self.args.clear_storage):
+            self.args.clear_storage or self.args.configure):
       info("Nothing to do.")
       return 0
 
@@ -867,9 +867,12 @@ class OpenSKInstaller:
       return 0
 
     # Perform checks if OpenSK was flashed.
-    if self.args.application != "ctap2":
-      return 0
+    if self.args.application == "ctap2" or self.args.configure:
+      self.configure()
+    return 0
 
+  def configure(self):
+    info("Configuring device.")
     # Trying to check or configure the device. Booting might take some time.
     for i in range(5):
       # Increasing wait time, total of 10 seconds.
@@ -1056,6 +1059,13 @@ if __name__ == "__main__":
       const="with_nfc",
       dest="features",
       help=("Compiles the OpenSK application with support for nfc."),
+  )
+  main_parser.add_argument(
+      "--configure",
+      action="store_true",
+      default=False,
+      dest="configure",
+      help="Configure.",
   )
   main_parser.add_argument(
       "--vendor-hid",

--- a/deploy.py
+++ b/deploy.py
@@ -1081,7 +1081,7 @@ if __name__ == "__main__":
   main_parser.add_argument(
       "--configure",
       action="store_true",
-      default=False,
+      default=True,
       dest="configure",
       help="Configure.",
   )


### PR DESCRIPTION
This flag allows the deploy.py script to just run the phase of configuring the device. This will benefit the work on Vendor HID, which can cause troubles with configuring.