### PR TITLE
Support credBlob for non-resident credentials

### DIFF
--- a/src/api/customization.rs
+++ b/src/api/customization.rs
@@ -184,6 +184,8 @@ pub trait Customization {
     /// # Invariant
     ///
     /// - The length must be at least 32.
+    /// - OpenSK puts a limit that the length must be at most 64, as it needs to
+    ///   be persisted in the credential ID.
     fn max_cred_blob_length(&self) -> usize;
 
     /// Limits the number of considered entries in credential lists.
@@ -397,8 +399,8 @@ pub fn is_valid(customization: &impl Customization) -> bool {
         return false;
     }
 
-    // Max cred blob length should be at least 32.
-    if customization.max_cred_blob_length() < 32 {
+    // Max cred blob length should be at least 32, and at most 64.
+    if customization.max_cred_blob_length() < 32 || customization.max_cred_blob_length() > 64 {
         return false;
     }
 

--- a/src/ctap/credential_id.rs
+++ b/src/ctap/credential_id.rs
@@ -47,6 +47,7 @@ struct CredentialSource {
     private_key: PrivateKey,
     rp_id_hash: [u8; 32],
     cred_protect_policy: Option<CredentialProtectionPolicy>,
+    cred_blob: Option<Vec<u8>>,
 }
 
 // The data fields contained in the credential ID are serizlied using CBOR maps.
@@ -55,6 +56,7 @@ enum CredentialSourceField {
     PrivateKey = 0,
     RpIdHash = 1,
     CredProtectPolicy = 2,
+    CredBlob = 3,
 }
 
 impl From<CredentialSourceField> for sk_cbor::Value {
@@ -81,6 +83,7 @@ fn decrypt_legacy_credential_id(
         private_key,
         rp_id_hash: plaintext[32..64].try_into().unwrap(),
         cred_protect_policy: None,
+        cred_blob: None,
     }))
 }
 
@@ -98,10 +101,11 @@ fn decrypt_cbor_credential_id(
           CredentialSourceField::PrivateKey => private_key,
           CredentialSourceField::RpIdHash=> rp_id_hash,
           CredentialSourceField::CredProtectPolicy => cred_protect_policy,
+          CredentialSourceField::CredBlob => cred_blob,
       } = extract_map(cbor_credential_source)?;
     }
