### PR TITLE
Use latest in workflows

### DIFF
--- a/.github/workflows/boards_build.yml
+++ b/.github/workflows/boards_build.yml
@@ -12,7 +12,7 @@ jobs:
   build_boards:
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15]
+        os: [ubuntu-latest, macos-10.15]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/cargo_audit.yml
+++ b/.github/workflows/cargo_audit.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   audit:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: github.repository == 'google/OpenSK'
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/cargo_check.yml
+++ b/.github/workflows/cargo_check.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   cargo_check:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/cargo_clippy.yml
+++ b/.github/workflows/cargo_clippy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   cargo_clippy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/cargo_fmt.yml
+++ b/.github/workflows/cargo_fmt.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   cargo_format:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/cargo_fuzz.yml
+++ b/.github/workflows/cargo_fuzz.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_fuzzing:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/cbor_test.yml
+++ b/.github/workflows/cbor_test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   cbor_test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   coveralls:
     name: OpenSK code coverage
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/crypto_test.yml
+++ b/.github/workflows/crypto_test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   crypto_test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/heapviz_test.yml
+++ b/.github/workflows/heapviz_test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   heapviz_test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Install ncurses

--- a/.github/workflows/mdlint.yml
+++ b/.github/workflows/mdlint.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   mdlint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: markdownlint-cli

--- a/.github/workflows/opensk_build.yml
+++ b/.github/workflows/opensk_build.yml
@@ -9,7 +9,7 @@ jobs:
   build_ctap2:
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15]
+        os: [ubuntu-latest, macos-10.15]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/opensk_test.yml
+++ b/.github/workflows/opensk_test.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   ctap2_test:
     name: CTAP2 unit tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/persistent_store_test.yml
+++ b/.github/workflows/persistent_store_test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   persistent_store_test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,7 +9,7 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   pylint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
@@ -29,7 +29,7 @@ jobs:
         run: ./tools/run_pylint.sh
 
   yapf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.7

--- a/.github/workflows/reproducible.yml
+++ b/.github/workflows/reproducible.yml
@@ -9,7 +9,7 @@ jobs:
   check_hashes:
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15]
+        os: [ubuntu-latest, macos-10.15]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/rng256_test.yml
+++ b/.github/workflows/rng256_test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   rng256_test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Workflows started failing becaues of deprecated versions. This applies the suggested fix.