### PR TITLE
Configure the flash as read-only at boot

### DIFF
--- a/patches/tock/01-persistent-storage.patch
+++ b/patches/tock/01-persistent-storage.patch
@@ -1,5 +1,5 @@
 diff --git a/chips/nrf52/src/nvmc.rs b/chips/nrf52/src/nvmc.rs
-index adbc2a2b5..7594ec867 100644
+index adbc2a2b5..4092cf346 100644
 --- a/chips/nrf52/src/nvmc.rs
 +++ b/chips/nrf52/src/nvmc.rs
 @@ -3,15 +3,19 @@
@@ -68,7 +68,7 @@ index adbc2a2b5..7594ec867 100644
              let word: u32 = (data[i + 0] as u32) << 0
                  | (data[i + 1] as u32) << 8
                  | (data[i + 2] as u32) << 16
-@@ -387,3 +399,236 @@ impl hil::flash::Flash for Nvmc {
+@@ -387,3 +399,237 @@ impl hil::flash::Flash for Nvmc {
          self.erase_page(page_number)
      }
  }
@@ -139,6 +139,7 @@ index adbc2a2b5..7594ec867 100644
 +        apps: Grant<App>,
 +        deferred_caller: &'static DynamicDeferredCall,
 +    ) -> SyscallDriver {
++        nvmc.configure_readonly();
 +        SyscallDriver {
 +            nvmc,
 +            apps,

--- a/patches/tock/09-add-vendor-hid-usb-interface.patch
+++ b/patches/tock/09-add-vendor-hid-usb-interface.patch
@@ -156,7 +156,7 @@ index f7899d8c5..6956523c6 100644
                          hil::usb::CtrlSetupResult::ErrGeneric
                      }
 diff --git a/capsules/src/usb/usbc_ctap_hid.rs b/capsules/src/usb/usbc_ctap_hid.rs
-index 642039120..41d69752c 100644
+index 642039120..adb7fde14 100644
 --- a/capsules/src/usb/usbc_ctap_hid.rs
 +++ b/capsules/src/usb/usbc_ctap_hid.rs
 @@ -44,21 +44,59 @@ static CTAP_REPORT_DESCRIPTOR: &'static [u8] = &[

--- a/patches/tock/10-avoid-app-reentry.patch
+++ b/patches/tock/10-avoid-app-reentry.patch
@@ -1,6 +1,6 @@
 diff --git a/capsules/src/usb/app.rs b/capsules/src/usb/app.rs
 new file mode 100644
-index 000000000..28dff3575
+index 000000000..c2f434f12
 --- /dev/null
 +++ b/capsules/src/usb/app.rs
 @@ -0,0 +1,65 @@
@@ -79,7 +79,7 @@ index 3f3a4f646..cb5e0af97 100644
  pub mod descriptors;
  pub mod usb_ctap;
 diff --git a/capsules/src/usb/usb_ctap.rs b/capsules/src/usb/usb_ctap.rs
-index da3d16d85..3a709aab5 100644
+index da3d16d85..e8f1a87a4 100644
 --- a/capsules/src/usb/usb_ctap.rs
 +++ b/capsules/src/usb/usb_ctap.rs
 @@ -1,7 +1,7 @@
@@ -262,7 +262,7 @@ index da3d16d85..3a709aab5 100644
                                  if !app.waiting {
                                      // The call to receive_packet() collected a pending packet.
 diff --git a/capsules/src/usb/usbc_ctap_hid.rs b/capsules/src/usb/usbc_ctap_hid.rs
-index 41d69752c..cf17d7942 100644
+index adb7fde14..f6762b4b9 100644
 --- a/capsules/src/usb/usbc_ctap_hid.rs
 +++ b/capsules/src/usb/usbc_ctap_hid.rs
 @@ -11,6 +11,7 @@ use super::descriptors::HIDSubordinateDescriptor;


### PR DESCRIPTION
This makes code run faster without having to wait for the first mutable flash operation.