### PR TITLE
Fix user presence by not overwriting error with OK()

### DIFF
--- a/src/api/user_presence.rs
+++ b/src/api/user_presence.rs
@@ -15,6 +15,7 @@
 use crate::clock::ClockInt;
 use embedded_time::duration::Milliseconds;
 
+#[derive(Debug)]
 pub enum UserPresenceError {
     /// User explicitly declined user presence check.
     Declined,

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -349,14 +349,14 @@ fn check_user_presence(env: &mut impl Env, channel: Channel) -> Result<(), Ctap2
         // accordingly, so that all wait_with_timeout invocations are separated by
         // equal time intervals. That way token indicators, such as LEDs, will blink
         // with a consistent pattern.
-        let ka_result = send_keepalive_up_needed(env, channel, KEEPALIVE_DELAY);
-        if ka_result.is_err() {
+        let keepalive_result = send_keepalive_up_needed(env, channel, KEEPALIVE_DELAY);
+        if keepalive_result.is_err() {
             debug_ctap!(
                 env,
                 "Sending keepalive failed with error {:?}",
-                ka_result.as_ref().unwrap_err()
+                keepalive_result.as_ref().unwrap_err()
             );
-            result = ka_result;
+            result = keepalive_result;
             break;
         }
     }

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -1523,6 +1523,7 @@ mod test {
     use super::pin_protocol::{authenticate_pin_uv_auth_token, PinProtocol};
     use super::*;
     use crate::api::customization;
+    use crate::api::user_presence::UserPresenceResult;
     use crate::env::test::TestEnv;
     use crate::test_helpers;
     use cbor::{cbor_array, cbor_array_vec, cbor_map};
@@ -3750,6 +3751,30 @@ mod test {
             CtapInstant::new(0) + STATEFUL_COMMAND_TIMEOUT_DURATION + Milliseconds(1 as ClockInt),
         );
         assert_eq!(response, Err(Ctap2StatusCode::CTAP2_ERR_NOT_ALLOWED));
+    }
+
+    #[test]
+    fn test_check_user_presence() {
+        // This TestEnv always returns successful user_presence checks.
+        let mut env = TestEnv::new();
+        let response = check_user_presence(&mut env, DUMMY_CHANNEL);
+        assert!(matches!(response, Ok(_)));
+    }
+
+    #[test]
+    fn test_check_user_presence_timeout() {
+        // This will always return timeout.
+        fn user_presence_timeout() -> UserPresenceResult {
+            Err(UserPresenceError::Timeout)
+        }
+
+        let mut env = TestEnv::new();
+        env.user_presence().set(user_presence_timeout);
+        let response = check_user_presence(&mut env, DUMMY_CHANNEL);
+        assert!(matches!(
+            response,
+            Err(Ctap2StatusCode::CTAP2_ERR_USER_ACTION_TIMEOUT)
+        ));
     }
 
     #[test]

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -100,7 +100,7 @@ const ED_FLAG: u8 = 0x80;
 // CTAP2 specification section 6 requires that the depth of nested CBOR structures be limited to at most four levels.
 const MAX_CBOR_NESTING_DEPTH: i8 = 4;
 
-pub const TOUCH_TIMEOUT_MS: ClockInt = 30000;
+pub const TOUCH_TIMEOUT_MS: ClockInt = 3000;
 #[cfg(feature = "with_ctap1")]
 pub const TOUCH_TIMEOUT: Milliseconds<ClockInt> = Milliseconds(TOUCH_TIMEOUT_MS);
 #[cfg(feature = "with_ctap1")]
@@ -349,8 +349,14 @@ fn check_user_presence(env: &mut impl Env, channel: Channel) -> Result<(), Ctap2
         // accordingly, so that all wait_with_timeout invocations are separated by
         // equal time intervals. That way token indicators, such as LEDs, will blink
         // with a consistent pattern.
-        result = send_keepalive_up_needed(env, channel, KEEPALIVE_DELAY);
-        if result.is_err() {
+        let ka_result = send_keepalive_up_needed(env, channel, KEEPALIVE_DELAY);
+        if ka_result.is_err() {
+            debug_ctap!(
+                env,
+                "Sending keepalive failed with error {:?}",
+                ka_result.as_ref().unwrap_err()
+            );
+            result = ka_result;
             break;
         }
     }

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -100,7 +100,7 @@ const ED_FLAG: u8 = 0x80;
 // CTAP2 specification section 6 requires that the depth of nested CBOR structures be limited to at most four levels.
 const MAX_CBOR_NESTING_DEPTH: i8 = 4;
 
-pub const TOUCH_TIMEOUT_MS: ClockInt = 3000;
+pub const TOUCH_TIMEOUT_MS: ClockInt = 30000;
 #[cfg(feature = "with_ctap1")]
 pub const TOUCH_TIMEOUT: Milliseconds<ClockInt> = Milliseconds(TOUCH_TIMEOUT_MS);
 #[cfg(feature = "with_ctap1")]

--- a/tools/vendor_hid_test.py
+++ b/tools/vendor_hid_test.py
@@ -341,34 +341,22 @@ class CancelTests(unittest.TestCase):
         self.fido,
         'https://example.com',
         user_interaction=CliInteraction(cid + 1, connection))
-<<<<<<< HEAD
     with self.assertRaises(ClientError) as context:
       client.make_credential(self.create_options['publicKey'])
 
     self.assertEqual(context.exception.code, ClientError.ERR.TIMEOUT)
     self.assertEqual(context.exception.cause.code,
                      ctap.CtapError.ERR.USER_ACTION_TIMEOUT)
