### PR TITLE
Add check command to patches script

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -770,7 +770,7 @@ class OpenSKInstaller:
       info("Nothing to do.")
       return 0
 
-    subprocess.run(["./maintainers/patches", "check"])
+    subprocess.run(["./maintainers/patches", "check"], check=False)
 
     # Compile what needs to be compiled
     board_props = SUPPORTED_BOARDS[self.args.board]

--- a/deploy.py
+++ b/deploy.py
@@ -770,6 +770,8 @@ class OpenSKInstaller:
       info("Nothing to do.")
       return 0
 
+    subprocess.run(["./maintainers/patches", "check"])
+
     # Compile what needs to be compiled
     board_props = SUPPORTED_BOARDS[self.args.board]
     if self.args.tockos:

--- a/deploy.py
+++ b/deploy.py
@@ -770,7 +770,8 @@ class OpenSKInstaller:
       info("Nothing to do.")
       return 0
 
-    subprocess.run(["./maintainers/patches", "check"], check=False)
+    if self.args.check_patches:
+      subprocess.run(["./maintainers/patches", "check"], check=False)
 
     # Compile what needs to be compiled
     board_props = SUPPORTED_BOARDS[self.args.board]
@@ -1106,6 +1107,14 @@ if __name__ == "__main__":
             "curve Ed25519. "
             "Current implementation is not side-channel resilient due to use "
             "of variable-time arithmetic for computations over secret key."),
+  )
+
+  main_parser.add_argument(
+      "--disable-check-patches",
+      action="store_false",
+      default=True,
+      dest="check_patches",
+      help=("Don't check that patches are in sync with their submodules."),
   )
 
   main_parser.set_defaults(features=["with_ctap1"])

--- a/maintainers/patches
+++ b/maintainers/patches
@@ -7,12 +7,12 @@ PROGRAM="$0"
 MODULES=(tock libtock-rs)
 
 success() {
-  echo -e "\e[1;32mDone:\e[m $1"
+  echo -e "\r\e[1;32mDone:\e[m $1"
   exit 0
 }
 
 fail() {
-  echo -e "\e[1;31mError:\e[m $1"
+  echo -e "\r\e[1;31mError:\e[m $1"
   exit 1
 }
 
@@ -34,7 +34,7 @@ get_head() {
 help() {
   local root="$(get_root)"
   cat <<EOF
-Usage: ${PROGRAM} {apply|save}
+Usage: ${PROGRAM} {apply|save|restore|check}
 
   apply       Applies the patches to the submodules regardless of their state.
               As a consequence this can always be called to get to a clean state
@@ -50,6 +50,11 @@ Usage: ${PROGRAM} {apply|save}
               state. As a consequence this can always be called to get to a
               clean state but may result in data loss if there are unsaved
               changes.
+
+  check       Checks whether the submodules and the patches are in sync. This
+              may fail in two cases:
+              - when the patches were updated but not restored/applied, and
+              - when the submodules have been modified but not saved.
 
 Example:
 
@@ -85,6 +90,20 @@ EOF
   exit 0
 }
 
+apply_module() {
+  local root="$1" module="$2" file
+  git checkout -q "${root}"
+  if [[ "${module}" == tock ]]; then
+    cp -a ../../boards .
+    commit '00-boards'
+  fi
+  for file in ../../patches/"${module}"/*; do
+    git apply "${file}"
+    commit "$(basename "${file}" .patch)"
+    echo -n .
+  done
+}
+
 apply() {
   for module in "${MODULES[@]}"; do
     local root="$(get_root "${module}")"
@@ -92,15 +111,7 @@ apply() {
       cd third_party/"${module}"
       git reset -q --hard
       git clean -qfxd
-      git checkout -q "${root}"
-      if [[ "${module}" == tock ]]; then
-        cp -a ../../boards .
-        commit '00-boards'
-      fi
-      for file in ../../patches/"${module}"/*; do
-        git apply "${file}"
-        commit "$(basename "${file}" .patch)"
-      done
+      apply_module "${root}" "${module}"
     )
   done
 }
@@ -119,7 +130,7 @@ save() {
           | sed '/^-- $/,$d' > "../../patches/${module}/${file#*-}"
       done
       git clean -qfxd
-      top="$(get_head)"
+      local top="$(get_head)"
       git checkout -q "${root}"
       if [[ "${module}" == tock ]]; then
         rm -r boards
@@ -131,6 +142,29 @@ save() {
       git reset -q --hard
       git clean -qfxd
       git checkout -q "${top}"
+    )
+  done
+}
+
+check() {
+  # Overwrite the commit function to do nothing.
+  commit() { true; }
+  for module in "${MODULES[@]}"; do
+    local root="$(get_root "${module}")"
+    ( set -e
+      cd third_party/"${module}"
+      git add .
+      git commit --allow-empty -qmx
+      local top="$(get_head)"
+      apply_module "${root}" "${module}"
+      git add .
+      git commit --allow-empty -qmy
+      # We need to cleanup (and not exit) regardless of a diff.
+      local r; if git diff "${top}" --quiet; then r=0; else r=1; fi
+      git checkout -q "${top}"
+      git reset -q HEAD~
+      [[ "${r}" -eq 0 ]] \
+        || fail "The ${module} submodule differs from its patches."
     )
   done
 }
@@ -148,10 +182,14 @@ case $1 in
     success 'Saved the submodules to the patches.'
     ;;
   restore)
-    # Ovewrite the commit function to do nothing.
+    # Overwrite the commit function to do nothing.
     commit() { true; }
     apply
     success 'Restored the submodules.'
+    ;;
+  check)
+    check
+    success 'The submodules and patches are in sync.'
     ;;
   *) fail 'Unexpected argument. Run without argument for help.' ;;
 esac

--- a/maintainers/reproduce_board.sh
+++ b/maintainers/reproduce_board.sh
@@ -20,10 +20,10 @@ echo "========================================" >> reproducible/elf2tab.txt
 echo "Board: $BOARD" >> reproducible/elf2tab.txt
 echo "----------------------------------------" >> reproducible/elf2tab.txt
 
-./deploy.py --verbose-build --board=$BOARD --no-app --programmer=none
+./deploy.py --verbose-build --disable-check-patches --board=$BOARD --no-app --programmer=none
 ./third_party/tock/tools/sha256sum/target/debug/sha256sum third_party/tock/target/thumbv7em-none-eabi/release/$BOARD.bin >> reproducible/binaries.sha256sum
 tar -rvf reproducible/reproduced.tar third_party/tock/target/thumbv7em-none-eabi/release/$BOARD.bin
 
-./deploy.py --verbose-build --board=$BOARD --opensk --programmer=none --elf2tab-output=reproducible/elf2tab.txt
+./deploy.py --verbose-build --disable-check-patches --board=$BOARD --opensk --programmer=none --elf2tab-output=reproducible/elf2tab.txt
 ./third_party/tock/tools/sha256sum/target/debug/sha256sum target/${BOARD}_merged.hex >> reproducible/binaries.sha256sum
 tar -rvf reproducible/reproduced.tar target/${BOARD}_merged.hex


### PR DESCRIPTION
After discussion in https://github.com/google/OpenSK/pull/500#issuecomment-1159240079 we realized that it would be nice to detect when the submodules and patches are not in sync. This PR always prints one of the following line during deploy:
- `Done: The submodules and patches are in sync.` (with green)
- `Error: The tock submodule differs from its patches.` (with red)
- same for libtock

Note that this doesn't prevent compilation because the user might be editing the submodules and it would be inconvenient to force saving the patches to compile.