### PR TITLE
Fix libfido in configure

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -46,4 +46,4 @@ rustup install stable
 cargo +stable install elf2tab --version 0.7.0 --root elf2tab/
 
 # Install python dependencies to factory configure OpenSK (crypto, JTAG lockdown)
-pip3 install --user --upgrade colorama tqdm cryptography "fido2>=0.9.1"
+pip3 install --user --upgrade colorama tqdm cryptography "fido2>=1.0.0"

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -61,9 +61,9 @@ def get_opensk_devices(batch_mode):
     if (dev.descriptor.vid, dev.descriptor.pid) == OPENSK_VID_PID:
       if dev.capabilities & hid.CAPABILITY.CBOR:
         if batch_mode:
-          devices.append(ctap2.CTAP2(dev))
+          devices.append(ctap2.Ctap2(dev))
         else:
-          return [ctap2.CTAP2(dev)]
+          return [ctap2.Ctap2(dev)]
   return devices
 
 


### PR DESCRIPTION
As reported [here](https://github.com/google/OpenSK/issues/335#issuecomment-1153642499) by @gelintonx , libfido2 renamed the `CTAP2` devices to `Ctap2`. If configure worked for you before, you only notice this bug when you call:
```
pip install fido2 --upgrade
```

I wonder if we should leave a hint for users who don't have the upgraded libfido2 yet, but pull the latest develop?