### PR TITLE
Remove useless dependency after rng256 was split out

### DIFF
--- a/libraries/crypto/Cargo.toml
+++ b/libraries/crypto/Cargo.toml
@@ -10,7 +10,6 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-libtock_drivers = { path = "../../third_party/libtock-drivers" }
 rng256 = { path = "../rng256" }
 arrayref = "0.3.6"
 subtle = { version = "2.2.3", default-features = false, features = ["nightly"] }


### PR DESCRIPTION
This follows #470. The crypto library used to depend on Tock only because of the RNG. Now that this is move to its own crate, that dependency can be removed.