### PR TITLE
Allow read_slice to return a Vec

### DIFF
--- a/examples/store_latency.rs
+++ b/examples/store_latency.rs
@@ -194,10 +194,10 @@ fn main() {
     write_matrix(matrix);
 
     // Results for nrf52840dk_opensk:
-    // StorageConfig { page_size: 4096, num_pages: 20 }
+    // StorageConfig { num_pages: 20 }
     // Overwrite    Length      Boot  Compaction   Insert  Remove
-    //        no  50 words   16.2 ms    143.8 ms  18.3 ms  8.4 ms
-    //       yes   1 words  303.8 ms     97.9 ms   9.7 ms  4.7 ms
+    //        no  50 words   18.6 ms    145.8 ms  21.0 ms  9.8 ms
+    //       yes   1 words  335.8 ms    100.6 ms  11.7 ms  5.7 ms
 }
 
 fn align(x: &str, n: usize) {

--- a/libraries/persistent_store/src/buffer.rs
+++ b/libraries/persistent_store/src/buffer.rs
@@ -18,7 +18,7 @@
 //! actual flash storage. Instead it uses a buffer in memory to represent the storage state.
 
 use crate::{Storage, StorageError, StorageIndex, StorageResult};
-use alloc::borrow::Borrow;
+use alloc::borrow::{Borrow, Cow};
 use alloc::boxed::Box;
 use alloc::vec;
 
@@ -301,8 +301,8 @@ impl Storage for BufferStorage {
         self.options.max_page_erases
     }
 
-    fn read_slice(&self, index: StorageIndex, length: usize) -> StorageResult<&[u8]> {
-        Ok(&self.storage[index.range(length, self)?])
+    fn read_slice(&self, index: StorageIndex, length: usize) -> StorageResult<Cow<[u8]>> {
+        Ok(Cow::Borrowed(&self.storage[index.range(length, self)?]))
     }
 
     fn write_slice(&mut self, index: StorageIndex, value: &[u8]) -> StorageResult<()> {

--- a/libraries/persistent_store/src/storage.rs
+++ b/libraries/persistent_store/src/storage.rs
@@ -14,6 +14,8 @@
 
 //! Flash storage abstraction.
 
+use alloc::borrow::Cow;
+
 /// Represents a byte position in a storage.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct StorageIndex {
@@ -60,7 +62,7 @@ pub trait Storage {
     /// Reads a byte slice from the storage.
     ///
     /// The `index` must designate `length` bytes in the storage.
-    fn read_slice(&self, index: StorageIndex, length: usize) -> StorageResult<&[u8]>;
+    fn read_slice(&self, index: StorageIndex, length: usize) -> StorageResult<Cow<[u8]>>;
 
     /// Writes a word slice to the storage.
     ///

--- a/libraries/persistent_store/src/storage.rs
+++ b/libraries/persistent_store/src/storage.rs
@@ -62,6 +62,9 @@ pub trait Storage {
     /// Reads a byte slice from the storage.
     ///
     /// The `index` must designate `length` bytes in the storage.
+    ///
+    /// Note that we use `Cow` just because it derefs to `[u8]`. We don't really need the fact that
+    /// one can convert it to a `Vec`. In particular we don't do it in the store implementation.
     fn read_slice(&self, index: StorageIndex, length: usize) -> StorageResult<Cow<[u8]>>;
 
     /// Writes a word slice to the storage.

--- a/src/env/tock/storage.rs
+++ b/src/env/tock/storage.rs
@@ -14,6 +14,7 @@
 
 use crate::api::upgrade_storage::helper::{find_slice, is_aligned, ModRange};
 use crate::api::upgrade_storage::UpgradeStorage;
+use alloc::borrow::Cow;
 use alloc::vec::Vec;
 use core::cell::Cell;
 use libtock_core::{callback, syscalls};
@@ -196,9 +197,9 @@ impl Storage for TockStorage {
         self.max_page_erases
     }
 
-    fn read_slice(&self, index: StorageIndex, length: usize) -> StorageResult<&[u8]> {
+    fn read_slice(&self, index: StorageIndex, length: usize) -> StorageResult<Cow<[u8]>> {
         let start = index.range(length, self)?.start;
-        find_slice(&self.storage_locations, start, length)
+        find_slice(&self.storage_locations, start, length).map(Cow::Borrowed)
     }
 
     fn write_slice(&mut self, index: StorageIndex, value: &[u8]) -> StorageResult<()> {


### PR DESCRIPTION
Similar to #486 but takes the opposite approach:
- Memory-mapped storage can continue to return the slice directly
- Storage that require a mutable slice must allocate themselves

This is preferable to #486 because:
- Nordic has similar performance
- File-backed storage is not for embedded so allocating is ok

If we ever need to support `embedded-storage` trait, then we could add an `Option<&mut [u8]>` argument to be used and returned in the `Cow<[u8]>`. This would avoid allocation and copy. But since we don't have this need, we don't do it.