### PR TITLE
Test whether supporting passing an optional mutable buffer to Storage::read_slice has drawbacks (it does)

### DIFF
--- a/examples/erase_storage.rs
+++ b/examples/erase_storage.rs
@@ -29,7 +29,7 @@ fn is_page_erased(storage: &dyn Storage, page: usize) -> bool {
     let index = StorageIndex { page, byte: 0 };
     let length = storage.page_size();
     storage
-        .read_slice(index, length)
+        .read_slice(index, length, None)
         .unwrap()
         .iter()
         .all(|&x| x == 0xff)

--- a/examples/store_latency.rs
+++ b/examples/store_latency.rs
@@ -195,9 +195,9 @@ fn main() {
 
     // Results for nrf52840dk_opensk:
     // StorageConfig { num_pages: 20 }
-    // Overwrite    Length      Boot  Compaction   Insert  Remove
-    //        no  50 words   18.6 ms    145.8 ms  21.0 ms  9.8 ms
-    //       yes   1 words  335.8 ms    100.6 ms  11.7 ms  5.7 ms
+    // Overwrite    Length      Boot  Compaction   Insert   Remove
+    //        no  50 words   20.6 ms    147.1 ms  22.9 ms  10.8 ms
+    //       yes   1 words  351.6 ms    102.3 ms  12.9 ms   6.3 ms
 }
 
 fn align(x: &str, n: usize) {

--- a/examples/store_latency.rs
+++ b/examples/store_latency.rs
@@ -194,10 +194,10 @@ fn main() {
     write_matrix(matrix);
 
     // Results for nrf52840dk_opensk:
-    // StorageConfig { page_size: 4096, num_pages: 20 }
+    // StorageConfig { num_pages: 20 }
     // Overwrite    Length      Boot  Compaction   Insert  Remove
-    //        no  50 words   16.2 ms    143.8 ms  18.3 ms  8.4 ms
-    //       yes   1 words  303.8 ms     97.9 ms   9.7 ms  4.7 ms
+    //        no  50 words   18.6 ms    145.8 ms  21.0 ms  9.8 ms
+    //       yes   1 words  335.8 ms    100.6 ms  11.7 ms  5.7 ms
 }
 
 fn align(x: &str, n: usize) {

--- a/libraries/persistent_store/src/buffer.rs
+++ b/libraries/persistent_store/src/buffer.rs
@@ -18,7 +18,7 @@
 //! actual flash storage. Instead it uses a buffer in memory to represent the storage state.
 
 use crate::{Storage, StorageError, StorageIndex, StorageResult};
-use alloc::borrow::Borrow;
+use alloc::borrow::{Borrow, Cow};
 use alloc::boxed::Box;
 use alloc::vec;
 
@@ -301,8 +301,8 @@ impl Storage for BufferStorage {
         self.options.max_page_erases
     }
 
-    fn read_slice(&self, index: StorageIndex, length: usize) -> StorageResult<&[u8]> {
-        Ok(&self.storage[index.range(length, self)?])
+    fn read_slice(&self, index: StorageIndex, length: usize) -> StorageResult<Cow<[u8]>> {
+        Ok(Cow::Borrowed(&self.storage[index.range(length, self)?]))
     }
 
     fn write_slice(&mut self, index: StorageIndex, value: &[u8]) -> StorageResult<()> {

--- a/libraries/persistent_store/src/storage.rs
+++ b/libraries/persistent_store/src/storage.rs
@@ -14,6 +14,8 @@
 
 //! Flash storage abstraction.
 
+use alloc::borrow::Cow;
+
 /// Represents a byte position in a storage.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct StorageIndex {
@@ -60,7 +62,7 @@ pub trait Storage {
     /// Reads a byte slice from the storage.
     ///
     /// The `index` must designate `length` bytes in the storage.
-    fn read_slice(&self, index: StorageIndex, length: usize) -> StorageResult<&[u8]>;
+    fn read_slice(&self, index: StorageIndex, length: usize) -> StorageResult<Cow<[u8]>>;
 
     /// Writes a word slice to the storage.
     ///

--- a/libraries/persistent_store/src/storage.rs
+++ b/libraries/persistent_store/src/storage.rs
@@ -62,7 +62,12 @@ pub trait Storage {
     /// Reads a byte slice from the storage.
     ///
     /// The `index` must designate `length` bytes in the storage.
-    fn read_slice(&self, index: StorageIndex, length: usize) -> StorageResult<Cow<[u8]>>;
+    fn read_slice<'a>(
+        &'a self,
+        index: StorageIndex,
+        length: usize,
+        buffer: Option<&'a mut [u8]>,
+    ) -> StorageResult<Cow<'a, [u8]>>;
 
     /// Writes a word slice to the storage.
     ///

--- a/libraries/persistent_store/src/store.rs
+++ b/libraries/persistent_store/src/store.rs
@@ -1096,7 +1096,9 @@ impl<S: Storage> Store<S> {
     /// Reads a slice from the physical storage.
     fn storage_read_slice(&self, index: StorageIndex, length: Nat) -> Cow<[u8]> {
         // The only possible failures are if the slice spans multiple pages.
-        self.storage.read_slice(index, length as usize).unwrap()
+        self.storage
+            .read_slice(index, length as usize, None)
+            .unwrap()
     }
 
     /// Writes a slice to the virtual storage.
@@ -1121,7 +1123,7 @@ impl<S: Storage> Store<S> {
     fn storage_write_slice(&mut self, index: StorageIndex, value: &[u8]) -> StoreResult<()> {
         let word_size = self.format.word_size();
         debug_assert!(usize_to_nat(value.len()) % word_size == 0);
-        let slice = self.storage.read_slice(index, value.len())?;
+        let slice = self.storage.read_slice(index, value.len(), None)?;
         // Skip as many words that don't need to be written as possible.
         for start in (0..usize_to_nat(value.len())).step_by(word_size as usize) {
             if is_write_needed(

--- a/src/env/tock/storage.rs
+++ b/src/env/tock/storage.rs
@@ -14,6 +14,7 @@
 
 use crate::api::upgrade_storage::helper::{find_slice, is_aligned, ModRange};
 use crate::api::upgrade_storage::UpgradeStorage;
+use alloc::borrow::Cow;
 use alloc::vec::Vec;
 use core::cell::Cell;
 use libtock_core::{callback, syscalls};
@@ -196,9 +197,9 @@ impl Storage for TockStorage {
         self.max_page_erases
     }
 
-    fn read_slice(&self, index: StorageIndex, length: usize) -> StorageResult<&[u8]> {
+    fn read_slice(&self, index: StorageIndex, length: usize) -> StorageResult<Cow<[u8]>> {
         let start = index.range(length, self)?.start;
-        find_slice(&self.storage_locations, start, length)
+        find_slice(&self.storage_locations, start, length).map(Cow::Borrowed)
     }
 
     fn write_slice(&mut self, index: StorageIndex, value: &[u8]) -> StorageResult<()> {

--- a/src/env/tock/storage.rs
+++ b/src/env/tock/storage.rs
@@ -174,6 +174,11 @@ impl TockStorage {
     fn is_page_aligned(&self, x: usize) -> bool {
         is_aligned(self.page_size, x)
     }
+
+    fn find_slice(&self, index: StorageIndex, length: usize) -> StorageResult<&[u8]> {
+        let start = index.range(length, self)?.start;
+        find_slice(&self.storage_locations, start, length)
+    }
 }
 
 impl Storage for TockStorage {
@@ -197,23 +202,34 @@ impl Storage for TockStorage {
         self.max_page_erases
     }
 
-    fn read_slice(&self, index: StorageIndex, length: usize) -> StorageResult<Cow<[u8]>> {
-        let start = index.range(length, self)?.start;
-        find_slice(&self.storage_locations, start, length).map(Cow::Borrowed)
+    fn read_slice<'a>(
+        &'a self,
+        index: StorageIndex,
+        length: usize,
+        buffer: Option<&'a mut [u8]>,
+    ) -> StorageResult<Cow<'a, [u8]>> {
+        let slice = self.find_slice(index, length)?;
+        match buffer {
+            None => Ok(Cow::Borrowed(slice)),
+            Some(buffer) => {
+                buffer.copy_from_slice(slice);
+                Ok(Cow::Borrowed(slice))
+            }
+        }
     }
 
     fn write_slice(&mut self, index: StorageIndex, value: &[u8]) -> StorageResult<()> {
         if !self.is_word_aligned(index.byte) || !self.is_word_aligned(value.len()) {
             return Err(StorageError::NotAligned);
         }
-        let ptr = self.read_slice(index, value.len())?.as_ptr() as usize;
+        let ptr = self.find_slice(index, value.len())?.as_ptr() as usize;
         write_slice(ptr, value)
     }
 
     fn erase_page(&mut self, page: usize) -> StorageResult<()> {
         let index = StorageIndex { page, byte: 0 };
         let length = self.page_size();
-        let ptr = self.read_slice(index, length)?.as_ptr() as usize;
+        let ptr = self.find_slice(index, length)?.as_ptr() as usize;
         erase_page(ptr, length)
     }
 }


### PR DESCRIPTION
Adds optional buffer on top of `Cow` trick.