### PR TITLE
Only derive PartialEq and Eq for PrivateKey for tests

### DIFF
--- a/src/ctap/crypto_wrapper.rs
+++ b/src/ctap/crypto_wrapper.rs
@@ -89,7 +89,9 @@ pub fn aes256_cbc_decrypt(
 }
 
 /// An asymmetric private key that can sign messages.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
+// We shouldn't compare private keys in prod without constant-time operations.
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub enum PrivateKey {
     Ecdsa(ecdsa::SecKey),
 }

--- a/src/ctap/data_formats.rs
+++ b/src/ctap/data_formats.rs
@@ -571,7 +571,8 @@ impl TryFrom<cbor::Value> for CredentialProtectionPolicy {
 //
 // Note that we only use the WebAuthn definition as an example. This data-structure is not specified
 // by FIDO. In particular we may choose how we serialize and deserialize it.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct PublicKeyCredentialSource {
     pub key_type: PublicKeyCredentialType,
     pub credential_id: Vec<u8>,


### PR DESCRIPTION
We shouldn't compare private keys in prod for side-channel resilience.

Ideally we shouldn't clone too. We currently do for storage. Fixing this would probably require to serialize the private key in the credential struct.

This is related to [this discussion](https://github.com/google/OpenSK/pull/478#issuecomment-1129288781).