### PR TITLE
Increase CTAP timeouts while debugging enabled

### DIFF
--- a/src/ctap/hid/mod.rs
+++ b/src/ctap/hid/mod.rs
@@ -197,7 +197,10 @@ impl CtapHid {
     pub const CAPABILITY_NMSG: u8 = 0x08;
 
     // TODO: Is this timeout duration specified?
+    #[cfg(not(feature = "debug_ctap"))]
     const TIMEOUT_DURATION: Milliseconds<ClockInt> = Milliseconds(100 as ClockInt);
+    #[cfg(feature = "debug_ctap")]
+    const TIMEOUT_DURATION: Milliseconds<ClockInt> = Milliseconds(1000 as ClockInt);
 
     /// Creates a new CTAP HID packet parser.
     ///


### PR DESCRIPTION
When debugging was enabled, the CTAP parsing often returned CtapHidError::MsgTimeout, from ctap::hid::MessageAssembler::parse_packet().

This PR makes the timeout dramatically longer when debugging is enabled. It is likely this is caused by enabling the vendor_hid interface. When packets are interleaved between these interfaces, the CTAP timeout can be expired quite easily. 