### PR TITLE
Vendor HID for upgrades

### DIFF
--- a/docs/boards/nrf52840dk.md
+++ b/docs/boards/nrf52840dk.md
@@ -70,3 +70,11 @@ respectively. You can only upgrade the partition that is not currently running,
 so always alternate your calls to `perform_upgrade.sh`. Otherwise, this script
 works like `deploy.py`. You can call it even after you locked down your device,
 to deploy changes to your development board.
+
+If you deploy with `--vendor-hid`, also add this flag to `perform_upgrade.sh`,
+for example:
+
+```shell
+./deploy.py --board=nrf52840dk_opensk_a --opensk --vendor-hid
+./tools/perform_upgrade.sh nrf52840dk_opensk_b --vendor-hid
+```

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -216,6 +216,6 @@ if __name__ == "__main__":
       default=False,
       action="store_true",
       dest="use_vendor_hid",
-      help=("Whether to configure the device using the Vendor HID interface"),
+      help=("Whether to configure the device using the Vendor HID interface."),
   )
   main(parser.parse_args())

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -212,7 +212,7 @@ if __name__ == "__main__":
             "haven't been both programmed yet."),
   )
   parser.add_argument(
-      "--use-vendor-hid",
+      "--vendor-hid",
       default=False,
       action="store_true",
       dest="use_vendor_hid",

--- a/tools/deploy_partition.py
+++ b/tools/deploy_partition.py
@@ -257,6 +257,6 @@ if __name__ == "__main__":
       default=False,
       action="store_true",
       dest="use_vendor_hid",
-      help=("Whether to configure the device using the Vendor HID interface"),
+      help=("Whether to upgrade the device using the Vendor HID interface."),
   )
   main(parser.parse_args())

--- a/tools/perform_upgrade.sh
+++ b/tools/perform_upgrade.sh
@@ -23,7 +23,7 @@ set -e
 BOARD="$1"
 
 ./deploy.py --board=$BOARD --opensk --programmer=none
-python3 -m tools.deploy_partition --board=$BOARD
+python3 -m tools.deploy_partition --board=$BOARD "$2"
 if nrfjprog --reset --family NRF52 ; then
   echo "Upgrade finished!"
 else

--- a/tools/perform_upgrade.sh
+++ b/tools/perform_upgrade.sh
@@ -22,7 +22,7 @@ set -e
 
 BOARD="$1"
 
-./deploy.py --board=${BOARD} --opensk --programmer=none $2
+./deploy.py --board="${BOARD}" --opensk --programmer=none $2
 python3 -m tools.deploy_partition --board="${BOARD}" $2
 if nrfjprog --reset --family NRF52 ; then
   echo "Upgrade finished!"

--- a/tools/perform_upgrade.sh
+++ b/tools/perform_upgrade.sh
@@ -22,7 +22,7 @@ set -e
 
 BOARD="${1}"
 
-./deploy.py --board=$BOARD --opensk --programmer=none
+./deploy.py --board=$BOARD --opensk --programmer=none $2
 python3 -m tools.deploy_partition --board="${BOARD}" $2
 if nrfjprog --reset --family NRF52 ; then
   echo "Upgrade finished!"

--- a/tools/perform_upgrade.sh
+++ b/tools/perform_upgrade.sh
@@ -20,9 +20,9 @@
 
 set -e
 
-BOARD="${1}"
+BOARD="$1"
 
-./deploy.py --board=$BOARD --opensk --programmer=none $2
+./deploy.py --board=${BOARD} --opensk --programmer=none $2
 python3 -m tools.deploy_partition --board="${BOARD}" $2
 if nrfjprog --reset --family NRF52 ; then
   echo "Upgrade finished!"

--- a/tools/perform_upgrade.sh
+++ b/tools/perform_upgrade.sh
@@ -20,10 +20,10 @@
 
 set -e
 
-BOARD="$1"
+BOARD="${1}"
 
 ./deploy.py --board=$BOARD --opensk --programmer=none
-python3 -m tools.deploy_partition --board=$BOARD "$2"
+python3 -m tools.deploy_partition --board="${BOARD}" $2
 if nrfjprog --reset --family NRF52 ; then
   echo "Upgrade finished!"
 else


### PR DESCRIPTION
Allows sending upgrade over the Vendor HID transport. Also renames the flag in configure to `--vendor-hid` for consistency.