-=======
-    # TODO(https://github.com/google/OpenSK/issues/519): This should be an
-    # exception
-    client.make_credential(self.create_options['publicKey'])
->>>>>>> origin/develop
 
   def test_timeout(self):
     client = Fido2Client(
         self.fido, 'https://example.com', user_interaction=CliInteraction())
-<<<<<<< HEAD
     with self.assertRaises(ClientError) as context:
       client.make_credential(self.create_options['publicKey'])
 
     self.assertEqual(context.exception.code, ClientError.ERR.TIMEOUT)
     self.assertEqual(context.exception.cause.code,
                      ctap.CtapError.ERR.USER_ACTION_TIMEOUT)
-=======
-    # TODO(https://github.com/google/OpenSK/issues/519): This should be an
-    # exception
-    client.make_credential(self.create_options['publicKey'])
->>>>>>> origin/develop
 
 
 if __name__ == '__main__':

--- a/tools/vendor_hid_test.py
+++ b/tools/vendor_hid_test.py
@@ -1,7 +1,12 @@
 """These tests verify the functionality of the VendorHID interface."""
-from typing import Dict, Iterable
+from fido2 import ctap
+from fido2.hid import CtapHidDevice
+from fido2.hid.base import CtapHidConnection
+from fido2.client import Fido2Client, UserInteraction, ClientError
+from fido2.server import Fido2Server
 import hid
 import time
+from typing import Dict, Iterable
 import unittest
 
 _OPENSK_VID = 0x1915
@@ -12,6 +17,7 @@ _PACKETS = 4
 _PACKET_SIZE = 64
 _SEND_DATA_SIZE = _PACKET_SIZE + 1
 _BROADCAST_CID = bytes([0xFF, 0xFF, 0xFF, 0xFF])
+_TEST_USER = {'id': b'user_id', 'name': 'Foo User'}
 
 
 def sleep():
@@ -263,6 +269,94 @@ class HidInterfaces(unittest.TestCase):
   def test_11_batch_send_and_interleaved_receive_vendor_first(self):
     self._test_batch_send_and_interleaved_receive(self.vendor_hid,
                                                   self.fido_hid)
+
+
+def get_fido_device() -> CtapHidDevice:
+  for d in CtapHidDevice.list_devices():
+    if d.descriptor.vid == _OPENSK_VID and d.descriptor.pid == _OPENSK_PID:
+      return d
+  raise Exception('Unable to find Fido device')
+
+
+class CliInteraction(UserInteraction):
+  """Sends cancel messages while prompting user."""
+
+  def __init__(self, cid=None, connection: CtapHidConnection = None):
+    super(CliInteraction).__init__()
+    self.cid = cid
+    self.connection = connection
+
+  def prompt_up(self) -> None:
+    print('\n Don\'t touch your authenticator device now...\n')
+    # Send cancel messages to the specified device.
+    if self.connection and self.cid:
+      cancel_packet = (
+          self.cid.to_bytes(4, byteorder='big') + b'\x91' +
+          b''.join([b'\x00'] * 59))
+      assert len(cancel_packet) == _PACKET_SIZE, (
+          f'Expected packet to be {_PACKET_SIZE} '
+          'but was {len(cancel_packet)}')
+
+      self.connection.write_packet(cancel_packet)
+
+
+class CancelTests(unittest.TestCase):
+  """Tests for the canceling while waiting for user touch."""
+
+  @classmethod
+  def setUpClass(cls):
+    cls.fido = get_fido_device()
+
+  def setUp(self) -> None:
+    super().setUp()
+    server = Fido2Server({
+        'id': 'example.com',
+        'name': 'Example RP'
+    },
+                         attestation='direct')
+    self.create_options, _ = server.register_begin(
+        _TEST_USER,
+        user_verification='foo',
+        authenticator_attachment='cross-platform')
+
+  def test_cancel_works(self):
+    cid = self.fido._channel_id  # pylint: disable=protected-access
+    connection = self.fido._connection  # pylint: disable=protected-access
+    client = Fido2Client(
+        self.fido,
+        'https://example.com',
+        user_interaction=CliInteraction(cid, connection))
+
+    with self.assertRaises(ClientError) as context:
+      client.make_credential(self.create_options['publicKey'])
+
+    self.assertEqual(context.exception.code, ClientError.ERR.TIMEOUT)
+    self.assertEqual(context.exception.cause.code,
+                     ctap.CtapError.ERR.KEEPALIVE_CANCEL)
+
+  def test_cancel_ignores_wrong_cid(self):
+    cid = self.fido._channel_id  # pylint: disable=protected-access
+    connection = self.fido._connection  # pylint: disable=protected-access
+    client = Fido2Client(
+        self.fido,
+        'https://example.com',
+        user_interaction=CliInteraction(cid + 1, connection))
+    with self.assertRaises(ClientError) as context:
+      client.make_credential(self.create_options['publicKey'])
+
+    self.assertEqual(context.exception.code, ClientError.ERR.TIMEOUT)
+    self.assertEqual(context.exception.cause.code,
+                     ctap.CtapError.ERR.USER_ACTION_TIMEOUT)
+
+  def test_timeout(self):
+    client = Fido2Client(
+        self.fido, 'https://example.com', user_interaction=CliInteraction())
+    with self.assertRaises(ClientError) as context:
+      client.make_credential(self.create_options['publicKey'])
+
+    self.assertEqual(context.exception.code, ClientError.ERR.TIMEOUT)
+    self.assertEqual(context.exception.cause.code,
+                     ctap.CtapError.ERR.USER_ACTION_TIMEOUT)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #519 

The key change is in check_user_presence(), where the result of the user_presence().wait_with_timeout() call is now not overwritten unless the subsequent call to send_keepalive_up_needed() returns an error.

Tests added in #520 demonstrate the bug.