### PR TITLE
Make Storage::read_slice take a mutable slice

### DIFF
--- a/examples/erase_storage.rs
+++ b/examples/erase_storage.rs
@@ -14,8 +14,10 @@
 
 #![no_std]
 
+extern crate alloc;
 extern crate lang_items;
 
+use alloc::vec;
 use core::fmt::Write;
 use ctap2::env::tock::take_storage;
 use libtock_drivers::console::Console;
@@ -28,11 +30,9 @@ libtock_core::stack_size! {0x800}
 fn is_page_erased(storage: &dyn Storage, page: usize) -> bool {
     let index = StorageIndex { page, byte: 0 };
     let length = storage.page_size();
-    storage
-        .read_slice(index, length)
-        .unwrap()
-        .iter()
-        .all(|&x| x == 0xff)
+    let mut content = vec![0; length];
+    storage.read_slice(index, &mut content).unwrap();
+    content.iter().all(|&x| x == 0xff)
 }
 
 fn main() {

--- a/examples/store_latency.rs
+++ b/examples/store_latency.rs
@@ -195,9 +195,9 @@ fn main() {
 
     // Results for nrf52840dk_opensk:
     // StorageConfig { page_size: 4096, num_pages: 20 }
-    // Overwrite    Length      Boot  Compaction   Insert  Remove
-    //        no  50 words   16.2 ms    143.8 ms  18.3 ms  8.4 ms
-    //       yes   1 words  303.8 ms     97.9 ms   9.7 ms  4.7 ms
+    // Overwrite    Length      Boot  Compaction   Insert   Remove
+    //        no  50 words   21.6 ms    149.1 ms  23.3 ms  11.0 ms
+    //       yes   1 words  417.0 ms    103.2 ms  13.2 ms   6.5 ms
 }
 
 fn align(x: &str, n: usize) {

--- a/libraries/persistent_store/src/format.rs
+++ b/libraries/persistent_store/src/format.rs
@@ -883,8 +883,8 @@ impl Header {
     ///
     /// If the user entry has no payload, the `footer` must be set to `None`. Otherwise it should be
     /// the last word of the entry.
-    pub fn check(&self, footer: Option<&[u8]>) -> bool {
-        footer.map_or(0, count_zeros) == self.checksum
+    pub fn check(&self, footer: Option<WordSlice>) -> bool {
+        footer.map_or(0, |x| count_zeros(&x)) == self.checksum
     }
 }
 

--- a/libraries/persistent_store/src/storage.rs
+++ b/libraries/persistent_store/src/storage.rs
@@ -59,8 +59,8 @@ pub trait Storage {
 
     /// Reads a byte slice from the storage.
     ///
-    /// The `index` must designate `length` bytes in the storage.
-    fn read_slice(&self, index: StorageIndex, length: usize) -> StorageResult<&[u8]>;
+    /// The `index` must designate `value.len()` bytes in the storage.
+    fn read_slice(&self, index: StorageIndex, value: &mut [u8]) -> StorageResult<()>;
 
     /// Writes a word slice to the storage.
     ///


### PR DESCRIPTION
As mentioned in [this comment](https://github.com/google/OpenSK/issues/485#issuecomment-1144024122), the `Storage::read_slice` API is too strong because some implementations cannot return a slice. This PR changes the API to take a mutable slice instead. This essentially enables 2 use-cases:
- File-backed storage as mentioned in #485
- Implementations using [`embedded_storage::nor_flash::NorFlash`](https://docs.rs/embedded-storage/0.3.0/embedded_storage/nor_flash/trait.NorFlash.html)