### PR TITLE
Interleave sending and receiving of packets to reduce rx latency

### DIFF
--- a/patches/tock/13-send-packet-before-receiving.patch
+++ b/patches/tock/13-send-packet-before-receiving.patch
@@ -1,0 +1,32 @@
+diff --git a/capsules/src/usb/usb_ctap.rs b/capsules/src/usb/usb_ctap.rs
+index 2c91c0968..ea8111069 100644
+--- a/capsules/src/usb/usb_ctap.rs
++++ b/capsules/src/usb/usb_ctap.rs
+@@ -253,18 +253,19 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> Driver for CtapUsbSyscallDriver<'a,
+                             if app.waiting {
+                                 ReturnCode::EALREADY
+                             } else {
++                                // Indicates to the driver that we have a packet to send.
++                                let r = self
++                                    .usb_client
++                                    .transmit_packet(app.buffer.as_ref().unwrap().as_ref(), endpoint);
++                                if r != ReturnCode::SUCCESS {
++                                    return r;
++                                }
+                                 // Indicates to the driver that we can receive any pending packet.
+                                 app.waiting = true;
+                                 self.usb_client.receive_packet(app);
+ 
+-                                if !app.waiting {
+-                                    // The call to receive_packet() collected a pending packet.
+-                                    ReturnCode::SUCCESS
+-                                } else {
+-                                    // Indicates to the driver that we have a packet to send.
+-                                    self.usb_client
+-                                        .transmit_packet(app.buffer.as_ref().unwrap().as_ref(), endpoint)
+-                                }
++                                ReturnCode::SUCCESS
++
+                             }
+                         } else {
+                             ReturnCode::EINVAL

--- a/src/api/connection.rs
+++ b/src/api/connection.rs
@@ -14,11 +14,12 @@
 
 use crate::clock::ClockInt;
 use embedded_time::duration::Milliseconds;
+use libtock_drivers::usb_ctap_hid::UsbEndpoint;
 
 pub enum SendOrRecvStatus {
     Timeout,
     Sent,
-    Received,
+    Received(UsbEndpoint),
 }
 
 pub struct SendOrRecvError;

--- a/src/api/connection.rs
+++ b/src/api/connection.rs
@@ -27,7 +27,7 @@ pub struct SendOrRecvError;
 pub type SendOrRecvResult = Result<SendOrRecvStatus, SendOrRecvError>;
 
 pub trait HidConnection {
-    fn send_or_recv_with_timeout(
+    fn send_and_maybe_recv(
         &mut self,
         buf: &mut [u8; 64],
         timeout: Milliseconds<ClockInt>,

--- a/src/ctap/hid/send.rs
+++ b/src/ctap/hid/send.rs
@@ -32,6 +32,10 @@ impl HidPacketIterator {
     pub fn none() -> HidPacketIterator {
         HidPacketIterator(None)
     }
+
+    pub fn has_data(&self) -> bool {
+        self.0.is_some()
+    }
 }
 
 impl Iterator for HidPacketIterator {

--- a/src/ctap/hid/send.rs
+++ b/src/ctap/hid/send.rs
@@ -34,7 +34,11 @@ impl HidPacketIterator {
     }
 
     pub fn has_data(&self) -> bool {
-        self.0.is_some()
+        if let Some(ms) = &self.0 {
+            ms.finished()
+        } else {
+            false
+        }
     }
 }
 
@@ -96,6 +100,15 @@ impl MessageSplitter {
             // Fill all of dst.
             dst.copy_from_slice(&data[..dst_len]);
             dst_len
+        }
+    }
+
+    // Is there more data to iterate over?
+    fn finished(&self) -> bool {
+        let payload_len = self.message.payload.len();
+        match self.seq {
+            None => true,
+            Some(_) => self.i < payload_len,
         }
     }
 }

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -274,7 +274,7 @@ fn send_keepalive_up_needed(
     let keepalive_msg = CtapHid::keepalive(cid, KeepaliveStatus::UpNeeded);
     for mut pkt in keepalive_msg {
         let ctap_hid_connection = transport.hid_connection(env);
-        match ctap_hid_connection.send_or_recv_with_timeout(&mut pkt, timeout) {
+        match ctap_hid_connection.send_and_maybe_recv(&mut pkt, timeout) {
             Ok(SendOrRecvStatus::Timeout) => {
                 debug_ctap!(env, "Sending a KEEPALIVE packet timed out");
                 // TODO: abort user presence test?

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -284,6 +284,7 @@ fn send_keepalive_up_needed(
                 debug_ctap!(env, "Sent KEEPALIVE packet");
             }
             Ok(SendOrRecvStatus::Received(_)) => {
+                // TODO(liamjm): Support receiving packets on both interfaces.
                 // We only parse one packet, because we only care about CANCEL.
                 let (received_cid, processed_packet) = CtapHid::process_single_packet(&pkt);
                 if received_cid != &cid {

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -83,6 +83,7 @@ use crypto::hmac::hmac_256;
 use crypto::sha256::Sha256;
 use crypto::{ecdsa, Hash256};
 use embedded_time::duration::Milliseconds;
+use libtock_drivers::usb_ctap_hid::UsbEndpoint;
 use rng256::Rng256;
 use sk_cbor as cbor;
 use sk_cbor::cbor_map_options;
@@ -283,7 +284,20 @@ fn send_keepalive_up_needed(
             Ok(SendOrRecvStatus::Sent) => {
                 debug_ctap!(env, "Sent KEEPALIVE packet");
             }
-            Ok(SendOrRecvStatus::Received(_)) => {
+            Ok(SendOrRecvStatus::Received(endpoint)) => {
+                let rx_transport = match endpoint {
+                    UsbEndpoint::MainHid => Transport::MainHid,
+                    #[cfg(feature = "vendor_hid")]
+                    UsbEndpoint::VendorHid => Transport::VendorHid,
+                };
+                if rx_transport != transport {
+                    debug_ctap!(
+                        env,
+                        "Received a packet on transport {:?} while sending a KEEPALIVE packet on transport {:?}",
+                         rx_transport, transport
+                    );
+                }
+
                 // TODO(liamjm): Support receiving packets on both interfaces.
                 // We only parse one packet, because we only care about CANCEL.
                 let (received_cid, processed_packet) = CtapHid::process_single_packet(&pkt);

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -283,7 +283,7 @@ fn send_keepalive_up_needed(
             Ok(SendOrRecvStatus::Sent) => {
                 debug_ctap!(env, "Sent KEEPALIVE packet");
             }
-            Ok(SendOrRecvStatus::Received) => {
+            Ok(SendOrRecvStatus::Received(_)) => {
                 // We only parse one packet, because we only care about CANCEL.
                 let (received_cid, processed_packet) = CtapHid::process_single_packet(&pkt);
                 if received_cid != &cid {

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -296,6 +296,8 @@ fn send_keepalive_up_needed(
                         "Received a packet on transport {:?} while sending a KEEPALIVE packet on transport {:?}",
                          rx_transport, transport
                     );
+                    // Ignore this packet.
+                    continue;
                 }
 
                 // TODO(liamjm): Support receiving packets on both interfaces.

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -297,10 +297,10 @@ fn send_keepalive_up_needed(
                          rx_transport, transport
                     );
                     // Ignore this packet.
+                    // TODO(liamjm): Support receiving packets on both interfaces.
                     continue;
                 }
 
-                // TODO(liamjm): Support receiving packets on both interfaces.
                 // We only parse one packet, because we only care about CANCEL.
                 let (received_cid, processed_packet) = CtapHid::process_single_packet(&pkt);
                 if received_cid != &cid {

--- a/src/env/test/mod.rs
+++ b/src/env/test/mod.rs
@@ -85,7 +85,7 @@ fn new_storage() -> BufferStorage {
 }
 
 impl HidConnection for TestEnv {
-    fn send_or_recv_with_timeout(
+    fn send_and_maybe_recv(
         &mut self,
         _buf: &mut [u8; 64],
         _timeout: Milliseconds<ClockInt>,

--- a/src/env/tock/mod.rs
+++ b/src/env/tock/mod.rs
@@ -54,10 +54,8 @@ impl HidConnection for TockHidConnection {
         ) {
             Ok(usb_ctap_hid::SendOrRecvStatus::Timeout) => Ok(SendOrRecvStatus::Timeout),
             Ok(usb_ctap_hid::SendOrRecvStatus::Sent) => Ok(SendOrRecvStatus::Sent),
-            Ok(usb_ctap_hid::SendOrRecvStatus::Received(recv_endpoint))
-                if self.endpoint == recv_endpoint =>
-            {
-                Ok(SendOrRecvStatus::Received)
+            Ok(usb_ctap_hid::SendOrRecvStatus::Received(recv_endpoint)) => {
+                Ok(SendOrRecvStatus::Received(recv_endpoint))
             }
             _ => Err(SendOrRecvError),
         }

--- a/src/env/tock/mod.rs
+++ b/src/env/tock/mod.rs
@@ -42,7 +42,7 @@ pub struct TockHidConnection {
 }
 
 impl HidConnection for TockHidConnection {
-    fn send_or_recv_with_timeout(
+    fn send_and_maybe_recv(
         &mut self,
         buf: &mut [u8; 64],
         timeout: Milliseconds<ClockInt>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub mod clock;
 #[cfg(feature = "std")]
 pub mod ctap;
 #[cfg(not(feature = "std"))]
-mod ctap;
+pub mod ctap;
 pub mod env;
 #[cfg(feature = "std")]
 pub mod test_helpers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,10 +46,6 @@ macro_rules! debug_ctap {
 
 pub mod api;
 pub mod clock;
-// Implementation details must be public for testing (in particular fuzzing).
-#[cfg(feature = "std")]
-pub mod ctap;
-#[cfg(not(feature = "std"))]
 pub mod ctap;
 pub mod env;
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ macro_rules! debug_ctap {
 
 pub mod api;
 pub mod clock;
+// TODO(kaczmarczyck): Refactor this so that ctap module isn't public.
 pub mod ctap;
 pub mod env;
 #[cfg(feature = "std")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,14 +152,14 @@ fn main() {
             button.enable().flex_unwrap();
         }
 
-        // Variable for use in both the send_or_recv and recv cases.
+        // Variable for use in both the send_and_maybe_recv and recv cases.
         let mut usb_endpoint: Option<UsbEndpoint> = None;
         let mut pkt_request = [0; 64];
 
         if let Some(mut packet) = replies.next_packet() {
             // send and receive.
             let hid_connection = packet.transport.hid_connection(ctap.env());
-            match hid_connection.send_or_recv_with_timeout(&mut packet.packet, SEND_TIMEOUT) {
+            match hid_connection.send_and_maybe_recv(&mut packet.packet, SEND_TIMEOUT) {
                 Ok(SendOrRecvStatus::Timeout) => {
                     #[cfg(feature = "debug_ctap")]
                     print_packet_notice("Sending packet timed out", &clock);

--- a/src/main.rs
+++ b/src/main.rs
@@ -232,11 +232,13 @@ fn main() {
                 for ep in replies.replies.iter_mut() {
                     if ep.endpoint == endpoint {
                         if ep.reply.has_data() {
+                            #[cfg(feature = "debug_ctap")]
                             writeln!(
                                 Console::new(),
                                 "Warning overwritting existing reply for endpoint {}",
                                 endpoint as usize
-                            ).unwrap();
+                            )
+                            .unwrap();
                         }
                         ep.reply = reply;
                         break;

--- a/src/main.rs
+++ b/src/main.rs
@@ -231,6 +231,13 @@ fn main() {
                 // Update endpoint with the reply.
                 for ep in replies.replies.iter_mut() {
                     if ep.endpoint == endpoint {
+                        if ep.reply.has_data() {
+                            writeln!(
+                                Console::new(),
+                                "Warning overwritting existing reply for endpoint {}",
+                                endpoint as usize
+                            ).unwrap();
+                        }
                         ep.reply = reply;
                         break;
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,7 +235,7 @@ fn main() {
                             #[cfg(feature = "debug_ctap")]
                             writeln!(
                                 Console::new(),
-                                "Warning overwritting existing reply for endpoint {}",
+                                "Warning overwriting existing reply for endpoint {}",
                                 endpoint as usize
                             )
                             .unwrap();

--- a/tools/vendor_hid_test.py
+++ b/tools/vendor_hid_test.py
@@ -19,6 +19,12 @@ _BROADCAST_CID = bytes([0xFF, 0xFF, 0xFF, 0xFF])
 _TEST_USER = {'id': b'user_id', 'name': 'Foo User'}
 
 
+def sleep():
+  # TODO(liamjm): remove this sleep once it is not necessary.
+  time.sleep(.01)
+  pass
+
+
 def ping_data_size(packets):
   return 57 + 59 * (packets - 1)
 
@@ -57,6 +63,7 @@ class HidDevice(object):
         f'Expected packet to be {_SEND_DATA_SIZE} but was {len(init_packet)}')
     self.dev.write(bytes(init_packet))
     self.cid = self.dev.read(_PACKET_SIZE, 2000)[15:19]
+    sleep()
 
   def ping_init(self, packets=1, byte=0x88) -> int:
     size = ping_data_size(packets)
@@ -66,6 +73,7 @@ class HidDevice(object):
         f'Expected packet to be {_SEND_DATA_SIZE} but was {len(ping_packet)}')
 
     r = self.dev.write(bytes(ping_packet))
+    sleep()
     return r
 
   def ping_continue(self, num, byte=0x88) -> int:
@@ -88,6 +96,7 @@ class HidDevice(object):
   def read_and_print(self) -> int:
     d = self.dev.read(_PACKET_SIZE, 2000)
     self.rx_packets.append(d)
+    sleep()
     return len(d)
 
   def get_received_data(self) -> bytes:
@@ -320,7 +329,7 @@ class CancelTests(unittest.TestCase):
     client = Fido2Client(
         self.fido,
         'https://example.com',
-        user_interaction=CliInteraction(self.fido_hid, self.fido.))
+        user_interaction=CliInteraction(self.fido_hid, self.fido._channel_id))
 
     with self.assertRaises(ClientError) as context:
       client.make_credential(self.create_options['publicKey'])
@@ -332,7 +341,7 @@ class CancelTests(unittest.TestCase):
     client = Fido2Client(
         self.fido,
         'https://example.com',
-        user_interaction=CliInteraction(self.vendor_hid, self.fido.))
+        user_interaction=CliInteraction(self.vendor_hid, self.fido._channel_id))
 
     client.make_credential(self.create_options['publicKey'])
 
@@ -341,7 +350,7 @@ class CancelTests(unittest.TestCase):
         self.fido,
         'https://example.com',
         user_interaction=CliInteraction(self.fido_hid,
-                                        self.fido. + 1))
+                                        self.fido._channel_id + 1))
     client.make_credential(self.create_options['publicKey'])
 
 

--- a/tools/vendor_hid_test.py
+++ b/tools/vendor_hid_test.py
@@ -18,11 +18,6 @@ _SEND_DATA_SIZE = _PACKET_SIZE + 1
 _BROADCAST_CID = bytes([0xFF, 0xFF, 0xFF, 0xFF])
 _TEST_USER = {'id': b'user_id', 'name': 'Foo User'}
 
-def sleep():
-  # TODO(liamjm): remove this sleep once it is not necessary.
-  time.sleep(.01)
-  pass
-
 
 def ping_data_size(packets):
   return 57 + 59 * (packets - 1)
@@ -62,7 +57,6 @@ class HidDevice(object):
         f'Expected packet to be {_SEND_DATA_SIZE} but was {len(init_packet)}')
     self.dev.write(bytes(init_packet))
     self.cid = self.dev.read(_PACKET_SIZE, 2000)[15:19]
-    sleep()
 
   def ping_init(self, packets=1, byte=0x88) -> int:
     size = ping_data_size(packets)
@@ -72,7 +66,6 @@ class HidDevice(object):
         f'Expected packet to be {_SEND_DATA_SIZE} but was {len(ping_packet)}')
 
     r = self.dev.write(bytes(ping_packet))
-    sleep()
     return r
 
   def ping_continue(self, num, byte=0x88) -> int:
@@ -95,7 +88,6 @@ class HidDevice(object):
   def read_and_print(self) -> int:
     d = self.dev.read(_PACKET_SIZE, 2000)
     self.rx_packets.append(d)
-    sleep()
     return len(d)
 
   def get_received_data(self) -> bytes:
@@ -328,7 +320,7 @@ class CancelTests(unittest.TestCase):
     client = Fido2Client(
         self.fido,
         'https://example.com',
-        user_interaction=CliInteraction(self.fido_hid, self.fido._channel_id))
+        user_interaction=CliInteraction(self.fido_hid, self.fido.))
 
     with self.assertRaises(ClientError) as context:
       client.make_credential(self.create_options['publicKey'])
@@ -340,7 +332,7 @@ class CancelTests(unittest.TestCase):
     client = Fido2Client(
         self.fido,
         'https://example.com',
-        user_interaction=CliInteraction(self.vendor_hid, self.fido._channel_id))
+        user_interaction=CliInteraction(self.vendor_hid, self.fido.))
 
     client.make_credential(self.create_options['publicKey'])
 
@@ -349,7 +341,7 @@ class CancelTests(unittest.TestCase):
         self.fido,
         'https://example.com',
         user_interaction=CliInteraction(self.fido_hid,
-                                        self.fido._channel_id + 1))
+                                        self.fido. + 1))
     client.make_credential(self.create_options['publicKey'])
 
 

--- a/tools/vendor_hid_test.py
+++ b/tools/vendor_hid_test.py
@@ -293,9 +293,7 @@ def get_fido_device() -> CtapHidDevice:
 def get_fido_device_vendor() -> CtapHidDevice:
   # Patch for the Vendor Usage Page.
   with patch.object(fido2.hid.base, 'FIDO_USAGE_PAGE', 0xFF00):
-    # NOTE: Need to determine is this should be the same as FIDO.
-    with patch.object(fido2.hid.base, 'FIDO_USAGE', 0x0020):
-      return get_fido_device()
+    return get_fido_device()
 
 
 class CliInteraction(UserInteraction):

--- a/tools/vendor_hid_test.py
+++ b/tools/vendor_hid_test.py
@@ -326,10 +326,11 @@ class CancelTests(unittest.TestCase):
         authenticator_attachment='cross-platform')
 
   def test_cancel_works(self):
+    cid = self.fido._channel_id  # pylint: disable=protected-access
     client = Fido2Client(
         self.fido,
         'https://example.com',
-        user_interaction=CliInteraction(self.fido_hid, self.fido._channel_id))
+        user_interaction=CliInteraction(self.fido_hid, cid))
 
     with self.assertRaises(ClientError) as context:
       client.make_credential(self.create_options['publicKey'])
@@ -338,19 +339,20 @@ class CancelTests(unittest.TestCase):
                        ctap.CtapError.ERR.KEEPALIVE_CANCEL)
 
   def test_cancel_ignores_wrong_interface(self):
+    cid = self.fido._channel_id  # pylint: disable=protected-access
     client = Fido2Client(
         self.fido,
         'https://example.com',
-        user_interaction=CliInteraction(self.vendor_hid, self.fido._channel_id))
+        user_interaction=CliInteraction(self.vendor_hid, cid))
 
     client.make_credential(self.create_options['publicKey'])
 
   def test_cancel_ignores_wrong_cid(self):
+    cid = self.fido._channel_id  # pylint: disable=protected-access
     client = Fido2Client(
         self.fido,
         'https://example.com',
-        user_interaction=CliInteraction(self.fido_hid,
-                                        self.fido._channel_id + 1))
+        user_interaction=CliInteraction(self.fido_hid, cid + 1))
     client.make_credential(self.create_options['publicKey'])
 
 


### PR DESCRIPTION
As discussed in #502 and #514 packet processing latency is too slow when both interfaces are being used. Another cause for this is that when a reply is being sent, it does so in a tight loop (ie inner loop in the main function) without receiving any other packets. This can easily introduce hundreds of milliseconds delay.

This PR removes the innner loop in main and leaves just a single loop. Each iteration it will optionally send a packet and always attempt to receive an incoming packet (#514 ensures suitable routing of the oldest packet). For our use case, the processing of these packets will be interleaved across the FIDO and Vendor HID interfaces (if both are present).

Several changes are required for this:

1. SendOrRecvStatus enum now includes the UsbEndpoint in the Received variant.
1. Code that uses SendOrRecvStatus handles the UsbEndpoint.
1. The HidConnection::send_or_recv_with_timeout now allows any endpoint to be received, not just the one it sent one.
1. HidPacketIterator now supports peeking to see if there is any data.
1. main.rs has new structs to support the state tracking and large changes to the loop.
1. tock CtapUsbSyscallDriver now sends packet before receiving incoming packet. Without this the tx packet is lost.