### PR TITLE
Add test script to verify Vendor HID interface

### DIFF
--- a/tools/vendor_hid_test.py
+++ b/tools/vendor_hid_test.py
@@ -1,0 +1,191 @@
+"""These tests verify the functionality of the VendorHID interface."""
+import hid
+import time
+import unittest
+
+_OPENSK_VID = 0x1915
+_OPENSK_PID = 0x521F
+_FIDO_USAGE_PAGE = 0xF1D0
+_VENDOR_USAGE_PAGE = 0xFF00
+_PACKETS = 4
+_PACKET_SIZE = 64
+_SEND_DATA_SIZE = _PACKET_SIZE + 1
+_DEFAULT_CID = bytes([0xFF, 0xFF, 0xFF, 0xFF])
+
+def sleep():
+    time.sleep(.01)
+
+def ping_data_size(packets):
+  return 57 + 59 * (packets - 1)
+
+class HidDevice(object):
+    def __init__(self, device):
+        self.device = device
+        self.dev = None
+        self.cid = None
+        self.rx_packets = []
+        self.create_and_init()
+
+    def __del__(self):
+        if self.dev:
+          self.dev.close()
+
+
+    def create_and_init(self) -> None:
+        self.dev = hid.Device(path=self.device['path'])
+        # Nonce is all zeros, because we don't care.
+        init_packet = [0] + list(_DEFAULT_CID) + [0x86, 0x00, 0x08] + [0x00] * 57
+        if len(init_packet) != _SEND_DATA_SIZE:
+          raise Exception("Expected packet to be %d but was %d" % (_SEND_DATA_SIZE, len(init_packet)))
+        self.dev.write(bytes(init_packet))
+        self.cid = self.dev.read(_PACKET_SIZE, 2000)[15:19]
+        sleep()
+
+    def ping_init(self, packets=1, byte=0x88) -> int:
+        size = ping_data_size(packets)
+        ping_packet = [0] + list(self.cid) + [0x81, size // 256, size % 256] + [byte] * 57
+        if len(ping_packet) != _SEND_DATA_SIZE:
+          raise Exception("Expected packet to be %d but was %d" % (_PACKET_SIZE, len(ping_packet)))
+        r = self.dev.write(bytes(ping_packet))
+        sleep()
+        return r
+
+
+    def ping_continue(self, num, byte=0x88) -> int:
+        continue_packet = [0] + list(self.cid) + [num] + [byte] * 59
+        if len(continue_packet) != _SEND_DATA_SIZE:
+          raise Exception("Expected packet to be %d but was %d" % (_PACKET_SIZE, len(continue_packet)))
+        r = self.dev.write(bytes(continue_packet))
+        sleep()
+        return r
+
+    def read_and_print(self) -> int:
+        d = self.dev.read(_PACKET_SIZE, 2000)
+        self.rx_packets.append(d)
+        sleep()
+        return len(d)
+
+    def get_received_data(self):
+      """This combines the data from the received packets, to match the ping
+      packets sent."""
+      d = b""
+      if len(self.rx_packets) < _PACKETS:
+        raise Exception("Insufficent packets received - want %d, got %d" % (_PACKETS, len(self.rx_packets)))
+      d += self.rx_packets[-_PACKETS][7:]
+      for p in self.rx_packets[-_PACKETS+1:]:
+        d += p[5:]
+      return d
+
+
+def get_devices(usage_page):
+    for device in hid.enumerate(_OPENSK_VID, _OPENSK_PID):
+        if device['usage_page'] == usage_page:
+            yield device
+
+
+class VendorHid(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.fido_hid = cls.get_device(_FIDO_USAGE_PAGE)
+        cls.vendor_hid = cls.get_device(_VENDOR_USAGE_PAGE)
+
+    @classmethod
+    def get_device(cls, usage_page):
+      devices = list(get_devices(usage_page))
+      if len(devices) != 1:
+        raise Exception("Found %d devices" % len(devices))
+      return HidDevice(devices[0])
+
+    def assertReceivedDataMatches(self, device: HidDevice, byte):
+        expected = bytes([byte]*ping_data_size(_PACKETS))
+        self.assertEqual(device.get_received_data(), expected)
+
+    def test_00_init(self):
+        self.assertNotEqual(self.vendor_hid, None)
+        self.assertNotEqual(self.vendor_hid.device, None)
+        self.assertNotEqual(self.vendor_hid.dev, None)
+        self.assertNotEqual(self.vendor_hid.cid, None)
+
+        self.assertNotEqual(self.fido_hid, None)
+        self.assertNotEqual(self.fido_hid.device, None)
+        self.assertNotEqual(self.fido_hid.dev, None)
+        self.assertNotEqual(self.fido_hid.cid, None)
+
+    def test_01_cid(self):
+        self.assertNotEqual(self.vendor_hid.cid, _DEFAULT_CID)
+
+    def _test_ping(self, dev: HidDevice, byte):
+        r = dev.ping_init(_PACKETS, byte)
+        self.assertEqual(r, _SEND_DATA_SIZE)
+        for i in range(_PACKETS - 1):
+            r = dev.ping_continue(i, byte)
+            self.assertEqual(r, _SEND_DATA_SIZE)
+        for _ in range(_PACKETS):
+            r = dev.read_and_print()
+            self.assertEqual(r, _PACKET_SIZE)
+        self.assertReceivedDataMatches(dev, byte)
+
+    def test_02_fido_ping(self):
+      self._test_ping(self.fido_hid, byte=0x11)
+
+    def test_03_vendor_ping(self):
+      self._test_ping(self.vendor_hid, byte=0x22)
+
+    def test_04_interleaved_send_and_receive(self):
+        r = self.fido_hid.ping_init(packets=_PACKETS, byte=0x33)
+        self.assertEqual(r, _SEND_DATA_SIZE)
+        r = self.vendor_hid.ping_init(packets=_PACKETS, byte=0x44)
+        self.assertEqual(r, _SEND_DATA_SIZE)
+        for i in range(_PACKETS - 1):
+            r = self.fido_hid.ping_continue(i, byte=0x33)
+            self.assertEqual(r, _SEND_DATA_SIZE)
+            r = self.vendor_hid.ping_continue(i, byte=0x44)
+            self.assertEqual(r, _SEND_DATA_SIZE)
+        for i in range(_PACKETS):
+            r = self.fido_hid.read_and_print()
+            self.assertEqual(r, _PACKET_SIZE)
+            r = self.vendor_hid.read_and_print()
+            self.assertEqual(r, _PACKET_SIZE)
+        self.assertReceivedDataMatches(self.fido_hid, 0x33)
+        self.assertReceivedDataMatches(self.vendor_hid, 0x44)
+
+    def test_05_interleaved_send_and_batch_receive(self):
+        r = self.fido_hid.ping_init(packets=_PACKETS, byte=0x55)
+        self.assertEqual(r, _SEND_DATA_SIZE)
+        r = self.vendor_hid.ping_init(packets=_PACKETS, byte=0x66)
+        self.assertEqual(r, _SEND_DATA_SIZE)
+        for i in range(_PACKETS - 1):
+            r = self.fido_hid.ping_continue(i, byte=0x55)
+            self.assertEqual(r, _SEND_DATA_SIZE)
+            r = self.vendor_hid.ping_continue(i, byte=0x66)
+            self.assertEqual(r, _SEND_DATA_SIZE)
+        for i in range(_PACKETS):
+            r = self.fido_hid.read_and_print()
+            self.assertEqual(r, _PACKET_SIZE)
+        for i in range(_PACKETS):
+            r = self.vendor_hid.read_and_print()
+            self.assertEqual(r, _PACKET_SIZE)
+        self.assertReceivedDataMatches(self.fido_hid, 0x55)
+        self.assertReceivedDataMatches(self.vendor_hid, 0x66)
+
+    def test_06_batch_send_and_interleaved_receive(self):
+        r = self.fido_hid.ping_init(packets=_PACKETS, byte=0x77)
+        self.assertEqual(r, _SEND_DATA_SIZE)
+        for i in range(_PACKETS - 1):
+            r = self.fido_hid.ping_continue(i, byte=0x77)
+            self.assertEqual(r, _SEND_DATA_SIZE)
+        r = self.vendor_hid.ping_init(packets=_PACKETS, byte=0x88)
+        for i in range(_PACKETS - 1):
+            r = self.vendor_hid.ping_continue(i, byte=0x88)
+            self.assertEqual(r, _SEND_DATA_SIZE)
+        for i in range(_PACKETS):
+            r = self.fido_hid.read_and_print()
+            self.assertEqual(r, _PACKET_SIZE)
+            r = self.vendor_hid.read_and_print()
+            self.assertEqual(r, _PACKET_SIZE)
+        self.assertReceivedDataMatches(self.fido_hid, 0x77)
+        self.assertReceivedDataMatches(self.vendor_hid, 0x88)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/vendor_hid_test.py
+++ b/tools/vendor_hid_test.py
@@ -21,6 +21,15 @@ def ping_data_size(packets):
   return 57 + 59 * (packets - 1)
 
 
+_BYTE_VAL = 0x10
+
+
+def get_byte():
+  global _BYTE_VAL
+  _BYTE_VAL = _BYTE_VAL + 1
+  return _BYTE_VAL
+
+
 class HidDevice(object):
   """Class that helps interact with HID devices."""
 
@@ -141,23 +150,25 @@ class VendorHid(unittest.TestCase):
   def test_03_vendor_ping(self):
     self._test_ping(self.vendor_hid, byte=0x22)
 
-  def _test_interleaved_send_and_receive(self, first_device, second_device):
-    r = first_device.ping_init(packets=_PACKETS, byte=0x33)
+  def _test_interleaved_send_and_receive(self, a: HidDevice, b: HidDevice):
+    byte_a = get_byte()
+    byte_b = get_byte()
+    r = a.ping_init(packets=_PACKETS, byte=byte_a)
     self.assertEqual(r, _SEND_DATA_SIZE)
-    r = second_device.ping_init(packets=_PACKETS, byte=0x44)
+    r = b.ping_init(packets=_PACKETS, byte=byte_b)
     self.assertEqual(r, _SEND_DATA_SIZE)
     for i in range(_PACKETS - 1):
-      r = first_device.ping_continue(i, byte=0x33)
+      r = a.ping_continue(i, byte=byte_a)
       self.assertEqual(r, _SEND_DATA_SIZE)
-      r = second_device.ping_continue(i, byte=0x44)
+      r = b.ping_continue(i, byte=byte_b)
       self.assertEqual(r, _SEND_DATA_SIZE)
     for i in range(_PACKETS):
-      r = first_device.read_and_print()
+      r = a.read_and_print()
       self.assertEqual(r, _PACKET_SIZE)
-      r = second_device.read_and_print()
+      r = b.read_and_print()
       self.assertEqual(r, _PACKET_SIZE)
-    self.assertReceivedDataMatches(first_device, 0x33)
-    self.assertReceivedDataMatches(second_device, 0x44)
+    self.assertReceivedDataMatches(a, byte_a)
+    self.assertReceivedDataMatches(b, byte_b)
 
   def test_04_interleaved_send_and_receive_fido_first(self):
     self._test_interleaved_send_and_receive(self.fido_hid, self.vendor_hid)
@@ -165,54 +176,64 @@ class VendorHid(unittest.TestCase):
   def test_05_interleaved_send_and_receive_vendor_first(self):
     self._test_interleaved_send_and_receive(self.vendor_hid, self.fido_hid)
 
-  def _test_interleaved_send_and_batch_receive(self, first_device, second_device):
-    r = first_device.ping_init(packets=_PACKETS, byte=0x55)
+  def _test_interleaved_send_and_batch_receive(self, a: HidDevice,
+                                               b: HidDevice):
+    byte_a = get_byte()
+    byte_b = get_byte()
+    r = a.ping_init(packets=_PACKETS, byte=byte_a)
     self.assertEqual(r, _SEND_DATA_SIZE)
-    r = second_device.ping_init(packets=_PACKETS, byte=0x66)
+    r = b.ping_init(packets=_PACKETS, byte=byte_b)
     self.assertEqual(r, _SEND_DATA_SIZE)
     for i in range(_PACKETS - 1):
-      r = first_device.ping_continue(i, byte=0x55)
+      r = a.ping_continue(i, byte=byte_a)
       self.assertEqual(r, _SEND_DATA_SIZE)
-      r = second_device.ping_continue(i, byte=0x66)
+      r = b.ping_continue(i, byte=byte_b)
       self.assertEqual(r, _SEND_DATA_SIZE)
     for i in range(_PACKETS):
-      r = first_device.read_and_print()
+      r = a.read_and_print()
       self.assertEqual(r, _PACKET_SIZE)
     for i in range(_PACKETS):
-      r = second_device.read_and_print()
+      r = b.read_and_print()
       self.assertEqual(r, _PACKET_SIZE)
-    self.assertReceivedDataMatches(first_device, 0x55)
-    self.assertReceivedDataMatches(second_device, 0x66)
+    self.assertReceivedDataMatches(a, byte_a)
+    self.assertReceivedDataMatches(b, byte_b)
 
   def test_06_interleaved_send_and_batch_receive_fido_first(self):
-    self._test_interleaved_send_and_batch_receive(self.fido_hid, self.vendor_hid)
+    self._test_interleaved_send_and_batch_receive(self.fido_hid,
+                                                  self.vendor_hid)
 
   def test_07_interleaved_send_and_batch_receive_vendor_first(self):
-    self._test_interleaved_send_and_batch_receive(self.vendor_hid, self.fido_hid)
+    self._test_interleaved_send_and_batch_receive(self.vendor_hid,
+                                                  self.fido_hid)
 
-  def _test_batch_send_and_interleaved_receive(self, first_device, second_device):
-    r = first_device.ping_init(packets=_PACKETS, byte=0x77)
+  def _test_batch_send_and_interleaved_receive(self, a: HidDevice,
+                                               b: HidDevice):
+    byte_a = get_byte()
+    byte_b = get_byte()
+    r = a.ping_init(packets=_PACKETS, byte=byte_a)
     self.assertEqual(r, _SEND_DATA_SIZE)
     for i in range(_PACKETS - 1):
-      r = first_device.ping_continue(i, byte=0x77)
+      r = a.ping_continue(i, byte=byte_a)
       self.assertEqual(r, _SEND_DATA_SIZE)
-    r = second_device.ping_init(packets=_PACKETS, byte=0x88)
+    r = b.ping_init(packets=_PACKETS, byte=byte_b)
     for i in range(_PACKETS - 1):
-      r = second_device.ping_continue(i, byte=0x88)
+      r = b.ping_continue(i, byte=byte_b)
       self.assertEqual(r, _SEND_DATA_SIZE)
     for i in range(_PACKETS):
-      r = first_device.read_and_print()
+      r = a.read_and_print()
       self.assertEqual(r, _PACKET_SIZE)
-      r = second_device.read_and_print()
+      r = b.read_and_print()
       self.assertEqual(r, _PACKET_SIZE)
-    self.assertReceivedDataMatches(first_device, 0x77)
-    self.assertReceivedDataMatches(second_device, 0x88)
+    self.assertReceivedDataMatches(a, byte_a)
+    self.assertReceivedDataMatches(b, byte_b)
 
   def test_08_batch_send_and_interleaved_receive_fido_first(self):
-    self._test_batch_send_and_interleaved_receive(self.fido_hid, self.vendor_hid)
+    self._test_batch_send_and_interleaved_receive(self.fido_hid,
+                                                  self.vendor_hid)
 
   def test_09_batch_send_and_interleaved_receive_vendor_first(self):
-    self._test_batch_send_and_interleaved_receive(self.vendor_hid, self.fido_hid)
+    self._test_batch_send_and_interleaved_receive(self.vendor_hid,
+                                                  self.fido_hid)
 
 
 if __name__ == '__main__':

--- a/tools/vendor_hid_test.py
+++ b/tools/vendor_hid_test.py
@@ -38,12 +38,10 @@ class HidDevice(object):
   def create_and_init(self) -> None:
     self.dev = hid.Device(path=self.device['path'])
     # Nonce is all zeros, because we don't care.
-    init_packet = [0] + list(_DEFAULT_CID) + [0x86, 0x00, 0x08
-                                              ] + [0x00] * 57
+    init_packet = [0] + list(_DEFAULT_CID) + [0x86, 0x00, 0x08] + [0x00] * 57
     if len(init_packet) != _SEND_DATA_SIZE:
       raise Exception(
-          f'Expected packet to be {_SEND_DATA_SIZE} but was {len(init_packet)}'
-      )
+          f'Expected packet to be {_SEND_DATA_SIZE} but was {len(init_packet)}')
     self.dev.write(bytes(init_packet))
     self.cid = self.dev.read(_PACKET_SIZE, 2000)[15:19]
     sleep()
@@ -63,8 +61,7 @@ class HidDevice(object):
     continue_packet = [0] + list(self.cid) + [num] + [byte] * 59
     if len(continue_packet) != _SEND_DATA_SIZE:
       raise Exception(f'Expected packet to be {_SEND_DATA_SIZE} but was '
-                      '{len(continue_packet)}'
-      )
+                      '{len(continue_packet)}')
     r = self.dev.write(bytes(continue_packet))
     sleep()
     return r

