### PR TITLE
Use non-zero Usage on Vendor HID

### DIFF
--- a/patches/tock/09-add-vendor-hid-usb-interface.patch
+++ b/patches/tock/09-add-vendor-hid-usb-interface.patch
@@ -166,7 +166,7 @@ index 642039120..adb7fde14 100644
 +#[cfg(feature = "vendor_hid")]
 +static VENDOR_REPORT_DESCRIPTOR: &'static [u8] = &[
 +    0x06, 0x00, 0xFF, // HID_UsagePage ( VENDOR ),
-+    0x09, 0x00, // HID_Usage ( Unused ),
++    0x09, 0x01, // HID_Usage ( Unused ),
 +    0xA1, 0x01, // HID_Collection ( HID_Application ),
 +    0x09, 0x20, // HID_Usage ( FIDO_USAGE_DATA_IN ),
 +    0x15, 0x00, // HID_LogicalMin ( 0 ),


### PR DESCRIPTION
The vendor HID uses a Usage Page of 0xFF00, which means Vendor defined. The Usage was 0, as this doesn't matter, except when it does....

It turns that it does matter for the python HID library as it uses an implicit false check.
From https://github.com/Yubico/python-fido2/blob/main/fido2/hid/base.py#L122

```
  elif key == USAGE:
    if not usage:
      usage = value
```

The usage variable is initialized to None. The first time through this branch, it is set to 0. A subsequent loop [0] should see the usage is set and not overwrite the value. But, due to the wonders of duck-typing a value of 0 is also considered false, so the code enters the if branch. Using a non-zero usage value avoids this.

An alternative fix might be to change the FIDO2 library to use "if usage is None".

0: The subsequent loop is when the Usage is defined as part of the HID_Collection.