### PR TITLE
Support configure via the Vendor interface

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -755,6 +755,7 @@ class OpenSKInstaller:
             certificate=self.args.config_cert,
             priv_key=self.args.config_pkey,
             lock=self.args.lock_device,
+            use_vendor_hid="vendor_hid" in self.args.features,
         ))
     if not configure_response:
       return None
@@ -873,11 +874,6 @@ class OpenSKInstaller:
         fatal("Unexpected arguments to configure your device. Since you "
               "selected the programmer \"none\", the device is not ready to be "
               "configured yet.")
-      return 0
-
-    if "vendor_hid" in self.args.features:
-      # vendor_hid as a work in progress and is not compatible with configure
-      # mode.
       return 0
 
     # Perform checks if OpenSK was flashed.

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -3866,7 +3866,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "vendor_hid")]
     fn test_main_hid() {
         let mut env = TestEnv::new();
         let mut ctap_state = CtapState::new(&mut env, CtapInstant::new(0));
@@ -3881,13 +3880,19 @@ mod test {
             response,
             Ok(ResponseData::AuthenticatorGetInfo(_))
         ));
-        let response = ctap_state.process_parsed_command(
-            &mut env,
-            Command::AuthenticatorGetInfo,
-            VENDOR_CHANNEL,
-            CtapInstant::new(0),
-        );
-        assert_eq!(response, Err(Ctap2StatusCode::CTAP1_ERR_INVALID_COMMAND));
+        #[cfg(feature = "vendor_hid")]
+        {
+            let response = ctap_state.process_parsed_command(
+                &mut env,
+                Command::AuthenticatorGetInfo,
+                VENDOR_CHANNEL,
+                CtapInstant::new(0),
+            );
+            assert!(matches!(
+                response,
+                Ok(ResponseData::AuthenticatorGetInfo(_))
+            ));
+        }
     }
 
     #[test]

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -714,6 +714,7 @@ impl CtapState {
             }
             Command::AuthenticatorVendorUpgrade(params) => self.process_vendor_upgrade(env, params),
             Command::AuthenticatorVendorUpgradeInfo => self.process_vendor_upgrade_info(env),
+            Command::AuthenticatorGetInfo => self.process_get_info(env),
             _ => Err(Ctap2StatusCode::CTAP1_ERR_INVALID_COMMAND),
         }
     }

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -3866,7 +3866,7 @@ mod test {
     }
 
     #[test]
-    fn test_main_hid() {
+    fn test_get_info_command() {
         let mut env = TestEnv::new();
         let mut ctap_state = CtapState::new(&mut env, CtapInstant::new(0));
 
@@ -3893,6 +3893,20 @@ mod test {
                 Ok(ResponseData::AuthenticatorGetInfo(_))
             ));
         }
+    }
+
+    #[test]
+    #[cfg(feature = "vendor_hid")]
+    fn test_vendor_hid_does_not_support_fido_command() {
+        let mut env = TestEnv::new();
+        let mut ctap_state = CtapState::new(&mut env, CtapInstant::new(0));
+        let response = ctap_state.process_parsed_command(
+            &mut env,
+            Command::AuthenticatorGetNextAssertion,
+            VENDOR_CHANNEL,
+            CtapInstant::new(0),
+        );
+        assert_eq!(response, Err(Ctap2StatusCode::CTAP1_ERR_INVALID_COMMAND));
     }
 
     #[test]


### PR DESCRIPTION
If the vendor_hid feature is enabled, configure must happen through this interface.

This PR makes that happen by patching fido2 lib to select the Vendor HID interface via its usage page.

To get this to work, the GetInfo command was added to the supported commands on the Vender interface as the fido2 lib calls this command. This seems reasonable change anyway.