### PR TITLE
allows passing in capabilities to CtapHid

### DIFF
--- a/src/ctap/main_hid.rs
+++ b/src/ctap/main_hid.rs
@@ -35,7 +35,13 @@ impl MainHid {
 
     /// Instantiates a HID handler for CTAP1, CTAP2 and Wink.
     pub fn new() -> Self {
-        let hid = CtapHid::new();
+        #[cfg(feature = "with_ctap1")]
+        let capabilities = CtapHid::CAPABILITY_WINK | CtapHid::CAPABILITY_CBOR;
+        #[cfg(not(feature = "with_ctap1"))]
+        let capabilities =
+            CtapHid::CAPABILITY_WINK | CtapHid::CAPABILITY_CBOR | CtapHid::CAPABILITY_NMSG;
+
+        let hid = CtapHid::new(capabilities);
         let wink_permission = TimedPermission::waiting();
         MainHid {
             hid,

--- a/src/ctap/vendor_hid.rs
+++ b/src/ctap/vendor_hid.rs
@@ -29,7 +29,7 @@ pub struct VendorHid {
 impl VendorHid {
     /// Instantiates a HID handler for CTAP1, CTAP2 and Wink.
     pub fn new() -> Self {
-        let hid = CtapHid::new();
+        let hid = CtapHid::new(CtapHid::CAPABILITY_CBOR | CtapHid::CAPABILITY_NMSG);
         VendorHid { hid }
     }
 


### PR DESCRIPTION
I noticed that HID capabilities that we report should depend on the usage page. We can now pass the capabilities into the `CtapHid` constructor.