### PR TITLE
Process incoming packets on different interfaces in a round robin fashion.

### DIFF
--- a/patches/tock/12-pending-deadlock.patch
+++ b/patches/tock/12-pending-deadlock.patch
@@ -3,7 +3,7 @@ index 16b80cb10..949388b70 100644
 --- a/capsules/src/usb/usbc_ctap_hid.rs
 +++ b/capsules/src/usb/usbc_ctap_hid.rs
 @@ -120,7 +120,6 @@ struct EndpointState {
- 
+
      tx_packet: OptionalCell<[u8; 64]>,
      pending_in: Cell<bool>,
 -    pending_out: Cell<bool>,
@@ -21,13 +21,13 @@ index 16b80cb10..949388b70 100644
 @@ -142,6 +140,10 @@ impl EndpointState {
  pub struct ClientCtapHID<'a, 'b, C: 'a> {
      client_ctrl: ClientCtrl<'a, 'static, C>,
- 
+
 +    // Is there a pending OUT transaction happening?
 +    pending_out: Cell<bool>,
 +    next_endpoint_index: Cell<usize>,
 +
      endpoints: [EndpointState; NUM_ENDPOINTS],
- 
+
      // Interaction with the client
 @@ -264,6 +266,8 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
                  LANGUAGES,
@@ -40,7 +40,7 @@ index 16b80cb10..949388b70 100644
                  #[cfg(feature = "vendor_hid")]
 @@ -306,12 +310,13 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
      }
- 
+
      pub fn receive_packet(&'a self, app: &mut App) {
 -        for (_, s) in self.endpoints.iter().enumerate() {
 -            if s.pending_out.get() {
@@ -64,12 +64,12 @@ index 16b80cb10..949388b70 100644
              {
 -                assert!(s.pending_out.take());
 +                assert!(self.pending_out.take());
- 
+
                  // Clear any pending packet on the transmitting side.
                  // It's up to the client to handle the received packet and decide if this packet
 @@ -352,6 +357,13 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
                  self.cancel_in_transaction(endpoint);
- 
+
                  self.client.map(|client| client.packet_received(&buf, endpoint, app));
 +                // Update next packet to send.
 +                for (i, ep) in self.endpoints.iter().enumerate() {
@@ -83,7 +83,7 @@ index 16b80cb10..949388b70 100644
                  // Cannot receive now, indicate a delay to the controller.
 @@ -387,8 +399,8 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
      }
- 
+
      fn cancel_out_transaction(&'a self, endpoint: usize) -> bool {
 -        if let Some(s) = self.get_endpoint(endpoint) {
 -            s.pending_out.take()

--- a/patches/tock/12-pending-deadlock.patch
+++ b/patches/tock/12-pending-deadlock.patch
@@ -1,5 +1,5 @@
 diff --git a/capsules/src/usb/usbc_ctap_hid.rs b/capsules/src/usb/usbc_ctap_hid.rs
-index 16b80cb10..2876074e1 100644
+index 16b80cb10..2b19519e4 100644
 --- a/capsules/src/usb/usbc_ctap_hid.rs
 +++ b/capsules/src/usb/usbc_ctap_hid.rs
 @@ -120,7 +120,6 @@ struct EndpointState {
@@ -38,7 +38,7 @@ index 16b80cb10..2876074e1 100644
              endpoints: [
                  EndpointState::new(ENDPOINT_NUM),
                  #[cfg(feature = "vendor_hid")]
-@@ -306,16 +310,20 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
+@@ -306,12 +310,13 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
      }
 
      pub fn receive_packet(&'a self, app: &mut App) {
@@ -53,19 +53,12 @@ index 16b80cb10..2876074e1 100644
 +        } else {
 +            self.pending_out.set(true);
 +            // Process the next endpoint that has a delayed packet.
-+            // TODO(liamjm): Determine if a round-robin approach reduces latency
-+            // in the worst case.
 +            for i in self.next_endpoint_index.get()..self.next_endpoint_index.get()+NUM_ENDPOINTS {
 +                let s = &self.endpoints[i % NUM_ENDPOINTS];
                  // In case we reported Delay before, send the pending packet back to the client.
                  // Otherwise, there's nothing to do, the controller will send us a packet_out when a
                  // packet arrives.
-                 if s.delayed_out.take() {
-+                    self.next_endpoint_index.set((i + 1) % NUM_ENDPOINTS);
-                     if self.send_packet_to_client(s.endpoint, Some(app)) {
-                         // If that succeeds, alert the controller that we can now
-                         // receive data on the Interrupt OUT endpoint.
-@@ -344,7 +352,7 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
+@@ -344,7 +349,7 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
                  .client
                  .map_or(false, |client| client.can_receive_packet(&app))
              {
@@ -74,7 +67,21 @@ index 16b80cb10..2876074e1 100644
 
                  // Clear any pending packet on the transmitting side.
                  // It's up to the client to handle the received packet and decide if this packet
-@@ -387,8 +395,8 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
+@@ -352,6 +357,13 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
+                 self.cancel_in_transaction(endpoint);
+ 
+                 self.client.map(|client| client.packet_received(&buf, endpoint, app));
++                // Update next packet to send.
++                for (i, ep) in self.endpoints.iter().enumerate() {
++                  if ep.endpoint == endpoint {
++                    self.next_endpoint_index.set((i + 1) % NUM_ENDPOINTS);
++                    break
++                  }
++                }
+                 true
+             } else {
+                 // Cannot receive now, indicate a delay to the controller.
+@@ -387,8 +399,8 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
      }
 
      fn cancel_out_transaction(&'a self, endpoint: usize) -> bool {

--- a/patches/tock/12-pending-deadlock.patch
+++ b/patches/tock/12-pending-deadlock.patch
@@ -1,9 +1,9 @@
 diff --git a/capsules/src/usb/usbc_ctap_hid.rs b/capsules/src/usb/usbc_ctap_hid.rs
-index 16b80cb10..2b19519e4 100644
+index 16b80cb10..949388b70 100644
 --- a/capsules/src/usb/usbc_ctap_hid.rs
 +++ b/capsules/src/usb/usbc_ctap_hid.rs
 @@ -120,7 +120,6 @@ struct EndpointState {
-
+ 
      tx_packet: OptionalCell<[u8; 64]>,
      pending_in: Cell<bool>,
 -    pending_out: Cell<bool>,
@@ -21,13 +21,13 @@ index 16b80cb10..2b19519e4 100644
 @@ -142,6 +140,10 @@ impl EndpointState {
  pub struct ClientCtapHID<'a, 'b, C: 'a> {
      client_ctrl: ClientCtrl<'a, 'static, C>,
-
+ 
 +    // Is there a pending OUT transaction happening?
 +    pending_out: Cell<bool>,
 +    next_endpoint_index: Cell<usize>,
 +
      endpoints: [EndpointState; NUM_ENDPOINTS],
-
+ 
      // Interaction with the client
 @@ -264,6 +266,8 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
                  LANGUAGES,
@@ -40,7 +40,7 @@ index 16b80cb10..2b19519e4 100644
                  #[cfg(feature = "vendor_hid")]
 @@ -306,12 +310,13 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
      }
-
+ 
      pub fn receive_packet(&'a self, app: &mut App) {
 -        for (_, s) in self.endpoints.iter().enumerate() {
 -            if s.pending_out.get() {
@@ -53,7 +53,7 @@ index 16b80cb10..2b19519e4 100644
 +        } else {
 +            self.pending_out.set(true);
 +            // Process the next endpoint that has a delayed packet.
-+            for i in self.next_endpoint_index.get()..self.next_endpoint_index.get()+NUM_ENDPOINTS {
++            for i in self.next_endpoint_index.get()..self.next_endpoint_index.get() + NUM_ENDPOINTS {
 +                let s = &self.endpoints[i % NUM_ENDPOINTS];
                  // In case we reported Delay before, send the pending packet back to the client.
                  // Otherwise, there's nothing to do, the controller will send us a packet_out when a
@@ -64,7 +64,7 @@ index 16b80cb10..2b19519e4 100644
              {
 -                assert!(s.pending_out.take());
 +                assert!(self.pending_out.take());
-
+ 
                  // Clear any pending packet on the transmitting side.
                  // It's up to the client to handle the received packet and decide if this packet
 @@ -352,6 +357,13 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
@@ -73,17 +73,17 @@ index 16b80cb10..2b19519e4 100644
                  self.client.map(|client| client.packet_received(&buf, endpoint, app));
 +                // Update next packet to send.
 +                for (i, ep) in self.endpoints.iter().enumerate() {
-+                  if ep.endpoint == endpoint {
-+                    self.next_endpoint_index.set((i + 1) % NUM_ENDPOINTS);
-+                    break
-+                  }
++                    if ep.endpoint == endpoint {
++                        self.next_endpoint_index.set((i + 1) % NUM_ENDPOINTS);
++                        break;
++                    }
 +                }
                  true
              } else {
                  // Cannot receive now, indicate a delay to the controller.
 @@ -387,8 +399,8 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
      }
-
+ 
      fn cancel_out_transaction(&'a self, endpoint: usize) -> bool {
 -        if let Some(s) = self.get_endpoint(endpoint) {
 -            s.pending_out.take()

--- a/patches/tock/12-pending-deadlock.patch
+++ b/patches/tock/12-pending-deadlock.patch
@@ -1,9 +1,9 @@
 diff --git a/capsules/src/usb/usbc_ctap_hid.rs b/capsules/src/usb/usbc_ctap_hid.rs
-index 16b80cb10..c71ed639a 100644
+index 16b80cb10..2876074e1 100644
 --- a/capsules/src/usb/usbc_ctap_hid.rs
 +++ b/capsules/src/usb/usbc_ctap_hid.rs
 @@ -120,7 +120,6 @@ struct EndpointState {
- 
+
      tx_packet: OptionalCell<[u8; 64]>,
      pending_in: Cell<bool>,
 -    pending_out: Cell<bool>,
@@ -18,27 +18,29 @@ index 16b80cb10..c71ed639a 100644
              delayed_out: Cell::new(false),
          }
      }
-@@ -142,6 +140,9 @@ impl EndpointState {
+@@ -142,6 +140,10 @@ impl EndpointState {
  pub struct ClientCtapHID<'a, 'b, C: 'a> {
      client_ctrl: ClientCtrl<'a, 'static, C>,
- 
+
 +    // Is there a pending OUT transaction happening?
 +    pending_out: Cell<bool>,
++    next_endpoint_index: Cell<usize>,
 +
      endpoints: [EndpointState; NUM_ENDPOINTS],
- 
+
      // Interaction with the client
-@@ -264,6 +265,7 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
+@@ -264,6 +266,8 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
                  LANGUAGES,
                  strings,
              ),
 +            pending_out: Cell::new(false),
++            next_endpoint_index: Cell::new(0),
              endpoints: [
                  EndpointState::new(ENDPOINT_NUM),
                  #[cfg(feature = "vendor_hid")]
-@@ -306,12 +308,14 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
+@@ -306,16 +310,20 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
      }
- 
+
      pub fn receive_packet(&'a self, app: &mut App) {
 -        for (_, s) in self.endpoints.iter().enumerate() {
 -            if s.pending_out.get() {
@@ -50,25 +52,31 @@ index 16b80cb10..c71ed639a 100644
 +            // The previous packet has not yet been received, reject the new one.
 +        } else {
 +            self.pending_out.set(true);
-+            // Process the first endpoint that has a delayed packet.
++            // Process the next endpoint that has a delayed packet.
 +            // TODO(liamjm): Determine if a round-robin approach reduces latency
 +            // in the worst case.
-+            for (_, s) in self.endpoints.iter().enumerate() {
++            for i in self.next_endpoint_index.get()..self.next_endpoint_index.get()+NUM_ENDPOINTS {
++                let s = &self.endpoints[i % NUM_ENDPOINTS];
                  // In case we reported Delay before, send the pending packet back to the client.
                  // Otherwise, there's nothing to do, the controller will send us a packet_out when a
                  // packet arrives.
-@@ -344,7 +348,7 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
+                 if s.delayed_out.take() {
++                    self.next_endpoint_index.set((i + 1) % NUM_ENDPOINTS);
+                     if self.send_packet_to_client(s.endpoint, Some(app)) {
+                         // If that succeeds, alert the controller that we can now
+                         // receive data on the Interrupt OUT endpoint.
+@@ -344,7 +352,7 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
                  .client
                  .map_or(false, |client| client.can_receive_packet(&app))
              {
 -                assert!(s.pending_out.take());
 +                assert!(self.pending_out.take());
- 
+
                  // Clear any pending packet on the transmitting side.
                  // It's up to the client to handle the received packet and decide if this packet
-@@ -387,8 +391,8 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
+@@ -387,8 +395,8 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
      }
- 
+
      fn cancel_out_transaction(&'a self, endpoint: usize) -> bool {
 -        if let Some(s) = self.get_endpoint(endpoint) {
 -            s.pending_out.take()


### PR DESCRIPTION
The current approach selects the first endpoint  / interface (the main FIDO one) first all the time. This introduces a delay in processing the Vendor HID interface. This can lead to timeouts in processing the packets as each packet must be received within 100ms of the last one. #502 addresses this by increasing this timeout, but this is only a hack.

This PR fixes this problem by always processing the other interface than the previous packet. This is implemented by tracking the last endpoint that returned data, and trying the other one first next time (new next_endpoint_index variable).
This PR is implemented as a change to an existing patch (patches/tock/12-pending-deadlock.patch) as this is this patch has overlapping functionality.
