### PR TITLE
Duplicate the credential management command as a vendor command

### DIFF
--- a/src/ctap/command.rs
+++ b/src/ctap/command.rs
@@ -70,8 +70,12 @@ impl Command {
     const AUTHENTICATOR_CONFIG: u8 = 0x0D;
     const _AUTHENTICATOR_VENDOR_FIRST: u8 = 0x40;
     const AUTHENTICATOR_VENDOR_CONFIGURE: u8 = 0x40;
-    const AUTHENTICATOR_VENDOR_UPGRADE: u8 = 0x41;
-    const AUTHENTICATOR_VENDOR_UPGRADE_INFO: u8 = 0x42;
+    // This commands is the same as AUTHENTICATOR_CREDENTIAL_MANAGEMENT but is duplicated as a
+    // vendor command for legacy and compatibility reasons. See
+    // https://github.com/Yubico/libfido2/issues/628 for more information.
+    const AUTHENTICATOR_VENDOR_CREDENTIAL_MANAGEMENT: u8 = 0x41;
+    const AUTHENTICATOR_VENDOR_UPGRADE: u8 = 0x42;
+    const AUTHENTICATOR_VENDOR_UPGRADE_INFO: u8 = 0x43;
     const _AUTHENTICATOR_VENDOR_LAST: u8 = 0xBF;
 
     pub fn deserialize(bytes: &[u8]) -> Result<Command, Ctap2StatusCode> {
@@ -112,7 +116,8 @@ impl Command {
                 // Parameters are ignored.
                 Ok(Command::AuthenticatorGetNextAssertion)
             }
-            Command::AUTHENTICATOR_CREDENTIAL_MANAGEMENT => {
+            Command::AUTHENTICATOR_CREDENTIAL_MANAGEMENT
+            | Command::AUTHENTICATOR_VENDOR_CREDENTIAL_MANAGEMENT => {
                 let decoded_cbor = cbor_read(&bytes[1..])?;
                 Ok(Command::AuthenticatorCredentialManagement(
                     AuthenticatorCredentialManagementParameters::try_from(decoded_cbor)?,

--- a/tools/deploy_partition.py
+++ b/tools/deploy_partition.py
@@ -40,8 +40,8 @@ from tockloader import tab
 from tools.configure import fatal, error, info, get_opensk_devices, get_private_key
 
 OPENSK_VID_PID = (0x1915, 0x521F)
-OPENSK_VENDOR_UPGRADE = 0x41
-OPENSK_VENDOR_UPGRADE_INFO = 0x42
+OPENSK_VENDOR_UPGRADE = 0x42
+OPENSK_VENDOR_UPGRADE_INFO = 0x43
 PAGE_SIZE = 0x1000
 KERNEL_SIZE = 0x20000
 APP_SIZE = 0x20000


### PR DESCRIPTION
This permits to work with libfido2 and thus ssh-add. Fix #526.