### PR TITLE
Move out check credProtectPolicy logic

### DIFF
--- a/src/ctap/credential_id.rs
+++ b/src/ctap/credential_id.rs
@@ -353,7 +353,7 @@ mod test {
 
         for length in (1..CBOR_CREDENTIAL_ID_SIZE).step_by(16) {
             assert_eq!(
-                decrypt_credential_id(&mut env, encrypted_id[..length].to_vec(), &rp_id_hash,),
+                decrypt_credential_id(&mut env, encrypted_id[..length].to_vec(), &rp_id_hash),
                 Ok(None)
             );
         }

--- a/src/ctap/credential_id.rs
+++ b/src/ctap/credential_id.rs
@@ -206,7 +206,6 @@ pub fn decrypt_credential_id(
     env: &mut impl Env,
     credential_id: Vec<u8>,
     rp_id_hash: &[u8],
-    check_cred_protect: bool,
 ) -> Result<Option<PublicKeyCredentialSource>, Ctap2StatusCode> {
     if credential_id.len() < MIN_CREDENTIAL_ID_SIZE {
         return Ok(None);
@@ -240,9 +239,7 @@ pub fn decrypt_credential_id(
         return Ok(None);
     };
 
-    let is_protected = credential_source.cred_protect_policy
-        == Some(CredentialProtectionPolicy::UserVerificationRequired);
-    if rp_id_hash != credential_source.rp_id_hash || (check_cred_protect && is_protected) {
+    if rp_id_hash != credential_source.rp_id_hash {
         return Ok(None);
     }
 
@@ -279,7 +276,7 @@ mod test {
         let rp_id_hash = [0x55; 32];
         let encrypted_id =
             encrypt_to_credential_id(&mut env, &private_key, &rp_id_hash, None).unwrap();
-        let decrypted_source = decrypt_credential_id(&mut env, encrypted_id, &rp_id_hash, false)
+        let decrypted_source = decrypt_credential_id(&mut env, encrypted_id, &rp_id_hash)
             .unwrap()
             .unwrap();
 
@@ -313,7 +310,7 @@ mod test {
         encrypted_id.extend(&id_hmac);
 
         assert_eq!(
-            decrypt_credential_id(&mut env, encrypted_id, &rp_id_hash, false),
+            decrypt_credential_id(&mut env, encrypted_id, &rp_id_hash),
             Ok(None)
         );
     }
@@ -329,7 +326,7 @@ mod test {
             let mut modified_id = encrypted_id.clone();
             modified_id[i] ^= 0x01;
             assert_eq!(
-                decrypt_credential_id(&mut env, modified_id, &rp_id_hash, false),
+                decrypt_credential_id(&mut env, modified_id, &rp_id_hash),
                 Ok(None)
             );
         }
@@ -356,12 +353,7 @@ mod test {
 
         for length in (1..CBOR_CREDENTIAL_ID_SIZE).step_by(16) {
             assert_eq!(
-                decrypt_credential_id(
-                    &mut env,
-                    encrypted_id[..length].to_vec(),
-                    &rp_id_hash,
-                    false
-                ),
+                decrypt_credential_id(&mut env, encrypted_id[..length].to_vec(), &rp_id_hash,),
                 Ok(None)
             );
         }
@@ -408,13 +400,13 @@ mod test {
         let rp_id_hash = [0x55; 32];
         let encrypted_id =
             legacy_encrypt_to_credential_id(&mut env, ecdsa_key, &rp_id_hash).unwrap();
-        // When checking credProtect for legacy credentials the check will always pass because we didn't persist credProtect
-        // policy info in it.
-        let decrypted_source = decrypt_credential_id(&mut env, encrypted_id, &rp_id_hash, true)
+        let decrypted_source = decrypt_credential_id(&mut env, encrypted_id, &rp_id_hash)
             .unwrap()
             .unwrap();
 
         assert_eq!(private_key, decrypted_source.private_key);
+        // Legacy credentials didn't persist credProtectPolicy info, so it should be treated as None.
+        assert!(decrypted_source.cred_protect_policy.is_none());
     }
 
     #[test]
@@ -429,7 +421,7 @@ mod test {
     }
 
     #[test]
-    fn test_check_cred_protect_fail() {
+    fn test_cred_protect_persisted() {
         let mut env = TestEnv::new();
         let private_key = PrivateKey::new(&mut env, SignatureAlgorithm::ES256);
 
@@ -442,34 +434,13 @@ mod test {
         )
         .unwrap();
 
-        assert_eq!(
-            decrypt_credential_id(&mut env, encrypted_id, &rp_id_hash, true),
-            Ok(None)
-        );
-    }
-
-    #[test]
-    fn test_check_cred_protect_success() {
-        let mut env = TestEnv::new();
-        let private_key = PrivateKey::new(&mut env, SignatureAlgorithm::ES256);
-
-        let rp_id_hash = [0x55; 32];
-        let encrypted_id = encrypt_to_credential_id(
-            &mut env,
-            &private_key,
-            &rp_id_hash,
-            Some(CredentialProtectionPolicy::UserVerificationOptionalWithCredentialIdList),
-        )
-        .unwrap();
-
-        let decrypted_source = decrypt_credential_id(&mut env, encrypted_id, &rp_id_hash, true)
+        let decrypted_source = decrypt_credential_id(&mut env, encrypted_id, &rp_id_hash)
             .unwrap()
             .unwrap();
-
         assert_eq!(decrypted_source.private_key, private_key);
         assert_eq!(
             decrypted_source.cred_protect_policy,
-            Some(CredentialProtectionPolicy::UserVerificationOptionalWithCredentialIdList)
+            Some(CredentialProtectionPolicy::UserVerificationRequired)
         );
     }
 }

--- a/src/ctap/credential_management.rs
+++ b/src/ctap/credential_management.rs
@@ -872,10 +872,9 @@ mod test {
             Ok(ResponseData::AuthenticatorCredentialManagement(None))
         );
 
-        let updated_credential =
-            storage::find_credential(&mut env, "example.com", &[0x1D; 32], false)
-                .unwrap()
-                .unwrap();
+        let updated_credential = storage::find_credential(&mut env, "example.com", &[0x1D; 32])
+            .unwrap()
+            .unwrap();
         assert_eq!(updated_credential.user_handle, vec![0x01]);
         assert_eq!(&updated_credential.user_name.unwrap(), "new_name");
         assert_eq!(

--- a/src/ctap/ctap1.rs
+++ b/src/ctap/ctap1.rs
@@ -311,7 +311,7 @@ impl Ctap1Command {
         flags: Ctap1Flags,
         ctap_state: &mut CtapState,
     ) -> Result<Vec<u8>, Ctap1StatusCode> {
-        let credential_source = decrypt_credential_id(env, key_handle, &application, false)
+        let credential_source = decrypt_credential_id(env, key_handle, &application)
             .map_err(|_| Ctap1StatusCode::SW_WRONG_DATA)?;
         if let Some(credential_source) = credential_source {
             let ecdsa_key = credential_source
@@ -442,7 +442,6 @@ mod test {
             &mut env,
             response[67..67 + CBOR_CREDENTIAL_ID_SIZE].to_vec(),
             &application,
-            false
         )
         .unwrap()
         .is_some());

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -717,7 +717,7 @@ impl CtapState {
         Ok(())
     }
 
-    fn check_cred_protect(
+    fn check_cred_protect_for_listed_credential(
         &mut self,
         credential: &Option<PublicKeyCredentialSource>,
         has_uv: bool,
@@ -825,10 +825,10 @@ impl CtapState {
         let rp_id_hash = Sha256::hash(rp_id.as_bytes());
         if let Some(exclude_list) = exclude_list {
             for cred_desc in exclude_list {
-                if self.check_cred_protect(
+                if self.check_cred_protect_for_listed_credential(
                     &storage::find_credential(env, &rp_id, &cred_desc.key_id)?,
                     has_uv,
-                ) || self.check_cred_protect(
+                ) || self.check_cred_protect_for_listed_credential(
                     &decrypt_credential_id(env, cred_desc.key_id, &rp_id_hash)?,
                     has_uv,
                 ) {
@@ -1099,11 +1099,11 @@ impl CtapState {
     ) -> Result<Option<PublicKeyCredentialSource>, Ctap2StatusCode> {
         for allowed_credential in allow_list {
             let credential = storage::find_credential(env, rp_id, &allowed_credential.key_id)?;
-            if self.check_cred_protect(&credential, has_uv) {
+            if self.check_cred_protect_for_listed_credential(&credential, has_uv) {
                 return Ok(credential);
             }
             let credential = decrypt_credential_id(env, allowed_credential.key_id, rp_id_hash)?;
-            if self.check_cred_protect(&credential, has_uv) {
+            if self.check_cred_protect_for_listed_credential(&credential, has_uv) {
                 return Ok(credential);
             }
         }


### PR DESCRIPTION
Move the credProtectPolicy check outside credential ID decryption &
discoverable credential finding. Modify the unit tests, and add unit
tests for credProtectPolicy checking in non resident flows that were
originally missing.

This should have no behavioral differences.