--- a/tools/vendor_hid_test.py
+++ b/tools/vendor_hid_test.py
@@ -50,7 +50,6 @@ class HidDevice(object):
   def reset(self) -> None:
     self.rx_packets = []
 
-
   def create_and_init(self) -> None:
     self.dev = hid.Device(path=self.device['path'])
     # Nonce is all zeros, because we don't care.

--- a/tools/vendor_hid_test.py
+++ b/tools/vendor_hid_test.py
@@ -51,11 +51,10 @@ class HidDevice(object):
   def ping_init(self, packets=1, byte=0x88) -> int:
     size = ping_data_size(packets)
     ping_packet = [0] + list(self.cid) + [0x81, size // 256, size % 256
-                                          ] + [byte] * 57
+                                         ] + [byte] * 57
     if len(ping_packet) != _SEND_DATA_SIZE:
       raise Exception(
-          f'Expected packet to be {_SEND_DATA_SIZE} but was {len(ping_packet)}'
-      )
+          f'Expected packet to be {_SEND_DATA_SIZE} but was {len(ping_packet)}')
     r = self.dev.write(bytes(ping_packet))
     sleep()
     return r
@@ -63,9 +62,8 @@ class HidDevice(object):
   def ping_continue(self, num, byte=0x88) -> int:
     continue_packet = [0] + list(self.cid) + [num] + [byte] * 59
     if len(continue_packet) != _SEND_DATA_SIZE:
