### PR TITLE
Move protocol-specific user presence checking code from Env to CTAP library

### DIFF
--- a/src/api/channel.rs
+++ b/src/api/channel.rs
@@ -1,0 +1,33 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::clock::CtapDuration;
+
+pub enum SendOrRecvStatus {
+    Timeout,
+    Sent,
+    Received,
+}
+
+pub struct SendOrRecvError;
+
+pub type SendOrRecvResult = Result<SendOrRecvStatus, SendOrRecvError>;
+
+pub trait CtapHidChannel {
+    fn send_or_recv_with_timeout(
+        &mut self,
+        buf: &mut [u8; 64],
+        timeout: CtapDuration,
+    ) -> SendOrRecvResult;
+}

--- a/src/api/channel.rs
+++ b/src/api/channel.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::clock::CtapDuration;
+use crate::clock::ClockInt;
+use embedded_time::duration::Milliseconds;
 
 pub enum SendOrRecvStatus {
     Timeout,
@@ -28,6 +29,6 @@ pub trait CtapHidChannel {
     fn send_or_recv_with_timeout(
         &mut self,
         buf: &mut [u8; 64],
-        timeout: CtapDuration,
+        timeout: Milliseconds<ClockInt>,
     ) -> SendOrRecvResult;
 }

--- a/src/api/connection.rs
+++ b/src/api/connection.rs
@@ -25,7 +25,7 @@ pub struct SendOrRecvError;
 
 pub type SendOrRecvResult = Result<SendOrRecvStatus, SendOrRecvError>;
 
-pub trait CtapHidChannel {
+pub trait HidConnection {
     fn send_or_recv_with_timeout(
         &mut self,
         buf: &mut [u8; 64],

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3,6 +3,8 @@
 //! The [environment](crate::env::Env) is split into components. Each component has an API described
 //! by a trait. This module gathers the API of those components.
 
+pub mod channel;
 pub mod customization;
 pub mod firmware_protection;
 pub mod upgrade_storage;
+pub mod user_presence;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3,7 +3,7 @@
 //! The [environment](crate::env::Env) is split into components. Each component has an API described
 //! by a trait. This module gathers the API of those components.
 
-pub mod channel;
+pub mod connection;
 pub mod customization;
 pub mod firmware_protection;
 pub mod upgrade_storage;

--- a/src/api/user_presence.rs
+++ b/src/api/user_presence.rs
@@ -1,0 +1,42 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::clock::CtapDuration;
+use crate::ctap::Channel;
+
+pub enum UserPresenceStatus {
+    Confirmed,
+    Declined,
+    Canceled,
+    Timeout,
+}
+
+pub struct UserPresenceError;
+
+pub type UserPresenceResult = Result<UserPresenceStatus, UserPresenceError>;
+
+pub trait UserPresence {
+    /// Called at the beginning of user presence checking process.
+    fn check_init(&mut self, _channel: Channel);
+
+    /// Implements a wait for user presence confirmation or rejection.
+    fn wait_with_timeout(
+        &mut self,
+        _channel: Channel,
+        _timeout: CtapDuration,
+    ) -> UserPresenceResult;
+
+    /// Called at the end of user presence checking process.
+    fn check_complete(&mut self, _result: &UserPresenceResult);
+}

--- a/src/api/user_presence.rs
+++ b/src/api/user_presence.rs
@@ -16,11 +16,11 @@ use crate::clock::ClockInt;
 use embedded_time::duration::Milliseconds;
 
 pub enum UserPresenceError {
-    // User explicitly declined user presence check.
+    /// User explicitly declined user presence check.
     Declined,
-    // User presence check was canceled by User Agent.
+    /// User presence check was canceled by User Agent.
     Canceled,
-    // User presence check timed out.
+    /// User presence check timed out.
     Timeout,
 }
 
@@ -35,14 +35,6 @@ pub trait UserPresence {
     /// Waits until user presence is confirmed, rejected, or the given timeout expires.
     ///
     /// Must be called between calls to [`Self::check_init`] and [`Self::check_complete`].
-    ///
-    /// # Errors
-    ///
-    /// Returns [`UserPresenceError::Timeout`] if no evidence of user interaction was provided by
-    /// authenticator.
-    /// Returns [`UserPresenceError::Declined`] if user presence was explicitly denied by user.
-    /// Returns [`UserPresenceError::Canceled`] if authenticator receives CANCEL message from User
-    /// Agent during wait for user presence.
     fn wait_with_timeout(&mut self, timeout: Milliseconds<ClockInt>) -> UserPresenceResult;
 
     /// Finalizes a user presence check.

--- a/src/api/user_presence.rs
+++ b/src/api/user_presence.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use crate::clock::ClockInt;
-use crate::ctap::Channel;
 use embedded_time::duration::Milliseconds;
 
 pub enum UserPresenceError {
@@ -44,11 +43,7 @@ pub trait UserPresence {
     /// Returns [`UserPresenceError::Declined`] if user presence was explicitly denied by user.
     /// Returns [`UserPresenceError::Canceled`] if authenticator receives CANCEL message from User
     /// Agent during wait for user presence.
-    fn wait_with_timeout(
-        &mut self,
-        channel: Channel,
-        timeout: Milliseconds<ClockInt>,
-    ) -> UserPresenceResult;
+    fn wait_with_timeout(&mut self, timeout: Milliseconds<ClockInt>) -> UserPresenceResult;
 
     /// Finalizes a user presence check.
     ///

--- a/src/api/user_presence.rs
+++ b/src/api/user_presence.rs
@@ -12,31 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::clock::CtapDuration;
+use crate::clock::ClockInt;
 use crate::ctap::Channel;
+use embedded_time::duration::Milliseconds;
 
-pub enum UserPresenceStatus {
-    Confirmed,
+pub enum UserPresenceError {
     Declined,
     Canceled,
     Timeout,
 }
 
-pub struct UserPresenceError;
-
-pub type UserPresenceResult = Result<UserPresenceStatus, UserPresenceError>;
+pub type UserPresenceResult = Result<(), UserPresenceError>;
 
 pub trait UserPresence {
     /// Called at the beginning of user presence checking process.
-    fn check_init(&mut self, _channel: Channel);
+    fn check_init(&mut self, channel: Channel);
 
     /// Implements a wait for user presence confirmation or rejection.
     fn wait_with_timeout(
         &mut self,
-        _channel: Channel,
-        _timeout: CtapDuration,
+        channel: Channel,
+        timeout: Milliseconds<ClockInt>,
     ) -> UserPresenceResult;
 
     /// Called at the end of user presence checking process.
-    fn check_complete(&mut self, _result: &UserPresenceResult);
+    fn check_complete(&mut self, result: &UserPresenceResult);
 }

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -24,7 +24,7 @@ impl<const CLOCK_FREQUENCY: u32> fmt::Debug for LibtockClock<CLOCK_FREQUENCY> {
     }
 }
 
-const KEEPALIVE_DELAY_MS: ClockInt = 100;
+pub const KEEPALIVE_DELAY_MS: ClockInt = 100;
 pub const KEEPALIVE_DELAY: Milliseconds<ClockInt> = Milliseconds(KEEPALIVE_DELAY_MS);
 
 #[cfg(target_pointer_width = "32")]
@@ -57,6 +57,7 @@ pub fn new_clock() -> CtapClock {
 }
 
 pub type CtapInstant = embedded_time::Instant<CtapClock>;
+pub type CtapDuration = Milliseconds<ClockInt>;
 
 #[cfg(feature = "std")]
 pub const TEST_CLOCK_FREQUENCY_HZ: u32 = 32768;

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -57,7 +57,6 @@ pub fn new_clock() -> CtapClock {
 }
 
 pub type CtapInstant = embedded_time::Instant<CtapClock>;
-pub type CtapDuration = Milliseconds<ClockInt>;
 
 #[cfg(feature = "std")]
 pub const TEST_CLOCK_FREQUENCY_HZ: u32 = 32768;

--- a/src/ctap/ctap1.rs
+++ b/src/ctap/ctap1.rs
@@ -393,7 +393,7 @@ mod test {
     fn test_process_allowed() {
         let mut env = TestEnv::new();
         env.user_presence()
-            .set(|_| panic!("Unexpected user presence check in CTAP1"));
+            .set(|| panic!("Unexpected user presence check in CTAP1"));
         let mut ctap_state = CtapState::new(&mut env, CtapInstant::new(0));
         storage::toggle_always_uv(&mut env).unwrap();
 
@@ -410,7 +410,7 @@ mod test {
     fn test_process_register() {
         let mut env = TestEnv::new();
         env.user_presence()
-            .set(|_| panic!("Unexpected user presence check in CTAP1"));
+            .set(|| panic!("Unexpected user presence check in CTAP1"));
         let mut ctap_state = CtapState::new(&mut env, CtapInstant::new(0));
 
         let application = [0x0A; 32];
@@ -462,7 +462,7 @@ mod test {
     fn test_process_register_bad_message() {
         let mut env = TestEnv::new();
         env.user_presence()
-            .set(|_| panic!("Unexpected user presence check in CTAP1"));
+            .set(|| panic!("Unexpected user presence check in CTAP1"));
         let mut ctap_state = CtapState::new(&mut env, CtapInstant::new(0));
 
         let application = [0x0A; 32];
@@ -484,7 +484,7 @@ mod test {
 
         let mut env = TestEnv::new();
         env.user_presence()
-            .set(|_| panic!("Unexpected user presence check in CTAP1"));
+            .set(|| panic!("Unexpected user presence check in CTAP1"));
         let mut ctap_state = CtapState::new(&mut env, CtapInstant::new(0));
 
         ctap_state.u2f_up_state.consume_up(CtapInstant::new(0));
@@ -500,7 +500,7 @@ mod test {
     fn test_process_authenticate_check_only() {
         let mut env = TestEnv::new();
         env.user_presence()
-            .set(|_| panic!("Unexpected user presence check in CTAP1"));
+            .set(|| panic!("Unexpected user presence check in CTAP1"));
         let sk = PrivateKey::new(env.rng(), SignatureAlgorithm::ES256);
         let mut ctap_state = CtapState::new(&mut env, CtapInstant::new(0));
 
@@ -518,7 +518,7 @@ mod test {
     fn test_process_authenticate_check_only_wrong_rp() {
         let mut env = TestEnv::new();
         env.user_presence()
-            .set(|_| panic!("Unexpected user presence check in CTAP1"));
+            .set(|| panic!("Unexpected user presence check in CTAP1"));
         let sk = PrivateKey::new(env.rng(), SignatureAlgorithm::ES256);
         let mut ctap_state = CtapState::new(&mut env, CtapInstant::new(0));
 
@@ -537,7 +537,7 @@ mod test {
     fn test_process_authenticate_check_only_wrong_length() {
         let mut env = TestEnv::new();
         env.user_presence()
-            .set(|_| panic!("Unexpected user presence check in CTAP1"));
+            .set(|| panic!("Unexpected user presence check in CTAP1"));
         let sk = PrivateKey::new(env.rng(), SignatureAlgorithm::ES256);
         let mut ctap_state = CtapState::new(&mut env, CtapInstant::new(0));
 
@@ -575,7 +575,7 @@ mod test {
     fn test_process_authenticate_check_only_wrong_cla() {
         let mut env = TestEnv::new();
         env.user_presence()
-            .set(|_| panic!("Unexpected user presence check in CTAP1"));
+            .set(|| panic!("Unexpected user presence check in CTAP1"));
         let sk = PrivateKey::new(env.rng(), SignatureAlgorithm::ES256);
         let mut ctap_state = CtapState::new(&mut env, CtapInstant::new(0));
 
@@ -595,7 +595,7 @@ mod test {
     fn test_process_authenticate_check_only_wrong_ins() {
         let mut env = TestEnv::new();
         env.user_presence()
-            .set(|_| panic!("Unexpected user presence check in CTAP1"));
+            .set(|| panic!("Unexpected user presence check in CTAP1"));
         let sk = PrivateKey::new(env.rng(), SignatureAlgorithm::ES256);
         let mut ctap_state = CtapState::new(&mut env, CtapInstant::new(0));
 
@@ -615,7 +615,7 @@ mod test {
     fn test_process_authenticate_check_only_wrong_flags() {
         let mut env = TestEnv::new();
         env.user_presence()
-            .set(|_| panic!("Unexpected user presence check in CTAP1"));
+            .set(|| panic!("Unexpected user presence check in CTAP1"));
         let sk = PrivateKey::new(env.rng(), SignatureAlgorithm::ES256);
         let mut ctap_state = CtapState::new(&mut env, CtapInstant::new(0));
 
@@ -643,7 +643,7 @@ mod test {
     fn test_process_authenticate_enforce() {
         let mut env = TestEnv::new();
         env.user_presence()
-            .set(|_| panic!("Unexpected user presence check in CTAP1"));
+            .set(|| panic!("Unexpected user presence check in CTAP1"));
         let sk = PrivateKey::new(env.rng(), SignatureAlgorithm::ES256);
         let mut ctap_state = CtapState::new(&mut env, CtapInstant::new(0));
 
@@ -671,7 +671,7 @@ mod test {
     fn test_process_authenticate_dont_enforce() {
         let mut env = TestEnv::new();
         env.user_presence()
-            .set(|_| panic!("Unexpected user presence check in CTAP1"));
+            .set(|| panic!("Unexpected user presence check in CTAP1"));
         let sk = PrivateKey::new(env.rng(), SignatureAlgorithm::ES256);
         let mut ctap_state = CtapState::new(&mut env, CtapInstant::new(0));
 
@@ -709,7 +709,7 @@ mod test {
 
         let mut env = TestEnv::new();
         env.user_presence()
-            .set(|_| panic!("Unexpected user presence check in CTAP1"));
+            .set(|| panic!("Unexpected user presence check in CTAP1"));
         let mut ctap_state = CtapState::new(&mut env, CtapInstant::new(0));
 
         ctap_state.u2f_up_state.consume_up(CtapInstant::new(0));
@@ -728,7 +728,7 @@ mod test {
 
         let mut env = TestEnv::new();
         env.user_presence()
-            .set(|_| panic!("Unexpected user presence check in CTAP1"));
+            .set(|| panic!("Unexpected user presence check in CTAP1"));
         let mut ctap_state = CtapState::new(&mut env, CtapInstant::new(0));
 
         ctap_state.u2f_up_state.consume_up(CtapInstant::new(0));

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -322,7 +322,7 @@ fn send_keepalive_up_needed(
 ///
 /// Returns an error in case of timeout, user declining presence request, or keepalive error.
 fn check_user_presence(env: &mut impl Env, channel: Channel) -> Result<(), Ctap2StatusCode> {
-    env.user_presence().check_init(channel);
+    env.user_presence().check_init();
 
     // The timeout is N times the keepalive delay.
     const TIMEOUT_ITERATIONS: usize = TOUCH_TIMEOUT_MS as usize / KEEPALIVE_DELAY_MS as usize;
@@ -355,13 +355,8 @@ fn check_user_presence(env: &mut impl Env, channel: Channel) -> Result<(), Ctap2
         }
     }
 
-    env.user_presence().check_complete(&result);
-    match result {
-        Ok(()) => Ok(()),
-        Err(UserPresenceError::Timeout) => Err(Ctap2StatusCode::CTAP2_ERR_USER_ACTION_TIMEOUT),
-        Err(UserPresenceError::Declined) => Err(Ctap2StatusCode::CTAP2_ERR_OPERATION_DENIED),
-        Err(UserPresenceError::Canceled) => Err(Ctap2StatusCode::CTAP2_ERR_KEEPALIVE_CANCEL),
-    }
+    env.user_presence().check_complete();
+    result.map_err(|e| e.into())
 }
 
 /// Holds data necessary to sign an assertion for a credential.

--- a/src/ctap/status_code.rs
+++ b/src/ctap/status_code.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::api::user_presence::UserPresenceError;
+
 // CTAP specification (version 20190130) section 6.3
 // For now, only the CTAP2 codes are here, the CTAP1 are not included.
 #[allow(non_camel_case_types)]
@@ -80,4 +82,14 @@ pub enum Ctap2StatusCode {
     /// It may be possible that some of those errors are actually internal errors.
     CTAP2_ERR_VENDOR_HARDWARE_FAILURE = 0xF3,
     _CTAP2_ERR_VENDOR_LAST = 0xFF,
+}
+
+impl From<UserPresenceError> for Ctap2StatusCode {
+    fn from(user_presence_error: UserPresenceError) -> Self {
+        match user_presence_error {
+            UserPresenceError::Timeout => Self::CTAP2_ERR_USER_ACTION_TIMEOUT,
+            UserPresenceError::Declined => Self::CTAP2_ERR_OPERATION_DENIED,
+            UserPresenceError::Canceled => Self::CTAP2_ERR_KEEPALIVE_CANCEL,
+        }
+    }
 }

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -1,68 +1,14 @@
+use crate::api::channel::CtapHidChannel;
 use crate::api::customization::Customization;
 use crate::api::firmware_protection::FirmwareProtection;
 use crate::api::upgrade_storage::UpgradeStorage;
-use crate::clock::CtapDuration;
-use crate::ctap::status_code::Ctap2StatusCode;
-use crate::ctap::Channel;
+use crate::api::user_presence::UserPresence;
 use persistent_store::{Storage, Store};
 use rng256::Rng256;
 
 #[cfg(feature = "std")]
 pub mod test;
 pub mod tock;
-
-pub enum SendOrRecvStatus {
-    Timeout,
-    Sent,
-    Received,
-}
-
-pub struct SendOrRecvError;
-
-pub type SendOrRecvResult = Result<SendOrRecvStatus, SendOrRecvError>;
-
-pub trait CtapHidChannel {
-    fn send_or_recv_with_timeout(
-        &mut self,
-        buf: &mut [u8; 64],
-        timeout: CtapDuration,
-    ) -> SendOrRecvResult;
-}
-
-pub enum UserPresenceStatus {
-    Confirmed,
-    Declined,
-    Timeout,
-}
-
-pub type UserPresenceResult = Result<UserPresenceStatus, Ctap2StatusCode>;
-
-pub trait UserPresence {
-    /// Called at the beginning of user presence checking process.
-    fn user_presence_check_init(&mut self, _channel: Channel) {}
-
-    /// Implements a wait for user presence confirmation or rejection.
-    fn wait_for_user_presence_with_timeout(
-        &mut self,
-        _channel: Channel,
-        _timeout: CtapDuration,
-    ) -> UserPresenceResult {
-        Ok(UserPresenceStatus::Confirmed)
-    }
-
-    /// Called at the end of user presence checking process.
-    fn user_presence_check_complete(&mut self, _result: &UserPresenceResult) {}
-
-    /// Short-circuit implementation for fast user presence checking.
-    ///
-    /// Default algorithm for user presence checking waits for user action, while sending keepalive
-    /// packets to the user agent. Implementations may use this function to override this behavior
-    /// and return Some(Result<...>) to pass it immediately to the caller wanting to check user
-    /// presence.
-    fn quick_check(&mut self, _channel: Channel) -> Option<Result<(), Ctap2StatusCode>> {
-        None
-    }
-}
 
 /// Describes what CTAP needs to function.
 pub trait Env {

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -1,4 +1,4 @@
-use crate::api::channel::CtapHidChannel;
+use crate::api::connection::HidConnection;
 use crate::api::customization::Customization;
 use crate::api::firmware_protection::FirmwareProtection;
 use crate::api::upgrade_storage::UpgradeStorage;
@@ -19,7 +19,7 @@ pub trait Env {
     type FirmwareProtection: FirmwareProtection;
     type Write: core::fmt::Write;
     type Customization: Customization;
-    type CtapHidChannel: CtapHidChannel;
+    type HidConnection: HidConnection;
 
     fn rng(&mut self) -> &mut Self::Rng;
     fn user_presence(&mut self) -> &mut Self::UserPresence;
@@ -43,10 +43,10 @@ pub trait Env {
 
     fn customization(&self) -> &Self::Customization;
 
-    /// I/O channel for sending packets implementing CTAP HID protocol.
-    fn main_hid_channel(&mut self) -> &mut Self::CtapHidChannel;
+    /// I/O connection for sending packets implementing CTAP HID protocol.
+    fn main_hid_connection(&mut self) -> &mut Self::HidConnection;
 
-    /// I/O channel for sending packets implementing vendor extensions to CTAP HID protocol.
+    /// I/O connection for sending packets implementing vendor extensions to CTAP HID protocol.
     #[cfg(feature = "vendor_hid")]
-    fn vendor_hid_channel(&mut self) -> &mut Self::CtapHidChannel;
+    fn vendor_hid_connection(&mut self) -> &mut Self::HidConnection;
 }

--- a/src/env/test/mod.rs
+++ b/src/env/test/mod.rs
@@ -119,8 +119,8 @@ impl TestUserPresence {
 }
 
 impl UserPresence for TestUserPresence {
-    fn check(&mut self, channel: Channel) -> Result<(), Ctap2StatusCode> {
-        (self.check)(channel)
+    fn quick_check(&mut self, channel: Channel) -> Option<Result<(), Ctap2StatusCode>> {
+        Some((self.check)(channel))
     }
 }
 

--- a/src/env/test/mod.rs
+++ b/src/env/test/mod.rs
@@ -2,11 +2,12 @@ use self::upgrade_storage::BufferUpgradeStorage;
 use crate::api::channel::{CtapHidChannel, SendOrRecvError, SendOrRecvResult};
 use crate::api::customization::DEFAULT_CUSTOMIZATION;
 use crate::api::firmware_protection::FirmwareProtection;
-use crate::api::user_presence::{UserPresence, UserPresenceResult, UserPresenceStatus};
-use crate::clock::CtapDuration;
+use crate::api::user_presence::{UserPresence, UserPresenceResult};
+use crate::clock::ClockInt;
 use crate::ctap::Channel;
 use crate::env::Env;
 use customization::TestCustomization;
+use embedded_time::duration::Milliseconds;
 use persistent_store::{BufferOptions, BufferStorage, Store};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -72,7 +73,7 @@ impl CtapHidChannel for TestEnv {
     fn send_or_recv_with_timeout(
         &mut self,
         _buf: &mut [u8; 64],
-        _timeout: CtapDuration,
+        _timeout: Milliseconds<ClockInt>,
     ) -> SendOrRecvResult {
         // TODO: Implement I/O from canned requests/responses for integration testing.
         Err(SendOrRecvError)
@@ -85,7 +86,7 @@ impl TestEnv {
             rng: StdRng::seed_from_u64(0),
         };
         let user_presence = TestUserPresence {
-            check: Box::new(|_| Ok(UserPresenceStatus::Confirmed)),
+            check: Box::new(|_| Ok(())),
         };
         let storage = new_storage();
         let store = Store::new(storage).ok().unwrap();
@@ -124,7 +125,7 @@ impl UserPresence for TestUserPresence {
     fn wait_with_timeout(
         &mut self,
         channel: Channel,
-        _timeout: CtapDuration,
+        _timeout: Milliseconds<ClockInt>,
     ) -> UserPresenceResult {
         (self.check)(channel)
     }

--- a/src/env/test/mod.rs
+++ b/src/env/test/mod.rs
@@ -1,5 +1,5 @@
 use self::upgrade_storage::BufferUpgradeStorage;
-use crate::api::channel::{CtapHidChannel, SendOrRecvError, SendOrRecvResult};
+use crate::api::channel::{CtapHidChannel, SendOrRecvResult, SendOrRecvStatus};
 use crate::api::customization::DEFAULT_CUSTOMIZATION;
 use crate::api::firmware_protection::FirmwareProtection;
 use crate::api::user_presence::{UserPresence, UserPresenceResult};
@@ -76,7 +76,7 @@ impl CtapHidChannel for TestEnv {
         _timeout: Milliseconds<ClockInt>,
     ) -> SendOrRecvResult {
         // TODO: Implement I/O from canned requests/responses for integration testing.
-        Err(SendOrRecvError)
+        Ok(SendOrRecvStatus::Sent)
     }
 }
 

--- a/src/env/test/mod.rs
+++ b/src/env/test/mod.rs
@@ -121,7 +121,7 @@ impl TestUserPresence {
 }
 
 impl UserPresence for TestUserPresence {
-    fn check_init(&mut self, _channel: Channel) {}
+    fn check_init(&mut self) {}
     fn wait_with_timeout(
         &mut self,
         channel: Channel,
@@ -129,7 +129,7 @@ impl UserPresence for TestUserPresence {
     ) -> UserPresenceResult {
         (self.check)(channel)
     }
-    fn check_complete(&mut self, _result: &UserPresenceResult) {}
+    fn check_complete(&mut self) {}
 }
 
 impl FirmwareProtection for TestEnv {

--- a/src/env/tock/mod.rs
+++ b/src/env/tock/mod.rs
@@ -2,11 +2,10 @@ pub use self::storage::{TockStorage, TockUpgradeStorage};
 use crate::api::customization::{CustomizationImpl, DEFAULT_CUSTOMIZATION};
 use crate::api::firmware_protection::FirmwareProtection;
 use crate::clock::{CtapDuration, KEEPALIVE_DELAY_MS};
-use crate::ctap::hid::{CtapHid, CtapHidCommand, KeepaliveStatus, ProcessedPacket};
-use crate::ctap::status_code::Ctap2StatusCode;
 use crate::ctap::{Channel, Transport};
 use crate::env::{
     CtapHidChannel, Env, SendOrRecvError, SendOrRecvResult, SendOrRecvStatus, UserPresence,
+    UserPresenceResult, UserPresenceStatus,
 };
 use core::cell::Cell;
 use core::sync::atomic::{AtomicBool, Ordering};
@@ -61,6 +60,7 @@ pub struct TockEnv {
     main_channel: TockCtapHidChannel,
     #[cfg(feature = "vendor_hid")]
     vendor_channel: TockCtapHidChannel,
+    blink_pattern: usize,
 }
 
 impl TockEnv {
@@ -85,6 +85,7 @@ impl TockEnv {
             vendor_channel: TockCtapHidChannel {
                 transport: Transport::VendorHid,
             },
+            blink_pattern: 0,
         }
     }
 }
@@ -102,8 +103,72 @@ pub fn take_storage() -> StorageResult<TockStorage> {
 }
 
 impl UserPresence for TockEnv {
-    fn check(&mut self, channel: Channel) -> Result<(), Ctap2StatusCode> {
-        check_user_presence(self, channel)
+    fn user_presence_check_init(&mut self, _channel: Channel) {
+        self.blink_pattern = 0;
+    }
+    fn wait_for_user_presence_with_timeout(
+        &mut self,
+        _channel: Channel,
+        timeout: CtapDuration,
+    ) -> UserPresenceResult {
+        blink_leds(self.blink_pattern);
+        self.blink_pattern += 1;
+
+        let button_touched = Cell::new(false);
+        let mut buttons_callback = buttons::with_callback(|_button_num, state| {
+            match state {
+                ButtonState::Pressed => button_touched.set(true),
+                ButtonState::Released => (),
+            };
+        });
+        let mut buttons = buttons_callback.init().flex_unwrap();
+        for mut button in &mut buttons {
+            button.enable().flex_unwrap();
+        }
+
+        // Setup a keep-alive callback.
+        let keepalive_expired = Cell::new(false);
+        let mut keepalive_callback = timer::with_callback(|_, _| {
+            keepalive_expired.set(true);
+        });
+        let mut keepalive = keepalive_callback.init().flex_unwrap();
+        let keepalive_alarm = keepalive
+            .set_alarm(timer::Duration::from_ms(timeout.integer() as isize))
+            .flex_unwrap();
+
+        // Wait for a button touch or an alarm.
+        libtock_drivers::util::yieldk_for(|| button_touched.get() || keepalive_expired.get());
+
+        // Cleanup alarm callback.
+        match keepalive.stop_alarm(keepalive_alarm) {
+            Ok(()) => (),
+            Err(TockError::Command(CommandError {
+                return_code: EALREADY,
+                ..
+            })) => assert!(keepalive_expired.get()),
+            Err(_e) => {
+                #[cfg(feature = "debug_ctap")]
+                panic!("Unexpected error when stopping alarm: {:?}", _e);
+                #[cfg(not(feature = "debug_ctap"))]
+                panic!("Unexpected error when stopping alarm: <error is only visible with the debug_ctap feature>");
+            }
+        }
+
+        for mut button in &mut buttons {
+            button.disable().flex_unwrap();
+        }
+
+        if button_touched.get() {
+            Ok(UserPresenceStatus::Confirmed)
+        } else if keepalive_expired.get() {
+            Ok(UserPresenceStatus::Timeout)
+        } else {
+            panic!("Unexpected exit condition");
+        }
+    }
+
+    fn user_presence_check_complete(&mut self, _result: &UserPresenceResult) {
+        switch_off_leds();
     }
 }
 
@@ -168,67 +233,6 @@ impl Env for TockEnv {
     }
 }
 
-// Returns whether the keepalive was sent, or false if cancelled.
-fn send_keepalive_up_needed(
-    env: &mut TockEnv,
-    channel: Channel,
-    timeout: Duration<isize>,
-) -> Result<(), Ctap2StatusCode> {
-    let (endpoint, cid) = match channel {
-        Channel::MainHid(cid) => (usb_ctap_hid::UsbEndpoint::MainHid, cid),
-        #[cfg(feature = "vendor_hid")]
-        Channel::VendorHid(cid) => (usb_ctap_hid::UsbEndpoint::VendorHid, cid),
-    };
-    let keepalive_msg = CtapHid::keepalive(cid, KeepaliveStatus::UpNeeded);
-    for mut pkt in keepalive_msg {
-        let status =
-            usb_ctap_hid::send_or_recv_with_timeout(&mut pkt, timeout, endpoint).flex_unwrap();
-        match status {
-            usb_ctap_hid::SendOrRecvStatus::Timeout => {
-                debug_ctap!(env, "Sending a KEEPALIVE packet timed out");
-                // TODO: abort user presence test?
-            }
-            usb_ctap_hid::SendOrRecvStatus::Sent => {
-                debug_ctap!(env, "Sent KEEPALIVE packet");
-            }
-            usb_ctap_hid::SendOrRecvStatus::Received(received_endpoint) => {
-                // We only parse one packet, because we only care about CANCEL.
-                let (received_cid, processed_packet) = CtapHid::process_single_packet(&pkt);
-                if received_endpoint != endpoint || received_cid != &cid {
-                    debug_ctap!(
-                        env,
-                        "Received a packet on channel ID {:?} while sending a KEEPALIVE packet",
-                        received_cid,
-                    );
-                    return Ok(());
-                }
-                match processed_packet {
-                    ProcessedPacket::InitPacket { cmd, .. } => {
-                        if cmd == CtapHidCommand::Cancel as u8 {
-                            // We ignore the payload, we can't answer with an error code anyway.
-                            debug_ctap!(env, "User presence check cancelled");
-                            return Err(Ctap2StatusCode::CTAP2_ERR_KEEPALIVE_CANCEL);
-                        } else {
-                            debug_ctap!(
-                                env,
-                                "Discarded packet with command {} received while sending a KEEPALIVE packet",
-                                cmd,
-                            );
-                        }
-                    }
-                    ProcessedPacket::ContinuationPacket { .. } => {
-                        debug_ctap!(
-                            env,
-                            "Discarded continuation packet received while sending a KEEPALIVE packet",
-                        );
-                    }
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 pub fn blink_leds(pattern_seed: usize) {
     for l in 0..led::count().flex_unwrap() {
         if (pattern_seed ^ l).count_ones() & 1 != 0 {
@@ -279,84 +283,3 @@ pub fn switch_off_leds() {
 }
 
 pub const KEEPALIVE_DELAY_TOCK: Duration<isize> = Duration::from_ms(KEEPALIVE_DELAY_MS as isize);
-
-fn check_user_presence(env: &mut TockEnv, channel: Channel) -> Result<(), Ctap2StatusCode> {
-    // The timeout is N times the keepalive delay.
-    const TIMEOUT_ITERATIONS: usize =
-        crate::ctap::TOUCH_TIMEOUT_MS as usize / KEEPALIVE_DELAY_MS as usize;
-
-    // First, send a keep-alive packet to notify that the keep-alive status has changed.
-    send_keepalive_up_needed(env, channel, KEEPALIVE_DELAY_TOCK)?;
-
-    // Listen to the button presses.
-    let button_touched = Cell::new(false);
-    let mut buttons_callback = buttons::with_callback(|_button_num, state| {
-        match state {
-            ButtonState::Pressed => button_touched.set(true),
-            ButtonState::Released => (),
-        };
-    });
-    let mut buttons = buttons_callback.init().flex_unwrap();
-    // At the moment, all buttons are accepted. You can customize your setup here.
-    for mut button in &mut buttons {
-        button.enable().flex_unwrap();
-    }
-
-    let mut keepalive_response = Ok(());
-    for i in 0..TIMEOUT_ITERATIONS {
-        blink_leds(i);
-
-        // Setup a keep-alive callback.
-        let keepalive_expired = Cell::new(false);
-        let mut keepalive_callback = timer::with_callback(|_, _| {
-            keepalive_expired.set(true);
-        });
-        let mut keepalive = keepalive_callback.init().flex_unwrap();
-        let keepalive_alarm = keepalive.set_alarm(KEEPALIVE_DELAY_TOCK).flex_unwrap();
-
-        // Wait for a button touch or an alarm.
-        libtock_drivers::util::yieldk_for(|| button_touched.get() || keepalive_expired.get());
-
-        // Cleanup alarm callback.
-        match keepalive.stop_alarm(keepalive_alarm) {
-            Ok(()) => (),
-            Err(TockError::Command(CommandError {
-                return_code: EALREADY,
-                ..
-            })) => assert!(keepalive_expired.get()),
-            Err(_e) => {
-                #[cfg(feature = "debug_ctap")]
-                panic!("Unexpected error when stopping alarm: {:?}", _e);
-                #[cfg(not(feature = "debug_ctap"))]
-                panic!("Unexpected error when stopping alarm: <error is only visible with the debug_ctap feature>");
-            }
-        }
-
-        // TODO: this may take arbitrary time. The keepalive_delay should be adjusted accordingly,
-        // so that LEDs blink with a consistent pattern.
-        if keepalive_expired.get() {
-            // Do not return immediately, because we must clean up still.
-            keepalive_response = send_keepalive_up_needed(env, channel, KEEPALIVE_DELAY_TOCK);
-        }
-
-        if button_touched.get() || keepalive_response.is_err() {
-            break;
-        }
-    }
-
-    switch_off_leds();
-
-    // Cleanup button callbacks.
-    for mut button in &mut buttons {
-        button.disable().flex_unwrap();
-    }
-
-    // Returns whether the user was present.
-    if keepalive_response.is_err() {
-        keepalive_response
-    } else if button_touched.get() {
-        Ok(())
-    } else {
-        Err(Ctap2StatusCode::CTAP2_ERR_USER_ACTION_TIMEOUT)
-    }
-}

--- a/src/env/tock/mod.rs
+++ b/src/env/tock/mod.rs
@@ -128,7 +128,7 @@ impl UserPresence for TockEnv {
         let immediate_check = timeout.integer() == 0;
         let keepalive_expired = Cell::new(immediate_check);
         // Setup a keep-alive callback.
-        if ! immediate_check {
+        if !immediate_check {
             let mut keepalive_callback = timer::with_callback(|_, _| {
                 keepalive_expired.set(true);
             });

--- a/src/env/tock/mod.rs
+++ b/src/env/tock/mod.rs
@@ -1,6 +1,7 @@
 pub use self::storage::{TockStorage, TockUpgradeStorage};
 use crate::api::customization::{CustomizationImpl, DEFAULT_CUSTOMIZATION};
 use crate::api::firmware_protection::FirmwareProtection;
+use crate::clock::KEEPALIVE_DELAY_MS;
 use crate::ctap::hid::{CtapHid, CtapHidCommand, KeepaliveStatus, ProcessedPacket};
 use crate::ctap::status_code::Ctap2StatusCode;
 use crate::ctap::Channel;
@@ -222,8 +223,7 @@ pub fn switch_off_leds() {
     }
 }
 
-const KEEPALIVE_DELAY_MS: isize = 100;
-pub const KEEPALIVE_DELAY_TOCK: Duration<isize> = Duration::from_ms(KEEPALIVE_DELAY_MS);
+pub const KEEPALIVE_DELAY_TOCK: Duration<isize> = Duration::from_ms(KEEPALIVE_DELAY_MS as isize);
 
 fn check_user_presence(env: &mut TockEnv, channel: Channel) -> Result<(), Ctap2StatusCode> {
     // The timeout is N times the keepalive delay.

--- a/src/env/tock/mod.rs
+++ b/src/env/tock/mod.rs
@@ -1,12 +1,11 @@
 pub use self::storage::{TockStorage, TockUpgradeStorage};
+use crate::api::channel::{CtapHidChannel, SendOrRecvError, SendOrRecvResult, SendOrRecvStatus};
 use crate::api::customization::{CustomizationImpl, DEFAULT_CUSTOMIZATION};
 use crate::api::firmware_protection::FirmwareProtection;
+use crate::api::user_presence::{UserPresence, UserPresenceResult, UserPresenceStatus};
 use crate::clock::{CtapDuration, KEEPALIVE_DELAY_MS};
 use crate::ctap::{Channel, Transport};
-use crate::env::{
-    CtapHidChannel, Env, SendOrRecvError, SendOrRecvResult, SendOrRecvStatus, UserPresence,
-    UserPresenceResult, UserPresenceStatus,
-};
+use crate::env::Env;
 use core::cell::Cell;
 use core::sync::atomic::{AtomicBool, Ordering};
 use embedded_time::fixed_point::FixedPoint;
@@ -103,10 +102,10 @@ pub fn take_storage() -> StorageResult<TockStorage> {
 }
 
 impl UserPresence for TockEnv {
-    fn user_presence_check_init(&mut self, _channel: Channel) {
+    fn check_init(&mut self, _channel: Channel) {
         self.blink_pattern = 0;
     }
-    fn wait_for_user_presence_with_timeout(
+    fn wait_with_timeout(
         &mut self,
         _channel: Channel,
         timeout: CtapDuration,
@@ -167,7 +166,7 @@ impl UserPresence for TockEnv {
         }
     }
 
-    fn user_presence_check_complete(&mut self, _result: &UserPresenceResult) {
+    fn check_complete(&mut self, _result: &UserPresenceResult) {
         switch_off_leds();
     }
 }

--- a/src/env/tock/mod.rs
+++ b/src/env/tock/mod.rs
@@ -99,7 +99,7 @@ pub fn take_storage() -> StorageResult<TockStorage> {
 }
 
 impl UserPresence for TockEnv {
-    fn check_init(&mut self, _channel: Channel) {
+    fn check_init(&mut self) {
         self.blink_pattern = 0;
     }
     fn wait_with_timeout(
@@ -107,6 +107,9 @@ impl UserPresence for TockEnv {
         _channel: Channel,
         timeout: Milliseconds<ClockInt>,
     ) -> UserPresenceResult {
+        if timeout.integer() == 0 {
+            return Err(UserPresenceError::Timeout);
+        }
         blink_leds(self.blink_pattern);
         self.blink_pattern += 1;
 
@@ -122,34 +125,31 @@ impl UserPresence for TockEnv {
             button.enable().flex_unwrap();
         }
 
-        let immediate_check = timeout.integer() == 0;
-        let keepalive_expired = Cell::new(immediate_check);
         // Setup a keep-alive callback.
-        if !immediate_check {
-            let mut keepalive_callback = timer::with_callback(|_, _| {
-                keepalive_expired.set(true);
-            });
-            let mut keepalive = keepalive_callback.init().flex_unwrap();
-            let keepalive_alarm = keepalive
-                .set_alarm(timer::Duration::from_ms(timeout.integer() as isize))
-                .flex_unwrap();
+        let keepalive_expired = Cell::new(false);
+        let mut keepalive_callback = timer::with_callback(|_, _| {
+            keepalive_expired.set(true);
+        });
+        let mut keepalive = keepalive_callback.init().flex_unwrap();
+        let keepalive_alarm = keepalive
+            .set_alarm(timer::Duration::from_ms(timeout.integer() as isize))
+            .flex_unwrap();
 
-            // Wait for a button touch or an alarm.
-            libtock_drivers::util::yieldk_for(|| button_touched.get() || keepalive_expired.get());
+        // Wait for a button touch or an alarm.
+        libtock_drivers::util::yieldk_for(|| button_touched.get() || keepalive_expired.get());
 
-            // Cleanup alarm callback.
-            match keepalive.stop_alarm(keepalive_alarm) {
-                Ok(()) => (),
-                Err(TockError::Command(CommandError {
-                    return_code: EALREADY,
-                    ..
-                })) => assert!(keepalive_expired.get()),
-                Err(_e) => {
-                    #[cfg(feature = "debug_ctap")]
-                    panic!("Unexpected error when stopping alarm: {:?}", _e);
-                    #[cfg(not(feature = "debug_ctap"))]
-                    panic!("Unexpected error when stopping alarm: <error is only visible with the debug_ctap feature>");
-                }
+        // Cleanup alarm callback.
+        match keepalive.stop_alarm(keepalive_alarm) {
+            Ok(()) => (),
+            Err(TockError::Command(CommandError {
+                return_code: EALREADY,
+                ..
+            })) => assert!(keepalive_expired.get()),
+            Err(_e) => {
+                #[cfg(feature = "debug_ctap")]
+                panic!("Unexpected error when stopping alarm: {:?}", _e);
+                #[cfg(not(feature = "debug_ctap"))]
+                panic!("Unexpected error when stopping alarm: <error is only visible with the debug_ctap feature>");
             }
         }
 
@@ -166,7 +166,7 @@ impl UserPresence for TockEnv {
         }
     }
 
-    fn check_complete(&mut self, _result: &UserPresenceResult) {
+    fn check_complete(&mut self) {
         switch_off_leds();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,4 +118,13 @@ impl<E: Env> Ctap<E> {
         self.state.update_timeouts(now);
         self.hid.update_wink_timeout(now);
     }
+
+    pub fn main_hid_channel(&mut self) -> &mut E::CtapHidChannel {
+        self.env.main_hid_channel()
+    }
+
+    #[cfg(feature = "vendor_hid")]
+    pub fn vendor_hid_channel(&mut self) -> &mut E::CtapHidChannel {
+        self.env.vendor_hid_channel()
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@ impl<E: Env> Ctap<E> {
         &mut self.hid
     }
 
-    #[cfg(feature = "std")]
     pub fn env(&mut self) -> &mut E {
         &mut self.env
     }
@@ -117,14 +116,5 @@ impl<E: Env> Ctap<E> {
     pub fn update_timeouts(&mut self, now: CtapInstant) {
         self.state.update_timeouts(now);
         self.hid.update_wink_timeout(now);
-    }
-
-    pub fn main_hid_channel(&mut self) -> &mut E::CtapHidChannel {
-        self.env.main_hid_channel()
-    }
-
-    #[cfg(feature = "vendor_hid")]
-    pub fn vendor_hid_channel(&mut self) -> &mut E::CtapHidChannel {
-        self.env.vendor_hid_channel()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,13 +28,13 @@ use core::convert::TryFrom;
 use core::convert::TryInto;
 #[cfg(feature = "debug_ctap")]
 use core::fmt::Write;
+use ctap2::api::channel::{CtapHidChannel, SendOrRecvStatus};
 #[cfg(feature = "debug_ctap")]
 use ctap2::clock::CtapClock;
 use ctap2::clock::{new_clock, Clock, ClockInt, CtapDuration, KEEPALIVE_DELAY, KEEPALIVE_DELAY_MS};
 #[cfg(feature = "with_ctap1")]
 use ctap2::env::tock::blink_leds;
 use ctap2::env::tock::{switch_off_leds, wink_leds, TockEnv};
-use ctap2::env::{CtapHidChannel, SendOrRecvStatus};
 use ctap2::Transport;
 #[cfg(feature = "debug_ctap")]
 use embedded_time::duration::Microseconds;
@@ -134,11 +134,7 @@ fn main() {
             let reply = ctap.process_hid_packet(&pkt_request, transport, now);
             // This block handles sending packets.
             for mut pkt_reply in reply {
-                let channel = match transport {
-                    Transport::MainHid => ctap.main_hid_channel(),
-                    #[cfg(feature = "vendor_hid")]
-                    Transport::VendorHid => ctap.vendor_hid_channel(),
-                };
+                let channel = transport.hid_channel(ctap.env());
                 match channel.send_or_recv_with_timeout(&mut pkt_reply, SEND_TIMEOUT) {
                     Ok(SendOrRecvStatus::Timeout) => {
                         #[cfg(feature = "debug_ctap")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,10 +30,11 @@ use core::convert::TryInto;
 use core::fmt::Write;
 #[cfg(feature = "debug_ctap")]
 use ctap2::clock::CtapClock;
-use ctap2::clock::{new_clock, Clock, ClockInt, KEEPALIVE_DELAY};
+use ctap2::clock::{new_clock, Clock, ClockInt, CtapDuration, KEEPALIVE_DELAY, KEEPALIVE_DELAY_MS};
 #[cfg(feature = "with_ctap1")]
 use ctap2::env::tock::blink_leds;
-use ctap2::env::tock::{switch_off_leds, wink_leds, TockEnv, KEEPALIVE_DELAY_TOCK};
+use ctap2::env::tock::{switch_off_leds, wink_leds, TockEnv};
+use ctap2::env::{CtapHidChannel, SendOrRecvStatus};
 use ctap2::Transport;
 #[cfg(feature = "debug_ctap")]
 use embedded_time::duration::Microseconds;
@@ -48,7 +49,8 @@ use libtock_drivers::usb_ctap_hid;
 
 libtock_core::stack_size! {0x4000}
 
-const SEND_TIMEOUT: Duration<isize> = Duration::from_ms(1000);
+const SEND_TIMEOUT: CtapDuration = Milliseconds(1000);
+const KEEPALIVE_DELAY_TOCK: Duration<isize> = Duration::from_ms(KEEPALIVE_DELAY_MS as isize);
 
 fn main() {
     let clock = new_clock();
@@ -132,26 +134,29 @@ fn main() {
             let reply = ctap.process_hid_packet(&pkt_request, transport, now);
             // This block handles sending packets.
             for mut pkt_reply in reply {
-                let status =
-                    usb_ctap_hid::send_or_recv_with_timeout(&mut pkt_reply, SEND_TIMEOUT, endpoint)
-                        .flex_unwrap();
-                match status {
-                    usb_ctap_hid::SendOrRecvStatus::Timeout => {
+                let channel = match transport {
+                    Transport::MainHid => ctap.main_hid_channel(),
+                    #[cfg(feature = "vendor_hid")]
+                    Transport::VendorHid => ctap.vendor_hid_channel(),
+                };
+                match channel.send_or_recv_with_timeout(&mut pkt_reply, SEND_TIMEOUT) {
+                    Ok(SendOrRecvStatus::Timeout) => {
                         #[cfg(feature = "debug_ctap")]
                         print_packet_notice("Sending packet timed out", &clock);
                         // TODO: reset the ctap_hid state.
                         // Since sending the packet timed out, we cancel this reply.
                         break;
                     }
-                    usb_ctap_hid::SendOrRecvStatus::Sent => {
+                    Ok(SendOrRecvStatus::Sent) => {
                         #[cfg(feature = "debug_ctap")]
                         print_packet_notice("Sent packet", &clock);
                     }
-                    usb_ctap_hid::SendOrRecvStatus::Received(_) => {
+                    Ok(SendOrRecvStatus::Received) => {
                         #[cfg(feature = "debug_ctap")]
                         print_packet_notice("Received an UNEXPECTED packet", &clock);
                         // TODO: handle this unexpected packet.
                     }
+                    Err(_) => panic!("Error sending packet"),
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ use core::fmt::Write;
 use ctap2::api::channel::{CtapHidChannel, SendOrRecvStatus};
 #[cfg(feature = "debug_ctap")]
 use ctap2::clock::CtapClock;
-use ctap2::clock::{new_clock, Clock, ClockInt, CtapDuration, KEEPALIVE_DELAY, KEEPALIVE_DELAY_MS};
+use ctap2::clock::{new_clock, Clock, ClockInt, KEEPALIVE_DELAY, KEEPALIVE_DELAY_MS};
 #[cfg(feature = "with_ctap1")]
 use ctap2::env::tock::blink_leds;
 use ctap2::env::tock::{switch_off_leds, wink_leds, TockEnv};
@@ -49,7 +49,7 @@ use libtock_drivers::usb_ctap_hid;
 
 libtock_core::stack_size! {0x4000}
 
-const SEND_TIMEOUT: CtapDuration = Milliseconds(1000);
+const SEND_TIMEOUT: Milliseconds<ClockInt> = Milliseconds(1000);
 const KEEPALIVE_DELAY_TOCK: Duration<isize> = Duration::from_ms(KEEPALIVE_DELAY_MS as isize);
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use core::convert::TryFrom;
 use core::convert::TryInto;
 #[cfg(feature = "debug_ctap")]
 use core::fmt::Write;
-use ctap2::api::channel::{CtapHidChannel, SendOrRecvStatus};
+use ctap2::api::connection::{HidConnection, SendOrRecvStatus};
 #[cfg(feature = "debug_ctap")]
 use ctap2::clock::CtapClock;
 use ctap2::clock::{new_clock, Clock, ClockInt, KEEPALIVE_DELAY, KEEPALIVE_DELAY_MS};
@@ -134,8 +134,8 @@ fn main() {
             let reply = ctap.process_hid_packet(&pkt_request, transport, now);
             // This block handles sending packets.
             for mut pkt_reply in reply {
-                let channel = transport.hid_channel(ctap.env());
-                match channel.send_or_recv_with_timeout(&mut pkt_reply, SEND_TIMEOUT) {
+                let hid_connection = transport.hid_connection(ctap.env());
+                match hid_connection.send_or_recv_with_timeout(&mut pkt_reply, SEND_TIMEOUT) {
                     Ok(SendOrRecvStatus::Timeout) => {
                         #[cfg(feature = "debug_ctap")]
                         print_packet_notice("Sending packet timed out", &clock);


### PR DESCRIPTION
Cleaned-up version of #497, part of implementation for #485. Code changes in this PR:
* Add `CtapDuration` type for timeouts in CTAP library
* Add `SendOrRecvStatus` and `SendOrRecvResult` types for results of I/O operations between authenticator and UA
* Add `UserPresenceStatus` and `UserPresenceResult` types for results of user presence checks
* Add main & vendor HID I/O channels to Env, use them for sending data from authenticator to UA
* Move `send_keepalive_up_needed` and `check_user_presence` functions from TockEnv to CTAP library
* Change `UserPresence` trait to provide fine-grained functions for user presence checking, along with `quick_check` function for short-circuiting user presence check for testing purposes