### PR TITLE
Derive Eq

### DIFF
--- a/libraries/crypto/src/ecdsa.rs
+++ b/libraries/crypto/src/ecdsa.rs
@@ -28,7 +28,7 @@ use rng256::Rng256;
 
 pub const NBYTES: usize = int256::NBYTES;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SecKey {
     k: NonZeroExponentP256,
 }

--- a/src/ctap/apdu.rs
+++ b/src/ctap/apdu.rs
@@ -18,7 +18,7 @@ use core::convert::TryFrom;
 
 const APDU_HEADER_LEN: usize = 4;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[allow(non_camel_case_types, dead_code)]
 pub enum ApduStatusCode {
     SW_SUCCESS = 0x90_00,
@@ -51,7 +51,7 @@ pub enum ApduInstructions {
     GetResponse = 0xC0,
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[allow(dead_code)]
 pub struct ApduHeader {
     pub cla: u8,
@@ -71,7 +71,7 @@ impl From<&[u8; APDU_HEADER_LEN]> for ApduHeader {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 /// The APDU cases
 pub enum Case {
     Le1,
@@ -83,7 +83,7 @@ pub enum Case {
     Le3,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[allow(dead_code)]
 pub enum ApduType {
     Instruction,
@@ -91,7 +91,7 @@ pub enum ApduType {
     Extended(Case),
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[allow(dead_code)]
 pub struct Apdu {
     pub header: ApduHeader,

--- a/src/ctap/command.rs
+++ b/src/ctap/command.rs
@@ -36,7 +36,7 @@ use sk_cbor::destructure_cbor_map;
 const MIN_LARGE_BLOB_LEN: usize = 17;
 
 // CTAP specification (version 20190130) section 6.1
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[allow(clippy::enum_variant_names)]
 pub enum Command {
     AuthenticatorMakeCredential(AuthenticatorMakeCredentialParameters),
@@ -155,7 +155,7 @@ impl Command {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct AuthenticatorMakeCredentialParameters {
     pub client_data_hash: Vec<u8>,
@@ -245,7 +245,7 @@ impl TryFrom<cbor::Value> for AuthenticatorMakeCredentialParameters {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AuthenticatorGetAssertionParameters {
     pub rp_id: String,
     pub client_data_hash: Vec<u8>,
@@ -316,7 +316,7 @@ impl TryFrom<cbor::Value> for AuthenticatorGetAssertionParameters {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AuthenticatorClientPinParameters {
     pub pin_uv_auth_protocol: PinUvAuthProtocol,
     pub sub_command: ClientPinSubCommand,
@@ -373,7 +373,7 @@ impl TryFrom<cbor::Value> for AuthenticatorClientPinParameters {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AuthenticatorLargeBlobsParameters {
     pub get: Option<usize>,
     pub set: Option<Vec<u8>>,
@@ -447,7 +447,7 @@ impl TryFrom<cbor::Value> for AuthenticatorLargeBlobsParameters {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AuthenticatorConfigParameters {
     pub sub_command: ConfigSubCommand,
     pub sub_command_params: Option<ConfigSubCommandParams>,
@@ -489,7 +489,7 @@ impl TryFrom<cbor::Value> for AuthenticatorConfigParameters {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AuthenticatorAttestationMaterial {
     pub certificate: Vec<u8>,
     pub private_key: [u8; key_material::ATTESTATION_PRIVATE_KEY_LENGTH],
@@ -518,7 +518,7 @@ impl TryFrom<cbor::Value> for AuthenticatorAttestationMaterial {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AuthenticatorCredentialManagementParameters {
     pub sub_command: CredentialManagementSubCommand,
     pub sub_command_params: Option<CredentialManagementSubCommandParameters>,
@@ -557,7 +557,7 @@ impl TryFrom<cbor::Value> for AuthenticatorCredentialManagementParameters {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AuthenticatorVendorConfigureParameters {
     pub lockdown: bool,
     pub attestation_material: Option<AuthenticatorAttestationMaterial>,
@@ -584,7 +584,7 @@ impl TryFrom<cbor::Value> for AuthenticatorVendorConfigureParameters {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AuthenticatorVendorUpgradeParameters {
     pub address: Option<usize>,
     pub data: Vec<u8>,

--- a/src/ctap/ctap1.rs
+++ b/src/ctap/ctap1.rs
@@ -27,7 +27,7 @@ pub type Ctap1StatusCode = ApduStatusCode;
 // The specification referenced in this file is at:
 // https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-raw-message-formats-v1.2-ps-20170411.pdf
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Ctap1Flags {
     CheckOnly = 0x07,
     EnforceUpAndSign = 0x03,
@@ -53,15 +53,12 @@ impl Into<u8> for Ctap1Flags {
     }
 }
 
-#[derive(Debug, PartialEq)]
-// TODO: remove #allow when https://github.com/rust-lang/rust/issues/64362 is fixed
+#[derive(Debug, PartialEq, Eq)]
 enum U2fCommand {
-    #[allow(dead_code)]
     Register {
         challenge: [u8; 32],
         application: [u8; 32],
     },
-    #[allow(dead_code)]
     Authenticate {
         challenge: [u8; 32],
         application: [u8; 32],
@@ -69,7 +66,6 @@ enum U2fCommand {
         flags: Ctap1Flags,
     },
     Version,
-    #[allow(dead_code)]
     VendorSpecific {
         payload: Vec<u8>,
     },

--- a/src/ctap/data_formats.rs
+++ b/src/ctap/data_formats.rs
@@ -29,7 +29,7 @@ use sk_cbor::{cbor_array_vec, cbor_map, cbor_map_options, destructure_cbor_map};
 const ES256_ALGORITHM: i64 = -7;
 
 // https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialrpentity
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct PublicKeyCredentialRpEntity {
     pub rp_id: String,
@@ -72,7 +72,7 @@ impl From<PublicKeyCredentialRpEntity> for cbor::Value {
 }
 
 // https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialuserentity
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct PublicKeyCredentialUserEntity {
     pub user_id: Vec<u8>,
@@ -120,7 +120,7 @@ impl From<PublicKeyCredentialUserEntity> for cbor::Value {
 }
 
 // https://www.w3.org/TR/webauthn/#enumdef-publickeycredentialtype
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub enum PublicKeyCredentialType {
     PublicKey,
@@ -153,7 +153,7 @@ impl TryFrom<cbor::Value> for PublicKeyCredentialType {
 }
 
 // https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialparameters
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct PublicKeyCredentialParameter {
     pub cred_type: PublicKeyCredentialType,
@@ -187,7 +187,7 @@ impl From<PublicKeyCredentialParameter> for cbor::Value {
 }
 
 // https://www.w3.org/TR/webauthn/#enumdef-authenticatortransport
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(test, derive(IntoEnumIterator))]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub enum AuthenticatorTransport {
@@ -225,7 +225,7 @@ impl TryFrom<cbor::Value> for AuthenticatorTransport {
 }
 
 // https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialdescriptor
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct PublicKeyCredentialDescriptor {
     pub key_type: PublicKeyCredentialType,
@@ -277,7 +277,7 @@ impl From<PublicKeyCredentialDescriptor> for cbor::Value {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct MakeCredentialExtensions {
     pub hmac_secret: bool,
@@ -323,7 +323,7 @@ impl TryFrom<cbor::Value> for MakeCredentialExtensions {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct GetAssertionExtensions {
     pub hmac_secret: Option<GetAssertionHmacSecretInput>,
     pub cred_blob: bool,
@@ -360,7 +360,7 @@ impl TryFrom<cbor::Value> for GetAssertionExtensions {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GetAssertionHmacSecretInput {
     pub key_agreement: CoseKey,
     pub salt_enc: Vec<u8>,
@@ -396,7 +396,7 @@ impl TryFrom<cbor::Value> for GetAssertionHmacSecretInput {
 }
 
 // Even though options are optional, we can use the default if not present.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct MakeCredentialOptions {
     pub rk: bool,
@@ -433,7 +433,7 @@ impl TryFrom<cbor::Value> for MakeCredentialOptions {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct GetAssertionOptions {
     pub up: bool,
     pub uv: bool,
@@ -478,7 +478,7 @@ impl TryFrom<cbor::Value> for GetAssertionOptions {
 }
 
 // https://www.w3.org/TR/webauthn/#packed-attestation
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct PackedAttestationStatement {
     pub alg: i64,
     pub sig: Vec<u8>,
@@ -497,7 +497,7 @@ impl From<PackedAttestationStatement> for cbor::Value {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub enum SignatureAlgorithm {
     ES256 = ES256_ALGORITHM as isize,
@@ -524,7 +524,7 @@ impl TryFrom<cbor::Value> for SignatureAlgorithm {
 }
 
 /// The credProtect extension's policies for resident credentials.
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd)]
 #[cfg_attr(test, derive(IntoEnumIterator))]
 #[allow(clippy::enum_variant_names)]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
@@ -563,7 +563,7 @@ impl TryFrom<cbor::Value> for CredentialProtectionPolicy {
 //
 // Note that we only use the WebAuthn definition as an example. This data-structure is not specified
 // by FIDO. In particular we may choose how we serialize and deserialize it.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PublicKeyCredentialSource {
     // TODO function to convert to / from Vec<u8>
     pub key_type: PublicKeyCredentialType,
@@ -701,7 +701,7 @@ impl PublicKeyCredentialSource {
 }
 
 // The COSE key is used for both ECDH and ECDSA public keys for transmission.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CoseKey {
     x_bytes: [u8; ecdh::NBYTES],
     y_bytes: [u8; ecdh::NBYTES],
@@ -853,7 +853,7 @@ impl TryFrom<CoseKey> for ecdsa::PubKey {
 /// Data structure for receiving a signature.
 ///
 /// See https://datatracker.ietf.org/doc/html/rfc8152#appendix-C.1.1 for reference.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CoseSignature {
     pub algorithm: SignatureAlgorithm,
     pub bytes: [u8; ecdsa::Signature::BYTES_LENGTH],
@@ -895,7 +895,7 @@ impl TryFrom<CoseSignature> for ecdsa::Signature {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub enum PinUvAuthProtocol {
     V1 = 1,
@@ -914,7 +914,7 @@ impl TryFrom<cbor::Value> for PinUvAuthProtocol {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(test, derive(IntoEnumIterator))]
 pub enum ClientPinSubCommand {
     GetPinRetries = 0x01,
@@ -952,7 +952,7 @@ impl TryFrom<cbor::Value> for ClientPinSubCommand {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(test, derive(IntoEnumIterator))]
 pub enum ConfigSubCommand {
     EnableEnterpriseAttestation = 0x01,
@@ -982,7 +982,7 @@ impl TryFrom<cbor::Value> for ConfigSubCommand {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ConfigSubCommandParams {
     SetMinPinLength(SetMinPinLengthParams),
 }
@@ -997,7 +997,7 @@ impl From<ConfigSubCommandParams> for cbor::Value {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SetMinPinLengthParams {
     pub new_min_pin_length: Option<u8>,
     pub min_pin_length_rp_ids: Option<Vec<String>>,
@@ -1052,7 +1052,7 @@ impl From<SetMinPinLengthParams> for cbor::Value {
 }
 
 /// The level of enterprise attestation allowed in MakeCredential.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum EnterpriseAttestationMode {
     /// Enterprise attestation is restricted to a list of RP IDs. Add your
     /// enterprises domain, e.g. "example.com", to the list below.
@@ -1074,7 +1074,7 @@ impl TryFrom<u64> for EnterpriseAttestationMode {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(test, derive(IntoEnumIterator))]
 pub enum CredentialManagementSubCommand {
     GetCredsMetadata = 0x01,
@@ -1110,7 +1110,7 @@ impl TryFrom<cbor::Value> for CredentialManagementSubCommand {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CredentialManagementSubCommandParameters {
     pub rp_id_hash: Option<Vec<u8>>,
     pub credential_id: Option<PublicKeyCredentialDescriptor>,

--- a/src/ctap/response.rs
+++ b/src/ctap/response.rs
@@ -24,7 +24,7 @@ use sk_cbor::{
     cbor_array_vec, cbor_bool, cbor_int, cbor_map_collection, cbor_map_options, cbor_text,
 };
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[allow(clippy::enum_variant_names)]
 pub enum ResponseData {
     AuthenticatorMakeCredential(AuthenticatorMakeCredentialResponse),
@@ -62,7 +62,7 @@ impl From<ResponseData> for Option<cbor::Value> {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AuthenticatorMakeCredentialResponse {
     pub fmt: String,
     pub auth_data: Vec<u8>,
@@ -91,7 +91,7 @@ impl From<AuthenticatorMakeCredentialResponse> for cbor::Value {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AuthenticatorGetAssertionResponse {
     pub credential: Option<PublicKeyCredentialDescriptor>,
     pub auth_data: Vec<u8>,
@@ -124,7 +124,7 @@ impl From<AuthenticatorGetAssertionResponse> for cbor::Value {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AuthenticatorGetInfoResponse {
     pub versions: Vec<String>,
     pub extensions: Option<Vec<String>>,
@@ -214,7 +214,7 @@ impl From<AuthenticatorGetInfoResponse> for cbor::Value {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AuthenticatorClientPinResponse {
     pub key_agreement: Option<CoseKey>,
     pub pin_uv_auth_token: Option<Vec<u8>>,
@@ -241,7 +241,7 @@ impl From<AuthenticatorClientPinResponse> for cbor::Value {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AuthenticatorLargeBlobsResponse {
     pub config: Vec<u8>,
 }
@@ -256,7 +256,7 @@ impl From<AuthenticatorLargeBlobsResponse> for cbor::Value {
     }
 }
 
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct AuthenticatorCredentialManagementResponse {
     pub existing_resident_credentials_count: Option<u64>,
     pub max_possible_remaining_resident_credentials_count: Option<u64>,
@@ -303,7 +303,7 @@ impl From<AuthenticatorCredentialManagementResponse> for cbor::Value {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AuthenticatorVendorConfigureResponse {
     pub cert_programmed: bool,
     pub pkey_programmed: bool,
@@ -323,7 +323,7 @@ impl From<AuthenticatorVendorConfigureResponse> for cbor::Value {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AuthenticatorVendorUpgradeInfoResponse {
     pub info: u32,
 }


### PR DESCRIPTION
As discussed in #476, if we derive `PartialEq`, we should also have `Eq`.

Additionally, I removed an outdated TODO in `src/ctap/ctap1.rs` that I found.