-      raise Exception(
-          f'Expected packet to be {_SEND_DATA_SIZE} but was '
-          '{len(continue_packet)}'
+      raise Exception(f'Expected packet to be {_SEND_DATA_SIZE} but was '
+                      '{len(continue_packet)}'
       )
     r = self.dev.write(bytes(continue_packet))
     sleep()

--- a/tools/vendor_hid_test.py
+++ b/tools/vendor_hid_test.py
@@ -14,7 +14,8 @@ _DEFAULT_CID = bytes([0xFF, 0xFF, 0xFF, 0xFF])
 
 
 def sleep():
-  time.sleep(.01)
+  #time.sleep(.01)
+  pass
 
 
 def ping_data_size(packets):
@@ -149,6 +150,24 @@ class VendorHid(unittest.TestCase):
 
   def test_03_vendor_ping(self):
     self._test_ping(self.vendor_hid, byte=0x22)
+
+  def _test_send_and_receive(self, a: HidDevice):
+    byte_a = get_byte()
+    r = a.ping_init(packets=_PACKETS, byte=byte_a)
+    self.assertEqual(r, _SEND_DATA_SIZE)
+    for i in range(_PACKETS - 1):
+      r = a.ping_continue(i, byte=byte_a)
+      self.assertEqual(r, _SEND_DATA_SIZE)
+    for i in range(_PACKETS):
+      r = a.read_and_print()
+      self.assertEqual(r, _PACKET_SIZE)
+    self.assertReceivedDataMatches(a, byte_a)
+
+  def test_04_send_and_receive_fido(self):
+    self._test_send_and_receive(self.fido_hid)
+
+  def test_05_send_and_receive_vendor(self):
+    self._test_send_and_receive(self.vendor_hid)
 
   def _test_interleaved_send_and_receive(self, a: HidDevice, b: HidDevice):
     byte_a = get_byte()

--- a/tools/vendor_hid_test.py
+++ b/tools/vendor_hid_test.py
@@ -14,187 +14,193 @@ _DEFAULT_CID = bytes([0xFF, 0xFF, 0xFF, 0xFF])
 
 
 def sleep():
-    time.sleep(.01)
+  time.sleep(.01)
 
 
 def ping_data_size(packets):
-    return 57 + 59 * (packets - 1)
+  return 57 + 59 * (packets - 1)
 
 
 class HidDevice(object):
+  """Class that helps interact with HID devices."""
 
-    def __init__(self, device):
-        self.device = device
-        self.dev = None
-        self.cid = None
-        self.rx_packets = []
-        self.create_and_init()
+  def __init__(self, device):
+    self.device = device
+    self.dev = None
+    self.cid = None
+    self.rx_packets = []
+    self.create_and_init()
 
-    def __del__(self):
-        if self.dev:
-            self.dev.close()
+  def __del__(self):
+    if self.dev:
+      self.dev.close()
 
-    def create_and_init(self) -> None:
-        self.dev = hid.Device(path=self.device['path'])
-        # Nonce is all zeros, because we don't care.
-        init_packet = [0] + list(_DEFAULT_CID) + [0x86, 0x00, 0x08
-                                                  ] + [0x00] * 57
-        if len(init_packet) != _SEND_DATA_SIZE:
-            raise Exception("Expected packet to be %d but was %d" %
-                            (_SEND_DATA_SIZE, len(init_packet)))
-        self.dev.write(bytes(init_packet))
-        self.cid = self.dev.read(_PACKET_SIZE, 2000)[15:19]
-        sleep()
+  def create_and_init(self) -> None:
+    self.dev = hid.Device(path=self.device['path'])
+    # Nonce is all zeros, because we don't care.
+    init_packet = [0] + list(_DEFAULT_CID) + [0x86, 0x00, 0x08
+                                              ] + [0x00] * 57
+    if len(init_packet) != _SEND_DATA_SIZE:
+      raise Exception(
+          f'Expected packet to be {_SEND_DATA_SIZE} but was {len(init_packet)}'
+      )
+    self.dev.write(bytes(init_packet))
+    self.cid = self.dev.read(_PACKET_SIZE, 2000)[15:19]
+    sleep()
 
-    def ping_init(self, packets=1, byte=0x88) -> int:
-        size = ping_data_size(packets)
-        ping_packet = [0] + list(self.cid) + [0x81, size // 256, size % 256
-                                              ] + [byte] * 57
-        if len(ping_packet) != _SEND_DATA_SIZE:
-            raise Exception("Expected packet to be %d but was %d" %
-                            (_PACKET_SIZE, len(ping_packet)))
-        r = self.dev.write(bytes(ping_packet))
-        sleep()
-        return r
+  def ping_init(self, packets=1, byte=0x88) -> int:
+    size = ping_data_size(packets)
+    ping_packet = [0] + list(self.cid) + [0x81, size // 256, size % 256
+                                          ] + [byte] * 57
+    if len(ping_packet) != _SEND_DATA_SIZE:
+      raise Exception(
+          f'Expected packet to be {_SEND_DATA_SIZE} but was {len(ping_packet)}'
+      )
+    r = self.dev.write(bytes(ping_packet))
+    sleep()
+    return r
 
-    def ping_continue(self, num, byte=0x88) -> int:
-        continue_packet = [0] + list(self.cid) + [num] + [byte] * 59
-        if len(continue_packet) != _SEND_DATA_SIZE:
-            raise Exception("Expected packet to be %d but was %d" %
-                            (_PACKET_SIZE, len(continue_packet)))
-        r = self.dev.write(bytes(continue_packet))
-        sleep()
-        return r
+  def ping_continue(self, num, byte=0x88) -> int:
+    continue_packet = [0] + list(self.cid) + [num] + [byte] * 59
+    if len(continue_packet) != _SEND_DATA_SIZE:
+      raise Exception(
+          f'Expected packet to be {_SEND_DATA_SIZE} but was '
+          '{len(continue_packet)}'
+      )
+    r = self.dev.write(bytes(continue_packet))
+    sleep()
+    return r
 
-    def read_and_print(self) -> int:
-        d = self.dev.read(_PACKET_SIZE, 2000)
-        self.rx_packets.append(d)
-        sleep()
-        return len(d)
+  def read_and_print(self) -> int:
+    d = self.dev.read(_PACKET_SIZE, 2000)
+    self.rx_packets.append(d)
+    sleep()
+    return len(d)
 
-    def get_received_data(self):
-        """This combines the data from the received packets, to match the ping
-      packets sent."""
-        d = b""
-        if len(self.rx_packets) < _PACKETS:
-            raise Exception("Insufficent packets received - want %d, got %d" %
-                            (_PACKETS, len(self.rx_packets)))
-        d += self.rx_packets[-_PACKETS][7:]
-        for p in self.rx_packets[-_PACKETS + 1:]:
-            d += p[5:]
-        return d
+  def get_received_data(self):
+    """This combines the data from the received packets, to match the ping
+packets sent."""
+    d = b''
+    if len(self.rx_packets) < _PACKETS:
+      raise Exception(f'Insufficent packets received - want {_PACKETS}'
+                      ', got {len(self.rx_packets)}')
+    d += self.rx_packets[-_PACKETS][7:]
+    for p in self.rx_packets[-_PACKETS + 1:]:
+      d += p[5:]
+    return d
 
 
 def get_devices(usage_page):
-    for device in hid.enumerate(_OPENSK_VID, _OPENSK_PID):
-        if device['usage_page'] == usage_page:
-            yield device
+  for device in hid.enumerate(_OPENSK_VID, _OPENSK_PID):
+    if device['usage_page'] == usage_page:
+      yield device
 
 
 class VendorHid(unittest.TestCase):
+  """Tests for the Vendor HID interface."""
 
-    @classmethod
-    def setUpClass(cls):
-        cls.fido_hid = cls.get_device(_FIDO_USAGE_PAGE)
-        cls.vendor_hid = cls.get_device(_VENDOR_USAGE_PAGE)
+  @classmethod
+  def setUpClass(cls):
+    cls.fido_hid = cls.get_device(_FIDO_USAGE_PAGE)
+    cls.vendor_hid = cls.get_device(_VENDOR_USAGE_PAGE)
 
-    @classmethod
-    def get_device(cls, usage_page):
-        devices = list(get_devices(usage_page))
-        if len(devices) != 1:
-            raise Exception("Found %d devices" % len(devices))
-        return HidDevice(devices[0])
+  @classmethod
+  def get_device(cls, usage_page):
+    devices = list(get_devices(usage_page))
+    if len(devices) != 1:
+      raise Exception(f'Found {len(devices)} devices')
+    return HidDevice(devices[0])
 
-    def assertReceivedDataMatches(self, device: HidDevice, byte):
-        expected = bytes([byte] * ping_data_size(_PACKETS))
-        self.assertEqual(device.get_received_data(), expected)
+  def assertReceivedDataMatches(self, device: HidDevice, byte):
+    expected = bytes([byte] * ping_data_size(_PACKETS))
+    self.assertEqual(device.get_received_data(), expected)
 
-    def test_00_init(self):
-        self.assertNotEqual(self.vendor_hid, None)
-        self.assertNotEqual(self.vendor_hid.device, None)
-        self.assertNotEqual(self.vendor_hid.dev, None)
-        self.assertNotEqual(self.vendor_hid.cid, None)
+  def test_00_init(self):
+    self.assertNotEqual(self.vendor_hid, None)
+    self.assertNotEqual(self.vendor_hid.device, None)
+    self.assertNotEqual(self.vendor_hid.dev, None)
+    self.assertNotEqual(self.vendor_hid.cid, None)
 
-        self.assertNotEqual(self.fido_hid, None)
-        self.assertNotEqual(self.fido_hid.device, None)
-        self.assertNotEqual(self.fido_hid.dev, None)
-        self.assertNotEqual(self.fido_hid.cid, None)
+    self.assertNotEqual(self.fido_hid, None)
+    self.assertNotEqual(self.fido_hid.device, None)
+    self.assertNotEqual(self.fido_hid.dev, None)
+    self.assertNotEqual(self.fido_hid.cid, None)
 
-    def test_01_cid(self):
-        self.assertNotEqual(self.vendor_hid.cid, _DEFAULT_CID)
+  def test_01_cid(self):
+    self.assertNotEqual(self.vendor_hid.cid, _DEFAULT_CID)
 
-    def _test_ping(self, dev: HidDevice, byte):
-        r = dev.ping_init(_PACKETS, byte)
-        self.assertEqual(r, _SEND_DATA_SIZE)
-        for i in range(_PACKETS - 1):
-            r = dev.ping_continue(i, byte)
-            self.assertEqual(r, _SEND_DATA_SIZE)
-        for _ in range(_PACKETS):
-            r = dev.read_and_print()
-            self.assertEqual(r, _PACKET_SIZE)
-        self.assertReceivedDataMatches(dev, byte)
+  def _test_ping(self, dev: HidDevice, byte):
+    r = dev.ping_init(_PACKETS, byte)
+    self.assertEqual(r, _SEND_DATA_SIZE)
+    for i in range(_PACKETS - 1):
+      r = dev.ping_continue(i, byte)
+      self.assertEqual(r, _SEND_DATA_SIZE)
+    for _ in range(_PACKETS):
+      r = dev.read_and_print()
+      self.assertEqual(r, _PACKET_SIZE)
+    self.assertReceivedDataMatches(dev, byte)
 
-    def test_02_fido_ping(self):
-        self._test_ping(self.fido_hid, byte=0x11)
+  def test_02_fido_ping(self):
+    self._test_ping(self.fido_hid, byte=0x11)
 
-    def test_03_vendor_ping(self):
-        self._test_ping(self.vendor_hid, byte=0x22)
+  def test_03_vendor_ping(self):
+    self._test_ping(self.vendor_hid, byte=0x22)
 
-    def test_04_interleaved_send_and_receive(self):
-        r = self.fido_hid.ping_init(packets=_PACKETS, byte=0x33)
-        self.assertEqual(r, _SEND_DATA_SIZE)
-        r = self.vendor_hid.ping_init(packets=_PACKETS, byte=0x44)
-        self.assertEqual(r, _SEND_DATA_SIZE)
-        for i in range(_PACKETS - 1):
-            r = self.fido_hid.ping_continue(i, byte=0x33)
-            self.assertEqual(r, _SEND_DATA_SIZE)
-            r = self.vendor_hid.ping_continue(i, byte=0x44)
-            self.assertEqual(r, _SEND_DATA_SIZE)
-        for i in range(_PACKETS):
-            r = self.fido_hid.read_and_print()
-            self.assertEqual(r, _PACKET_SIZE)
-            r = self.vendor_hid.read_and_print()
-            self.assertEqual(r, _PACKET_SIZE)
-        self.assertReceivedDataMatches(self.fido_hid, 0x33)
-        self.assertReceivedDataMatches(self.vendor_hid, 0x44)
+  def test_04_interleaved_send_and_receive(self):
+    r = self.fido_hid.ping_init(packets=_PACKETS, byte=0x33)
+    self.assertEqual(r, _SEND_DATA_SIZE)
+    r = self.vendor_hid.ping_init(packets=_PACKETS, byte=0x44)
+    self.assertEqual(r, _SEND_DATA_SIZE)
+    for i in range(_PACKETS - 1):
+      r = self.fido_hid.ping_continue(i, byte=0x33)
+      self.assertEqual(r, _SEND_DATA_SIZE)
+      r = self.vendor_hid.ping_continue(i, byte=0x44)
+      self.assertEqual(r, _SEND_DATA_SIZE)
+    for i in range(_PACKETS):
+      r = self.fido_hid.read_and_print()
+      self.assertEqual(r, _PACKET_SIZE)
+      r = self.vendor_hid.read_and_print()
+      self.assertEqual(r, _PACKET_SIZE)
+    self.assertReceivedDataMatches(self.fido_hid, 0x33)
+    self.assertReceivedDataMatches(self.vendor_hid, 0x44)
 
-    def test_05_interleaved_send_and_batch_receive(self):
-        r = self.fido_hid.ping_init(packets=_PACKETS, byte=0x55)
-        self.assertEqual(r, _SEND_DATA_SIZE)
-        r = self.vendor_hid.ping_init(packets=_PACKETS, byte=0x66)
-        self.assertEqual(r, _SEND_DATA_SIZE)
-        for i in range(_PACKETS - 1):
-            r = self.fido_hid.ping_continue(i, byte=0x55)
-            self.assertEqual(r, _SEND_DATA_SIZE)
-            r = self.vendor_hid.ping_continue(i, byte=0x66)
-            self.assertEqual(r, _SEND_DATA_SIZE)
-        for i in range(_PACKETS):
-            r = self.fido_hid.read_and_print()
-            self.assertEqual(r, _PACKET_SIZE)
-        for i in range(_PACKETS):
-            r = self.vendor_hid.read_and_print()
-            self.assertEqual(r, _PACKET_SIZE)
-        self.assertReceivedDataMatches(self.fido_hid, 0x55)
-        self.assertReceivedDataMatches(self.vendor_hid, 0x66)
+  def test_05_interleaved_send_and_batch_receive(self):
+    r = self.fido_hid.ping_init(packets=_PACKETS, byte=0x55)
+    self.assertEqual(r, _SEND_DATA_SIZE)
+    r = self.vendor_hid.ping_init(packets=_PACKETS, byte=0x66)
+    self.assertEqual(r, _SEND_DATA_SIZE)
+    for i in range(_PACKETS - 1):
+      r = self.fido_hid.ping_continue(i, byte=0x55)
+      self.assertEqual(r, _SEND_DATA_SIZE)
+      r = self.vendor_hid.ping_continue(i, byte=0x66)
+      self.assertEqual(r, _SEND_DATA_SIZE)
+    for i in range(_PACKETS):
+      r = self.fido_hid.read_and_print()
+      self.assertEqual(r, _PACKET_SIZE)
+    for i in range(_PACKETS):
+      r = self.vendor_hid.read_and_print()
+      self.assertEqual(r, _PACKET_SIZE)
+    self.assertReceivedDataMatches(self.fido_hid, 0x55)
+    self.assertReceivedDataMatches(self.vendor_hid, 0x66)
 
-    def test_06_batch_send_and_interleaved_receive(self):
-        r = self.fido_hid.ping_init(packets=_PACKETS, byte=0x77)
-        self.assertEqual(r, _SEND_DATA_SIZE)
-        for i in range(_PACKETS - 1):
-            r = self.fido_hid.ping_continue(i, byte=0x77)
-            self.assertEqual(r, _SEND_DATA_SIZE)
-        r = self.vendor_hid.ping_init(packets=_PACKETS, byte=0x88)
-        for i in range(_PACKETS - 1):
-            r = self.vendor_hid.ping_continue(i, byte=0x88)
-            self.assertEqual(r, _SEND_DATA_SIZE)
-        for i in range(_PACKETS):
-            r = self.fido_hid.read_and_print()
-            self.assertEqual(r, _PACKET_SIZE)
-            r = self.vendor_hid.read_and_print()
-            self.assertEqual(r, _PACKET_SIZE)
-        self.assertReceivedDataMatches(self.fido_hid, 0x77)
-        self.assertReceivedDataMatches(self.vendor_hid, 0x88)
+  def test_06_batch_send_and_interleaved_receive(self):
+    r = self.fido_hid.ping_init(packets=_PACKETS, byte=0x77)
+    self.assertEqual(r, _SEND_DATA_SIZE)
+    for i in range(_PACKETS - 1):
+      r = self.fido_hid.ping_continue(i, byte=0x77)
+      self.assertEqual(r, _SEND_DATA_SIZE)
+    r = self.vendor_hid.ping_init(packets=_PACKETS, byte=0x88)
+    for i in range(_PACKETS - 1):
+      r = self.vendor_hid.ping_continue(i, byte=0x88)
+      self.assertEqual(r, _SEND_DATA_SIZE)
+    for i in range(_PACKETS):
+      r = self.fido_hid.read_and_print()
+      self.assertEqual(r, _PACKET_SIZE)
+      r = self.vendor_hid.read_and_print()
+      self.assertEqual(r, _PACKET_SIZE)
+    self.assertReceivedDataMatches(self.fido_hid, 0x77)
+    self.assertReceivedDataMatches(self.vendor_hid, 0x88)
 
 
 if __name__ == '__main__':
-    unittest.main()
+  unittest.main()

--- a/tools/vendor_hid_test.py
+++ b/tools/vendor_hid_test.py
@@ -50,6 +50,7 @@ class HidDevice(object):
   def reset(self) -> None:
     self.rx_packets = []
 
+
   def create_and_init(self) -> None:
     self.dev = hid.Device(path=self.device['path'])
     # Nonce is all zeros, because we don't care.
@@ -93,6 +94,8 @@ packets sent."""
     d += self.rx_packets.pop(0)[7:]
     for p in self.rx_packets:
       d += p[5:]
+    # And clear the packets received to ensure consistency.
+    self.rx_packets = []
     return d
 
 


### PR DESCRIPTION
This script tests the vendor HID interface, ensuring that ping packets can be sent and received. Importantly it also tests this behavior while interleaving sends & receives with the main HID interface.

h/t to @kaczmarczyck for the bulk of this script.