-    Ok(match (private_key, rp_id_hash, cred_protect_policy) {
-        (Some(private_key), Some(rp_id_hash), cred_protect_policy) => {
+    Ok(match (private_key, rp_id_hash) {
+        (Some(private_key), Some(rp_id_hash)) => {
             let private_key = PrivateKey::try_from(private_key)?;
             let rp_id_hash = extract_byte_string(rp_id_hash)?;
             if rp_id_hash.len() != 32 {
@@ -112,10 +116,16 @@ fn decrypt_cbor_credential_id(
             } else {
                 None
             };
+            let cred_blob = if let Some(blob) = cred_blob {
+                Some(extract_byte_string(blob)?)
+            } else {
+                None
+            };
             Some(CredentialSource {
                 private_key,
                 rp_id_hash: rp_id_hash.try_into().unwrap(),
                 cred_protect_policy,
+                cred_blob,
             })
         }
         _ => None,
@@ -162,12 +172,14 @@ pub fn encrypt_to_credential_id(
     private_key: &PrivateKey,
     rp_id_hash: &[u8; 32],
     cred_protect_policy: Option<CredentialProtectionPolicy>,
+    cred_blob: Option<Vec<u8>>,
 ) -> Result<Vec<u8>, Ctap2StatusCode> {
     let mut payload = Vec::new();
     let cbor = cbor_map_options! {
       CredentialSourceField::PrivateKey => private_key,
       CredentialSourceField::RpIdHash=> rp_id_hash,
       CredentialSourceField::CredProtectPolicy => cred_protect_policy,
+      CredentialSourceField::CredBlob => cred_blob,
     };
     cbor_write(cbor, &mut payload)?;
     add_padding(&mut payload)?;
@@ -254,7 +266,7 @@ pub fn decrypt_credential_id(
         creation_order: 0,
         user_name: None,
         user_icon: None,
-        cred_blob: None,
+        cred_blob: credential_source.cred_blob,
         large_blob_key: None,
     }))
 }
@@ -262,6 +274,7 @@ pub fn decrypt_credential_id(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::api::customization::Customization;
     use crate::ctap::credential_id::CBOR_CREDENTIAL_ID_SIZE;
     use crate::ctap::SignatureAlgorithm;
     use crate::env::test::TestEnv;
@@ -275,7 +288,7 @@ mod test {
 
         let rp_id_hash = [0x55; 32];
         let encrypted_id =
-            encrypt_to_credential_id(&mut env, &private_key, &rp_id_hash, None).unwrap();
+            encrypt_to_credential_id(&mut env, &private_key, &rp_id_hash, None, None).unwrap();
         let decrypted_source = decrypt_credential_id(&mut env, encrypted_id, &rp_id_hash)
             .unwrap()
             .unwrap();
@@ -301,7 +314,7 @@ mod test {
 
         let rp_id_hash = [0x55; 32];
         let mut encrypted_id =
-            encrypt_to_credential_id(&mut env, &private_key, &rp_id_hash, None).unwrap();
+            encrypt_to_credential_id(&mut env, &private_key, &rp_id_hash, None, None).unwrap();
         encrypted_id[0] = UNSUPPORTED_CREDENTIAL_ID_VERSION;
         // Override the HMAC to pass the check.
         encrypted_id.truncate(&encrypted_id.len() - 32);
@@ -321,7 +334,7 @@ mod test {
 
         let rp_id_hash = [0x55; 32];
         let encrypted_id =
-            encrypt_to_credential_id(&mut env, &private_key, &rp_id_hash, None).unwrap();
+            encrypt_to_credential_id(&mut env, &private_key, &rp_id_hash, None, None).unwrap();
         for i in 0..encrypted_id.len() {
             let mut modified_id = encrypted_id.clone();
             modified_id[i] ^= 0x01;
@@ -349,7 +362,7 @@ mod test {
 
         let rp_id_hash = [0x55; 32];
         let encrypted_id =
-            encrypt_to_credential_id(&mut env, &private_key, &rp_id_hash, None).unwrap();
+            encrypt_to_credential_id(&mut env, &private_key, &rp_id_hash, None, None).unwrap();
 
         for length in (1..CBOR_CREDENTIAL_ID_SIZE).step_by(16) {
             assert_eq!(
@@ -416,8 +429,30 @@ mod test {
 
         let rp_id_hash = [0x55; 32];
         let encrypted_id =
-            encrypt_to_credential_id(&mut env, &private_key, &rp_id_hash, None).unwrap();
+            encrypt_to_credential_id(&mut env, &private_key, &rp_id_hash, None, None).unwrap();
         assert_eq!(encrypted_id.len(), CBOR_CREDENTIAL_ID_SIZE);
+    }
+
+    #[test]
+    fn test_encrypt_credential_max_cbor_size() {
+        // The cbor encoding length is variadic and depends on size of fields. Try to put maximum length
+        // for each encoded field and ensure that it doesn't go over the padding size.
+        let mut env = TestEnv::new();
+        // Currently all private key types have same length when transformed to bytes.
+        let private_key = PrivateKey::new(&mut env, SignatureAlgorithm::Es256);
+        let rp_id_hash = [0x55; 32];
+        let cred_protect_policy = Some(CredentialProtectionPolicy::UserVerificationOptional);
+        let cred_blob = Some(vec![0x55; env.customization().max_cred_blob_length()]);
+
+        let encrypted_id = encrypt_to_credential_id(
+            &mut env,
+            &private_key,
+            &rp_id_hash,
+            cred_protect_policy,
+            cred_blob,
+        );
+
+        assert!(encrypted_id.is_ok());
     }
 
     #[test]
@@ -431,6 +466,7 @@ mod test {
             &private_key,
             &rp_id_hash,
             Some(CredentialProtectionPolicy::UserVerificationRequired),
+            None,
         )
         .unwrap();
 
@@ -442,5 +478,23 @@ mod test {
             decrypted_source.cred_protect_policy,
             Some(CredentialProtectionPolicy::UserVerificationRequired)
         );
+    }
+
+    #[test]
+    fn test_cred_blob_persisted() {
+        let mut env = TestEnv::new();
+        let private_key = PrivateKey::new(&mut env, SignatureAlgorithm::Es256);
+
+        let rp_id_hash = [0x55; 32];
+        let cred_blob = Some(vec![0x55; env.customization().max_cred_blob_length()]);
+        let encrypted_id =
+            encrypt_to_credential_id(&mut env, &private_key, &rp_id_hash, None, cred_blob.clone())
+                .unwrap();
+
+        let decrypted_source = decrypt_credential_id(&mut env, encrypted_id, &rp_id_hash)
+            .unwrap()
+            .unwrap();
+        assert_eq!(decrypted_source.private_key, private_key);
+        assert_eq!(decrypted_source.cred_blob, cred_blob);
     }
 }

--- a/src/ctap/ctap1.rs
+++ b/src/ctap/ctap1.rs
@@ -249,7 +249,7 @@ impl Ctap1Command {
             .ecdsa_key(env)
             .map_err(|_| Ctap1StatusCode::SW_INTERNAL_EXCEPTION)?;
         let pk = sk.genpk();
-        let key_handle = encrypt_to_credential_id(env, &private_key, &application, None)
+        let key_handle = encrypt_to_credential_id(env, &private_key, &application, None, None)
             .map_err(|_| Ctap1StatusCode::SW_INTERNAL_EXCEPTION)?;
         if key_handle.len() > 0xFF {
             // This is just being defensive with unreachable code.
@@ -498,7 +498,7 @@ mod test {
 
         let rp_id = "example.com";
         let application = crypto::sha256::Sha256::hash(rp_id.as_bytes());
-        let key_handle = encrypt_to_credential_id(&mut env, &sk, &application, None).unwrap();
+        let key_handle = encrypt_to_credential_id(&mut env, &sk, &application, None, None).unwrap();
         let message = create_authenticate_message(&application, Ctap1Flags::CheckOnly, &key_handle);
 
         let response =
@@ -516,7 +516,7 @@ mod test {
 
         let rp_id = "example.com";
         let application = crypto::sha256::Sha256::hash(rp_id.as_bytes());
-        let key_handle = encrypt_to_credential_id(&mut env, &sk, &application, None).unwrap();
+        let key_handle = encrypt_to_credential_id(&mut env, &sk, &application, None, None).unwrap();
         let application = [0x55; 32];
         let message = create_authenticate_message(&application, Ctap1Flags::CheckOnly, &key_handle);
 
@@ -535,7 +535,7 @@ mod test {
 
         let rp_id = "example.com";
         let application = crypto::sha256::Sha256::hash(rp_id.as_bytes());
-        let key_handle = encrypt_to_credential_id(&mut env, &sk, &application, None).unwrap();
+        let key_handle = encrypt_to_credential_id(&mut env, &sk, &application, None, None).unwrap();
         let mut message = create_authenticate_message(
             &application,
             Ctap1Flags::DontEnforceUpAndSign,
@@ -573,7 +573,7 @@ mod test {
 
         let rp_id = "example.com";
         let application = crypto::sha256::Sha256::hash(rp_id.as_bytes());
-        let key_handle = encrypt_to_credential_id(&mut env, &sk, &application, None).unwrap();
+        let key_handle = encrypt_to_credential_id(&mut env, &sk, &application, None, None).unwrap();
         let mut message =
             create_authenticate_message(&application, Ctap1Flags::CheckOnly, &key_handle);
         message[0] = 0xEE;
@@ -593,7 +593,7 @@ mod test {
 
         let rp_id = "example.com";
         let application = crypto::sha256::Sha256::hash(rp_id.as_bytes());
-        let key_handle = encrypt_to_credential_id(&mut env, &sk, &application, None).unwrap();
+        let key_handle = encrypt_to_credential_id(&mut env, &sk, &application, None, None).unwrap();
         let mut message =
             create_authenticate_message(&application, Ctap1Flags::CheckOnly, &key_handle);
         message[1] = 0xEE;
@@ -613,7 +613,7 @@ mod test {
 
         let rp_id = "example.com";
         let application = crypto::sha256::Sha256::hash(rp_id.as_bytes());
-        let key_handle = encrypt_to_credential_id(&mut env, &sk, &application, None).unwrap();
+        let key_handle = encrypt_to_credential_id(&mut env, &sk, &application, None, None).unwrap();
         let mut message =
             create_authenticate_message(&application, Ctap1Flags::CheckOnly, &key_handle);
         message[2] = 0xEE;
@@ -641,7 +641,7 @@ mod test {
 
         let rp_id = "example.com";
         let application = crypto::sha256::Sha256::hash(rp_id.as_bytes());
-        let key_handle = encrypt_to_credential_id(&mut env, &sk, &application, None).unwrap();
+        let key_handle = encrypt_to_credential_id(&mut env, &sk, &application, None, None).unwrap();
         let message =
             create_authenticate_message(&application, Ctap1Flags::EnforceUpAndSign, &key_handle);
 
@@ -669,7 +669,7 @@ mod test {
 
         let rp_id = "example.com";
         let application = crypto::sha256::Sha256::hash(rp_id.as_bytes());
-        let key_handle = encrypt_to_credential_id(&mut env, &sk, &application, None).unwrap();
+        let key_handle = encrypt_to_credential_id(&mut env, &sk, &application, None, None).unwrap();
         let message = create_authenticate_message(
             &application,
             Ctap1Flags::DontEnforceUpAndSign,


### PR DESCRIPTION
- Add a upper limit of max_cred_blob_length
- Add test cases for cred_blob in non-resident flows
- Modify the test helper functions in ctap/mod.rs a bit