### PR TITLE
Adapts libtock drivers for vendor HID

### DIFF
--- a/patches/tock/11-usb-endpoint-receive.patch
+++ b/patches/tock/11-usb-endpoint-receive.patch
@@ -1,0 +1,13 @@
+diff --git a/capsules/src/usb/usb_ctap.rs b/capsules/src/usb/usb_ctap.rs
+index e8f1a87a4..2c1ecf934 100644
+--- a/capsules/src/usb/usb_ctap.rs
++++ b/capsules/src/usb/usb_ctap.rs
+@@ -57,7 +57,7 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> CtapUsbSyscallDriver<'a, 'b, C> {
+                 app.waiting = false;
+                 // Signal to the app that a packet is ready.
+                 app.callback
+-                    .map(|mut cb| cb.schedule(CTAP_CALLBACK_RECEIVED, 0, 0));
++                    .map(|mut cb| cb.schedule(CTAP_CALLBACK_RECEIVED, 1, 0));
+             }
+         }
+     }

--- a/src/env/tock/mod.rs
+++ b/src/env/tock/mod.rs
@@ -128,14 +128,14 @@ fn send_keepalive_up_needed(
         let status =
             usb_ctap_hid::send_or_recv_with_timeout(&mut pkt, timeout, endpoint).flex_unwrap();
         match status {
-            None => {
+            usb_ctap_hid::SendOrRecvStatus::Timeout => {
                 debug_ctap!(env, "Sending a KEEPALIVE packet timed out");
                 // TODO: abort user presence test?
             }
-            Some(usb_ctap_hid::SendOrRecvStatus::Sent) => {
+            usb_ctap_hid::SendOrRecvStatus::Sent => {
                 debug_ctap!(env, "Sent KEEPALIVE packet");
             }
-            Some(usb_ctap_hid::SendOrRecvStatus::Received(received_endpoint)) => {
+            usb_ctap_hid::SendOrRecvStatus::Received(received_endpoint) => {
                 // We only parse one packet, because we only care about CANCEL.
                 let (received_cid, processed_packet) = CtapHid::process_single_packet(&pkt);
                 if received_endpoint != endpoint || received_cid != &cid {

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,6 @@ use embedded_time::duration::Milliseconds;
 use libtock_drivers::buttons::{self, ButtonState};
 #[cfg(feature = "debug_ctap")]
 use libtock_drivers::console::Console;
-#[cfg(feature = "with_ctap1")]
 use libtock_drivers::result::FlexUnwrap;
 use libtock_drivers::timer::Duration;
 use libtock_drivers::usb_ctap_hid;
@@ -89,14 +88,21 @@ fn main() {
         }
 
         let mut pkt_request = [0; 64];
-        let usb_interface =
-            match usb_ctap_hid::recv_with_timeout(&mut pkt_request, KEEPALIVE_DELAY_TOCK) {
-                Some(usb_ctap_hid::SendOrRecvStatus::Received(interface)) => {
+        let usb_endpoint =
+            match usb_ctap_hid::recv_with_timeout(&mut pkt_request, KEEPALIVE_DELAY_TOCK)
+                .flex_unwrap()
+            {
+                Some(usb_ctap_hid::SendOrRecvStatus::Received(endpoint)) => {
                     #[cfg(feature = "debug_ctap")]
                     print_packet_notice("Received packet", &clock);
-                    Some(interface)
+                    Some(endpoint)
                 }
-                Some(_) => panic!("Error receiving packet"),
+                #[cfg(feature = "debug_ctap")]
+                Some(usb_ctap_hid::SendOrRecvStatus::Sent) => {
+                    panic!("Returned transmit status on receive")
+                }
+                #[cfg(not(feature = "debug_ctap"))]
+                Some(usb_ctap_hid::SendOrRecvStatus::Sent) => panic!(),
                 None => None,
             };
 
@@ -120,20 +126,18 @@ fn main() {
         // don't cause problems with timers.
         ctap.update_timeouts(now);
 
-        if let Some(interface) = usb_interface {
-            let transport = match interface {
-                usb_ctap_hid::UsbInterface::MainHid => Transport::MainHid,
+        if let Some(endpoint) = usb_endpoint {
+            let transport = match endpoint {
+                usb_ctap_hid::UsbEndpoint::MainHid => Transport::MainHid,
                 #[cfg(feature = "vendor_hid")]
-                usb_ctap_hid::UsbInterface::VendorHid => Transport::VendorHid,
+                usb_ctap_hid::UsbEndpoint::VendorHid => Transport::VendorHid,
             };
             let reply = ctap.process_hid_packet(&pkt_request, transport, now);
             // This block handles sending packets.
             for mut pkt_reply in reply {
-                let status = usb_ctap_hid::send_or_recv_with_timeout(
-                    &mut pkt_reply,
-                    SEND_TIMEOUT,
-                    interface,
-                );
+                let status =
+                    usb_ctap_hid::send_or_recv_with_timeout(&mut pkt_reply, SEND_TIMEOUT, endpoint)
+                        .flex_unwrap();
                 match status {
                     None => {
                         #[cfg(feature = "debug_ctap")]
@@ -142,7 +146,6 @@ fn main() {
                         // Since sending the packet timed out, we cancel this reply.
                         break;
                     }
-                    Some(usb_ctap_hid::SendOrRecvStatus::Error) => panic!("Error sending packet"),
                     Some(usb_ctap_hid::SendOrRecvStatus::Sent) => {
                         #[cfg(feature = "debug_ctap")]
                         print_packet_notice("Sent packet", &clock);


### PR DESCRIPTION
This PR took inspiration from #490 and #497 to improve our libtock USB drivers. It adds the same functionality as #490, and uses a style that is useful to address comments in #497. This explains my intent better than comments in these PRs could :)

The patch is a dummy to be replaced with the actual kernel logic from #490. It makes packets over `MainHid` get accepted, but `VendorHid` still doesn't work end-to-end.

Instead of returning an `Option<SendOrRecvStatus>`, where `Error` was one variant, we now move to `Result<Option<SendOrRecvStatus>, TockError>`. This distinguishes the error state better from success states, and we can start using the `?` operator.

I renamed all related `interface`s to consistently be called `endpoint`s. If you like `interface` better, let me know.

The `drop` is an explicit way to make sure the return values are not dropped before we can indirectly use them. Until now, that was an implicit property of Rust, but undocumented.