### PR TITLE
Add basic setup for multi-PIN

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,6 @@ persistent_store = { path = "libraries/persistent_store" }
 byteorder = { version = "1", default-features = false }
 arrayref = "0.3.6"
 subtle = { version = "2.2", default-features = false, features = ["nightly"] }
-# This import explicitly locks the version.
-serde_json = { version = "=1.0.69", default-features = false, features = ["alloc"] }
 embedded-time = "0.12.1"
 arbitrary = { version = "0.4.7", features = ["derive"], optional = true }
 rand = { version = "0.8.4", optional = true }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,8 +11,9 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = { version = "0.3" }
 fuzz_helper = { path = "fuzz_helper" }
-# This import explicitly locks the version.
-serde_json = { version = "=1.0.69" }
+# We import to explicitly lock the version.
+# Remove this dependency once CTAP is a library.
+bumpalo = "=3.8.0"
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,9 +11,6 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = { version = "0.3" }
 fuzz_helper = { path = "fuzz_helper" }
-# We import to explicitly lock the version.
-# Remove this dependency once CTAP is a library.
-bumpalo = "=3.8.0"
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/libraries/crypto/Cargo.toml
+++ b/libraries/crypto/Cargo.toml
@@ -21,6 +21,11 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "=1.0.69", optional = true }
 regex = { version = "1", optional = true }
 
+# We explicitly lock the version of those transitive dependencies because their
+# Cargo.toml don't parse with the nightly compiler used by Tock. Remove this
+# whole block once CTAP is a library.
+bumpalo = "=3.8.0" # transitive dependency of ring
+
 [features]
 std = ["hex", "ring", "rng256/std", "untrusted", "serde", "serde_json", "regex"]
 with_ctap1 = []

--- a/libraries/persistent_store/src/concat.rs
+++ b/libraries/persistent_store/src/concat.rs
@@ -1,0 +1,242 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Support for concatenated entries.
+//!
+//! This module permits to store multiple indexed values under the same key by concatenation. Such
+//! values must be at most 255 bytes and there can't be more than 255 such values under the same
+//! key (they are indexed with a `u8`).
+//!
+//! The rationale for using those particular constraints is that we want the number of bits to store
+//! the index and the number of bits to store the length to fit in an integer number of bytes
+//! (because the values are an integer number of bytes). Using only one byte is too restrictive
+//! (e.g. 8 values of at most 31 bytes or 16 values of at most 15 bytes). Using 2 bytes is plenty of
+//! space, so using one byte for each field makes parsing simpler and faster.
+//!
+//! The format is thus `(index:u8 length:u8 payload:[u8; length])*`. The concatenation is not
+//! particularly sorted.
+
+use crate::{Storage, Store, StoreError, StoreResult};
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::ops::Range;
+
+/// Reads a value from a concatenated entry.
+pub fn read(store: &Store<impl Storage>, key: usize, index: u8) -> StoreResult<Option<Vec<u8>>> {
+    let values = match store.find(key)? {
+        None => return Ok(None),
+        Some(x) => x,
+    };
+    Ok(find(&values, index)?.map(|range| values[range].to_vec()))
+}
+
+/// Writes a value to a concatenated entry.
+pub fn write(
+    store: &mut Store<impl Storage>,
+    key: usize,
+    index: u8,
+    value: &[u8],
+) -> StoreResult<()> {
+    if value.len() > 255 {
+        return Err(StoreError::InvalidArgument);
+    }
+    let mut values = store.find(key)?.unwrap_or(vec![]);
+    match find(&values, index)? {
+        None => {
+            values.push(index);
+            values.push(value.len() as u8);
+            values.extend_from_slice(value);
+        }
+        Some(mut range) => {
+            values[range.start - 1] = value.len() as u8;
+            match range.len().cmp(&value.len()) {
+                Ordering::Less => {
+                    let diff = value.len() - range.len();
+                    values.resize(values.len() + diff, 0);
+                    values[range.end..].rotate_right(diff);
+                    range.end += diff;
+                }
+                Ordering::Equal => (),
+                Ordering::Greater => {
+                    let diff = range.len() - value.len();
+                    range.end -= diff;
+                    values[range.end..].rotate_left(diff);
+                    values.truncate(values.len() - diff);
+                }
+            }
+            values[range].copy_from_slice(value);
+        }
+    }
+    store.insert(key, &values)
+}
+
+/// Deletes the value from a concatenated entry.
+pub fn delete(store: &mut Store<impl Storage>, key: usize, index: u8) -> StoreResult<()> {
+    let mut values = match store.find(key)? {
+        None => return Ok(()),
+        Some(x) => x,
+    };
+    let mut range = match find(&values, index)? {
+        None => return Ok(()),
+        Some(x) => x,
+    };
+    range.start -= 2;
+    values[range.start..].rotate_left(range.len());
+    values.truncate(values.len() - range.len());
+    store.insert(key, &values)
+}
+
+fn find(values: &[u8], index: u8) -> StoreResult<Option<Range<usize>>> {
+    let mut pos = 0;
+    while pos < values.len() {
+        if pos == values.len() - 1 {
+            return Err(StoreError::InvalidStorage);
+        }
+        let len = values[pos + 1] as usize;
+        if len > values.len() - 2 || pos > values.len() - 2 - len {
+            return Err(StoreError::InvalidStorage);
+        }
+        if index == values[pos] {
+            return Ok(Some(pos + 2..pos + 2 + len));
+        }
+        pos += 2 + len;
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::MINIMAL;
+
+    #[test]
+    fn read_empty_entry() {
+        let store = MINIMAL.new_store();
+        assert_eq!(read(&store, 0, 0), Ok(None));
+        assert_eq!(read(&store, 0, 1), Ok(None));
+    }
+
+    #[test]
+    fn read_missing_value() {
+        let mut store = MINIMAL.new_store();
+        let value = b"\x00\x03foo\x02\x05hello".to_vec();
+        store.insert(0, &value).unwrap();
+        assert_eq!(read(&store, 0, 1), Ok(None));
+    }
+
+    #[test]
+    fn read_existing_value() {
+        let mut store = MINIMAL.new_store();
+        let value = b"\x00\x03foo\x02\x05hello".to_vec();
+        store.insert(0, &value).unwrap();
+        assert_eq!(read(&store, 0, 0), Ok(Some(b"foo".to_vec())));
+        assert_eq!(read(&store, 0, 2), Ok(Some(b"hello".to_vec())));
+    }
+
+    #[test]
+    fn read_invalid_entry_too_long() {
+        let mut store = MINIMAL.new_store();
+        let value = b"\x00\x03foo\x02\x08hello".to_vec();
+        store.insert(0, &value).unwrap();
+        assert_eq!(read(&store, 0, 1), Err(StoreError::InvalidStorage));
+    }
+
+    #[test]
+    fn read_invalid_entry_too_short() {
+        let mut store = MINIMAL.new_store();
+        let value = b"\x00\x03foo\x02".to_vec();
+        store.insert(0, &value).unwrap();
+        assert_eq!(read(&store, 0, 1), Err(StoreError::InvalidStorage));
+    }
+
+    #[test]
+    fn write_empty_entry() {
+        let mut store = MINIMAL.new_store();
+        assert_eq!(write(&mut store, 0, 0, b"foo"), Ok(()));
+        assert_eq!(store.find(0), Ok(Some(b"\x00\x03foo".to_vec())));
+    }
+
+    #[test]
+    fn write_missing_value() {
+        let mut store = MINIMAL.new_store();
+        let value = b"\x00\x03foo".to_vec();
+        store.insert(0, &value).unwrap();
+        assert_eq!(write(&mut store, 0, 1, b"bar"), Ok(()));
+        assert_eq!(store.find(0), Ok(Some(b"\x00\x03foo\x01\x03bar".to_vec())));
+    }
+
+    #[test]
+    fn write_existing_value_same_size() {
+        let mut store = MINIMAL.new_store();
+        let value = b"\x00\x03foo\x02\x05hello".to_vec();
+        store.insert(0, &value).unwrap();
+        assert_eq!(write(&mut store, 0, 0, b"bar"), Ok(()));
+        assert_eq!(
+            store.find(0),
+            Ok(Some(b"\x00\x03bar\x02\x05hello".to_vec()))
+        );
+    }
+
+    #[test]
+    fn write_existing_value_longer() {
+        let mut store = MINIMAL.new_store();
+        let value = b"\x00\x03foo\x02\x05hello".to_vec();
+        store.insert(0, &value).unwrap();
+        assert_eq!(write(&mut store, 0, 0, b"barrage"), Ok(()));
+        assert_eq!(
+            store.find(0),
+            Ok(Some(b"\x00\x07barrage\x02\x05hello".to_vec()))
+        );
+    }
+
+    #[test]
+    fn write_existing_value_shorter() {
+        let mut store = MINIMAL.new_store();
+        let value = b"\x00\x08football\x02\x05hello".to_vec();
+        store.insert(0, &value).unwrap();
+        assert_eq!(write(&mut store, 0, 0, b"bar"), Ok(()));
+        assert_eq!(
+            store.find(0),
+            Ok(Some(b"\x00\x03bar\x02\x05hello".to_vec()))
+        );
+    }
+
+    #[test]
+    fn delete_empty_entry() {
+        let mut store = MINIMAL.new_store();
+        assert_eq!(delete(&mut store, 0, 0), Ok(()));
+        assert_eq!(delete(&mut store, 0, 1), Ok(()));
+    }
+
+    #[test]
+    fn delete_missing_value() {
+        let mut store = MINIMAL.new_store();
+        let value = b"\x00\x03foo\x02\x05hello".to_vec();
+        store.insert(0, &value).unwrap();
+        assert_eq!(delete(&mut store, 0, 1), Ok(()));
+        assert_eq!(
+            store.find(0),
+            Ok(Some(b"\x00\x03foo\x02\x05hello".to_vec()))
+        );
+    }
+
+    #[test]
+    fn delete_existing_value() {
+        let mut store = MINIMAL.new_store();
+        let value = b"\x00\x03foo\x02\x05hello".to_vec();
+        store.insert(0, &value).unwrap();
+        assert_eq!(delete(&mut store, 0, 0), Ok(()));
+        assert_eq!(store.find(0), Ok(Some(b"\x02\x05hello".to_vec())));
+    }
+}

--- a/libraries/persistent_store/src/lib.rs
+++ b/libraries/persistent_store/src/lib.rs
@@ -363,6 +363,7 @@ extern crate alloc;
 
 #[cfg(feature = "std")]
 mod buffer;
+pub mod concat;
 #[cfg(feature = "std")]
 mod driver;
 #[cfg(feature = "std")]

--- a/src/api/customization.rs
+++ b/src/api/customization.rs
@@ -242,6 +242,14 @@ pub trait Customization {
     /// for 10 years.
     fn max_supported_resident_keys(&self) -> usize;
 
+    /// Sets the slot count of the multi-PIN feature.
+    ///
+    /// # Invariant
+    ///
+    /// - The slot count may not make the storage entries that concatenate data
+    ///   of each slots become larger than the storage page size, or exceed the
+    ///   number of keys we reserve for the storage entries that use unique keys
+    ///   for each slot. The upper bound of this is currently 8.
     fn slot_count(&self) -> usize;
 }
 
@@ -428,6 +436,11 @@ pub fn is_valid(customization: &impl Customization) -> bool {
     if customization.max_rp_ids_length() == 0
         && customization.default_min_pin_length_rp_ids().is_empty()
     {
+        return false;
+    }
+
+    // Slot count should be at most 8.
+    if customization.slot_count() > 8 {
         return false;
     }
 

--- a/src/api/customization.rs
+++ b/src/api/customization.rs
@@ -241,6 +241,8 @@ pub trait Customization {
     /// With P=20 and K=150, we have I=2M which is enough for 500 increments per day
     /// for 10 years.
     fn max_supported_resident_keys(&self) -> usize;
+
+    fn slot_count(&self) -> usize;
 }
 
 #[derive(Clone)]
@@ -260,6 +262,7 @@ pub struct CustomizationImpl {
     pub max_large_blob_array_size: usize,
     pub max_rp_ids_length: usize,
     pub max_supported_resident_keys: usize,
+    pub slot_count: usize,
 }
 
 pub const DEFAULT_CUSTOMIZATION: CustomizationImpl = CustomizationImpl {
@@ -278,6 +281,7 @@ pub const DEFAULT_CUSTOMIZATION: CustomizationImpl = CustomizationImpl {
     max_large_blob_array_size: 2048,
     max_rp_ids_length: 8,
     max_supported_resident_keys: 150,
+    slot_count: 1,
 };
 
 impl Customization for CustomizationImpl {
@@ -350,6 +354,10 @@ impl Customization for CustomizationImpl {
 
     fn max_supported_resident_keys(&self) -> usize {
         self.max_supported_resident_keys
+    }
+
+    fn slot_count(&self) -> usize {
+        self.slot_count
     }
 }
 

--- a/src/api/customization.rs
+++ b/src/api/customization.rs
@@ -246,10 +246,15 @@ pub trait Customization {
     ///
     /// # Invariant
     ///
-    /// - The slot count may not make the storage entries that concatenate data
-    ///   of each slots become larger than the storage page size, or exceed the
-    ///   number of keys we reserve for the storage entries that use unique keys
-    ///   for each slot. The upper bound of this is currently 8.
+    /// - The slot count may not:
+    ///   - make the storage entries that concatenate data of each slots
+    ///     become larger than the storage page size,
+    ///   - go over u8, as we only reserve 1 byte for the array index for
+    ///     concatenated entries, or
+    ///   - exceed the number of keys we reserve for the storage entries
+    ///     that use unique keys for each slot.
+    ///
+    /// The upper bound of this is currently 8.
     fn slot_count(&self) -> usize;
 }
 

--- a/src/ctap/client_pin.rs
+++ b/src/ctap/client_pin.rs
@@ -166,9 +166,8 @@ impl ClientPin {
         shared_secret: &dyn SharedSecret,
         pin_hash_enc: Vec<u8>,
     ) -> Result<(), Ctap2StatusCode> {
-        if slot_id >= env.customization().slot_count()
-            || slot_id >= self.consecutive_pin_mismatches.len()
-        {
+        // To prevent out of bounds access in code below.
+        if slot_id >= self.consecutive_pin_mismatches.len() {
             return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
         }
         match storage::pin_hash(env, slot_id)? {
@@ -209,9 +208,7 @@ impl ClientPin {
     ) -> Result<AuthenticatorClientPinResponse, Ctap2StatusCode> {
         // TODO: Parse slot_id from params if multi-PIN feature is enabled.
         let slot_id = 0;
-        if slot_id >= env.customization().slot_count()
-            || slot_id >= self.consecutive_pin_mismatches.len()
-        {
+        if slot_id >= self.consecutive_pin_mismatches.len() {
             return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
         }
         Ok(AuthenticatorClientPinResponse {

--- a/src/ctap/client_pin.rs
+++ b/src/ctap/client_pin.rs
@@ -21,12 +21,13 @@ use super::pin_protocol::{verify_pin_uv_auth_token, PinProtocol, SharedSecret};
 use super::response::{AuthenticatorClientPinResponse, ResponseData};
 use super::status_code::Ctap2StatusCode;
 use super::token_state::PinUvAuthTokenState;
+use crate::api::customization::Customization;
 use crate::ctap::storage;
 use crate::env::Env;
 use alloc::boxed::Box;
-use alloc::str;
 use alloc::string::String;
 use alloc::vec::Vec;
+use alloc::{str, vec};
 use crypto::hmac::hmac_256;
 use crypto::sha256::Sha256;
 use crypto::Hash256;
@@ -78,6 +79,7 @@ fn decrypt_pin(
 /// truncated for persistent storage.
 fn check_and_store_new_pin(
     env: &mut impl Env,
+    slot_id: usize,
     shared_secret: &dyn SharedSecret,
     new_pin_enc: Vec<u8>,
 ) -> Result<(), Ctap2StatusCode> {
@@ -90,7 +92,7 @@ fn check_and_store_new_pin(
     let mut pin_hash = [0u8; PIN_AUTH_LENGTH];
     pin_hash.copy_from_slice(&Sha256::hash(&pin[..])[..PIN_AUTH_LENGTH]);
     // The PIN length is always < PIN_PADDED_LENGTH < 256.
-    storage::set_pin(env, &pin_hash, pin_length as u8)?;
+    storage::set_pin(env, slot_id, &pin_hash, pin_length as u8)?;
     Ok(())
 }
 
@@ -108,16 +110,16 @@ pub enum PinPermission {
 pub struct ClientPin {
     pin_protocol_v1: PinProtocol,
     pin_protocol_v2: PinProtocol,
-    consecutive_pin_mismatches: u8,
+    consecutive_pin_mismatches: Vec<u8>,
     pin_uv_auth_token_state: PinUvAuthTokenState,
 }
 
 impl ClientPin {
-    pub fn new(rng: &mut impl Rng256) -> ClientPin {
+    pub fn new(env: &mut impl Env) -> ClientPin {
         ClientPin {
-            pin_protocol_v1: PinProtocol::new(rng),
-            pin_protocol_v2: PinProtocol::new(rng),
-            consecutive_pin_mismatches: 0,
+            pin_protocol_v1: PinProtocol::new(env.rng()),
+            pin_protocol_v2: PinProtocol::new(env.rng()),
+            consecutive_pin_mismatches: vec![0; env.customization().slot_count()],
             pin_uv_auth_token_state: PinUvAuthTokenState::new(),
         }
     }
@@ -159,16 +161,22 @@ impl ClientPin {
     fn verify_pin_hash_enc(
         &mut self,
         env: &mut impl Env,
+        slot_id: usize,
         pin_uv_auth_protocol: PinUvAuthProtocol,
         shared_secret: &dyn SharedSecret,
         pin_hash_enc: Vec<u8>,
     ) -> Result<(), Ctap2StatusCode> {
-        match storage::pin_hash(env)? {
+        if slot_id >= env.customization().slot_count()
+            || slot_id >= self.consecutive_pin_mismatches.len()
+        {
+            return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
+        }
+        match storage::pin_hash(env, slot_id)? {
             Some(pin_hash) => {
-                if self.consecutive_pin_mismatches >= 3 {
+                if self.consecutive_pin_mismatches[slot_id] >= 3 {
                     return Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_BLOCKED);
                 }
-                storage::decr_pin_retries(env)?;
+                storage::decr_pin_retries(env, slot_id)?;
                 let pin_hash_dec = shared_secret
                     .decrypt(&pin_hash_enc)
                     .map_err(|_| Ctap2StatusCode::CTAP2_ERR_PIN_INVALID)?;
@@ -176,11 +184,11 @@ impl ClientPin {
                 if !bool::from(pin_hash.ct_eq(&pin_hash_dec)) {
                     self.get_mut_pin_protocol(pin_uv_auth_protocol)
                         .regenerate(env.rng());
-                    if storage::pin_retries(env)? == 0 {
+                    if storage::pin_retries(env, slot_id)? == 0 {
                         return Err(Ctap2StatusCode::CTAP2_ERR_PIN_BLOCKED);
                     }
-                    self.consecutive_pin_mismatches += 1;
-                    if self.consecutive_pin_mismatches >= 3 {
+                    self.consecutive_pin_mismatches[slot_id] += 1;
+                    if self.consecutive_pin_mismatches[slot_id] >= 3 {
                         return Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_BLOCKED);
                     }
                     return Err(Ctap2StatusCode::CTAP2_ERR_PIN_INVALID);
@@ -189,20 +197,28 @@ impl ClientPin {
             // This status code is not explicitly mentioned in the specification.
             None => return Err(Ctap2StatusCode::CTAP2_ERR_PUAT_REQUIRED),
         }
-        storage::reset_pin_retries(env)?;
-        self.consecutive_pin_mismatches = 0;
+        storage::reset_pin_retries(env, slot_id)?;
+        self.consecutive_pin_mismatches[slot_id] = 0;
         Ok(())
     }
 
     fn process_get_pin_retries(
         &self,
         env: &mut impl Env,
+        _client_pin_params: AuthenticatorClientPinParameters,
     ) -> Result<AuthenticatorClientPinResponse, Ctap2StatusCode> {
+        // TODO: Parse slot_id from params if multi-PIN feature is enabled.
+        let slot_id = 0;
+        if slot_id >= env.customization().slot_count()
+            || slot_id >= self.consecutive_pin_mismatches.len()
+        {
+            return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
+        }
         Ok(AuthenticatorClientPinResponse {
             key_agreement: None,
             pin_uv_auth_token: None,
-            retries: Some(storage::pin_retries(env)? as u64),
-            power_cycle_state: Some(self.consecutive_pin_mismatches >= 3),
+            retries: Some(storage::pin_retries(env, slot_id)? as u64),
+            power_cycle_state: Some(self.consecutive_pin_mismatches[slot_id] >= 3),
         })
     }
 
@@ -234,18 +250,20 @@ impl ClientPin {
             new_pin_enc,
             ..
         } = client_pin_params;
+        // TODO: Parse slot_id from params if multi-PIN feature is enabled.
+        let slot_id = 0;
         let key_agreement = ok_or_missing(key_agreement)?;
         let pin_uv_auth_param = ok_or_missing(pin_uv_auth_param)?;
         let new_pin_enc = ok_or_missing(new_pin_enc)?;
 
-        if storage::pin_hash(env)?.is_some() {
+        if storage::pin_hash(env, slot_id)?.is_some() {
             return Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID);
         }
         let shared_secret = self.get_shared_secret(pin_uv_auth_protocol, key_agreement)?;
         shared_secret.verify(&new_pin_enc, &pin_uv_auth_param)?;
 
-        check_and_store_new_pin(env, shared_secret.as_ref(), new_pin_enc)?;
-        storage::reset_pin_retries(env)?;
+        check_and_store_new_pin(env, slot_id, shared_secret.as_ref(), new_pin_enc)?;
+        storage::reset_pin_retries(env, slot_id)?;
         Ok(())
     }
 
@@ -262,12 +280,14 @@ impl ClientPin {
             pin_hash_enc,
             ..
         } = client_pin_params;
+        // TODO: Parse slot_id from params if multi-PIN feature is enabled.
+        let slot_id = 0;
         let key_agreement = ok_or_missing(key_agreement)?;
         let pin_uv_auth_param = ok_or_missing(pin_uv_auth_param)?;
         let new_pin_enc = ok_or_missing(new_pin_enc)?;
         let pin_hash_enc = ok_or_missing(pin_hash_enc)?;
 
-        if storage::pin_retries(env)? == 0 {
+        if storage::pin_retries(env, slot_id)? == 0 {
             return Err(Ctap2StatusCode::CTAP2_ERR_PIN_BLOCKED);
         }
         let shared_secret = self.get_shared_secret(pin_uv_auth_protocol, key_agreement)?;
@@ -276,12 +296,13 @@ impl ClientPin {
         shared_secret.verify(&auth_param_data, &pin_uv_auth_param)?;
         self.verify_pin_hash_enc(
             env,
+            slot_id,
             pin_uv_auth_protocol,
             shared_secret.as_ref(),
             pin_hash_enc,
         )?;
 
-        check_and_store_new_pin(env, shared_secret.as_ref(), new_pin_enc)?;
+        check_and_store_new_pin(env, slot_id, shared_secret.as_ref(), new_pin_enc)?;
         self.pin_protocol_v1.reset_pin_uv_auth_token(env.rng());
         self.pin_protocol_v2.reset_pin_uv_auth_token(env.rng());
         Ok(())
@@ -301,28 +322,32 @@ impl ClientPin {
             permissions_rp_id,
             ..
         } = client_pin_params;
+        // TODO: Parse slot_id from params if multi-PIN feature is enabled.
+        let slot_id = 0;
         let key_agreement = ok_or_missing(key_agreement)?;
         let pin_hash_enc = ok_or_missing(pin_hash_enc)?;
         if permissions.is_some() || permissions_rp_id.is_some() {
             return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
         }
 
-        if storage::pin_retries(env)? == 0 {
+        if storage::pin_retries(env, slot_id)? == 0 {
             return Err(Ctap2StatusCode::CTAP2_ERR_PIN_BLOCKED);
         }
         let shared_secret = self.get_shared_secret(pin_uv_auth_protocol, key_agreement)?;
         self.verify_pin_hash_enc(
             env,
+            slot_id,
             pin_uv_auth_protocol,
             shared_secret.as_ref(),
             pin_hash_enc,
         )?;
-        if storage::has_force_pin_change(env)? {
+        if storage::has_force_pin_change(env, slot_id)? {
             return Err(Ctap2StatusCode::CTAP2_ERR_PIN_INVALID);
         }
 
         self.pin_protocol_v1.reset_pin_uv_auth_token(env.rng());
         self.pin_protocol_v2.reset_pin_uv_auth_token(env.rng());
+        // TODO: pass the slot_id parameter and store it in the state too.
         self.pin_uv_auth_token_state
             .begin_using_pin_uv_auth_token(now);
         self.pin_uv_auth_token_state.set_default_permissions();
@@ -391,7 +416,9 @@ impl ClientPin {
         now: CtapInstant,
     ) -> Result<ResponseData, Ctap2StatusCode> {
         let response = match client_pin_params.sub_command {
-            ClientPinSubCommand::GetPinRetries => Some(self.process_get_pin_retries(env)?),
+            ClientPinSubCommand::GetPinRetries => {
+                Some(self.process_get_pin_retries(env, client_pin_params)?)
+            }
             ClientPinSubCommand::GetKeyAgreement => {
                 Some(self.process_get_key_agreement(client_pin_params)?)
             }
@@ -446,7 +473,9 @@ impl ClientPin {
         self.pin_protocol_v1.reset_pin_uv_auth_token(rng);
         self.pin_protocol_v2.regenerate(rng);
         self.pin_protocol_v2.reset_pin_uv_auth_token(rng);
-        self.consecutive_pin_mismatches = 0;
+        for v in &mut self.consecutive_pin_mismatches {
+            *v = 0;
+        }
         self.pin_uv_auth_token_state.stop_using_pin_uv_auth_token();
     }
 
@@ -557,11 +586,11 @@ impl ClientPin {
 
     #[cfg(test)]
     pub fn new_test(
+        env: &mut impl Env,
         key_agreement_key: crypto::ecdh::SecKey,
         pin_uv_auth_token: [u8; PIN_TOKEN_LENGTH],
         pin_uv_auth_protocol: PinUvAuthProtocol,
     ) -> ClientPin {
-        let mut env = crate::env::test::TestEnv::new();
         let (key_agreement_key_v1, key_agreement_key_v2) = match pin_uv_auth_protocol {
             PinUvAuthProtocol::V1 => (key_agreement_key, crypto::ecdh::SecKey::gensk(env.rng())),
             PinUvAuthProtocol::V2 => (crypto::ecdh::SecKey::gensk(env.rng()), key_agreement_key),
@@ -572,7 +601,7 @@ impl ClientPin {
         ClientPin {
             pin_protocol_v1: PinProtocol::new_test(key_agreement_key_v1, pin_uv_auth_token),
             pin_protocol_v2: PinProtocol::new_test(key_agreement_key_v2, pin_uv_auth_token),
-            consecutive_pin_mismatches: 0,
+            consecutive_pin_mismatches: vec![0; env.customization().slot_count()],
             pin_uv_auth_token_state,
         }
     }
@@ -592,7 +621,7 @@ mod test {
         pin[..4].copy_from_slice(b"1234");
         let mut pin_hash = [0u8; 16];
         pin_hash.copy_from_slice(&Sha256::hash(&pin[..])[..16]);
-        storage::set_pin(env, &pin_hash, 4).unwrap();
+        storage::set_pin(env, 0, &pin_hash, 4).unwrap();
     }
 
     /// Fails on PINs bigger than 64 bytes.
@@ -618,8 +647,12 @@ mod test {
         let pk = key_agreement_key.genpk();
         let key_agreement = CoseKey::from(pk);
         let pin_uv_auth_token = [0x91; PIN_TOKEN_LENGTH];
-        let client_pin =
-            ClientPin::new_test(key_agreement_key, pin_uv_auth_token, pin_uv_auth_protocol);
+        let client_pin = ClientPin::new_test(
+            &mut env,
+            key_agreement_key,
+            pin_uv_auth_token,
+            pin_uv_auth_protocol,
+        );
         let shared_secret = client_pin
             .get_pin_protocol(pin_uv_auth_protocol)
             .decapsulate(key_agreement, pin_uv_auth_protocol)
@@ -677,7 +710,7 @@ mod test {
     #[test]
     fn test_mix_pin_protocols() {
         let mut env = TestEnv::new();
-        let client_pin = ClientPin::new(env.rng());
+        let client_pin = ClientPin::new(&mut env);
         let pin_protocol_v1 = client_pin.get_pin_protocol(PinUvAuthProtocol::V1);
         let pin_protocol_v2 = client_pin.get_pin_protocol(PinUvAuthProtocol::V2);
         let message = vec![0xAA; 16];
@@ -718,7 +751,7 @@ mod test {
 
     fn test_helper_verify_pin_hash_enc(pin_uv_auth_protocol: PinUvAuthProtocol) {
         let mut env = TestEnv::new();
-        let mut client_pin = ClientPin::new(env.rng());
+        let mut client_pin = ClientPin::new(&mut env);
         let pin_protocol = client_pin.get_pin_protocol(pin_uv_auth_protocol);
         let shared_secret = pin_protocol
             .decapsulate(pin_protocol.get_public_key(), pin_uv_auth_protocol)
@@ -728,7 +761,7 @@ mod test {
             0x01, 0xD9, 0x88, 0x40, 0x50, 0xBB, 0xD0, 0x7A, 0x23, 0x1A, 0xEB, 0x69, 0xD8, 0x36,
             0xC4, 0x12,
         ];
-        storage::set_pin(&mut env, &pin_hash, 4).unwrap();
+        storage::set_pin(&mut env, 0, &pin_hash, 4).unwrap();
 
         let pin_hash_enc = shared_secret
             .as_ref()
@@ -737,6 +770,7 @@ mod test {
         assert_eq!(
             client_pin.verify_pin_hash_enc(
                 &mut env,
+                0,
                 pin_uv_auth_protocol,
                 shared_secret.as_ref(),
                 pin_hash_enc
@@ -748,6 +782,7 @@ mod test {
         assert_eq!(
             client_pin.verify_pin_hash_enc(
                 &mut env,
+                0,
                 pin_uv_auth_protocol,
                 shared_secret.as_ref(),
                 pin_hash_enc
@@ -759,22 +794,24 @@ mod test {
             .as_ref()
             .encrypt(env.rng(), &pin_hash)
             .unwrap();
-        client_pin.consecutive_pin_mismatches = 3;
+        client_pin.consecutive_pin_mismatches[0] = 3;
         assert_eq!(
             client_pin.verify_pin_hash_enc(
                 &mut env,
+                0,
                 pin_uv_auth_protocol,
                 shared_secret.as_ref(),
                 pin_hash_enc
             ),
             Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_BLOCKED)
         );
-        client_pin.consecutive_pin_mismatches = 0;
+        client_pin.consecutive_pin_mismatches[0] = 0;
 
         let pin_hash_enc = vec![0x77; PIN_AUTH_LENGTH - 1];
         assert_eq!(
             client_pin.verify_pin_hash_enc(
                 &mut env,
+                0,
                 pin_uv_auth_protocol,
                 shared_secret.as_ref(),
                 pin_hash_enc
@@ -786,6 +823,7 @@ mod test {
         assert_eq!(
             client_pin.verify_pin_hash_enc(
                 &mut env,
+                0,
                 pin_uv_auth_protocol,
                 shared_secret.as_ref(),
                 pin_hash_enc
@@ -813,7 +851,7 @@ mod test {
         let expected_response = Some(AuthenticatorClientPinResponse {
             key_agreement: None,
             pin_uv_auth_token: None,
-            retries: Some(storage::pin_retries(&mut env).unwrap() as u64),
+            retries: Some(storage::pin_retries(&mut env, 0).unwrap() as u64),
             power_cycle_state: Some(false),
         });
         assert_eq!(
@@ -821,11 +859,11 @@ mod test {
             Ok(ResponseData::AuthenticatorClientPin(expected_response))
         );
 
-        client_pin.consecutive_pin_mismatches = 3;
+        client_pin.consecutive_pin_mismatches[0] = 3;
         let expected_response = Some(AuthenticatorClientPinResponse {
             key_agreement: None,
             pin_uv_auth_token: None,
-            retries: Some(storage::pin_retries(&mut env).unwrap() as u64),
+            retries: Some(storage::pin_retries(&mut env, 0).unwrap() as u64),
             power_cycle_state: Some(true),
         });
         assert_eq!(
@@ -921,8 +959,8 @@ mod test {
             Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
         );
 
-        while storage::pin_retries(&mut env).unwrap() > 0 {
-            storage::decr_pin_retries(&mut env).unwrap();
+        while storage::pin_retries(&mut env, 0).unwrap() > 0 {
+            storage::decr_pin_retries(&mut env, 0).unwrap();
         }
         assert_eq!(
             client_pin.process_command(&mut env, params, CtapInstant::new(0)),
@@ -1015,7 +1053,7 @@ mod test {
         let mut env = TestEnv::new();
         set_standard_pin(&mut env);
 
-        assert_eq!(storage::force_pin_change(&mut env), Ok(()));
+        assert_eq!(storage::force_pin_change(&mut env, 0), Ok(()));
         assert_eq!(
             client_pin.process_command(&mut env, params, CtapInstant::new(0)),
             Err(Ctap2StatusCode::CTAP2_ERR_PIN_INVALID),
@@ -1125,7 +1163,7 @@ mod test {
         let mut env = TestEnv::new();
         set_standard_pin(&mut env);
 
-        assert_eq!(storage::force_pin_change(&mut env), Ok(()));
+        assert_eq!(storage::force_pin_change(&mut env, 0), Ok(()));
         assert_eq!(
             client_pin.process_command(&mut env, params, CtapInstant::new(0)),
             Err(Ctap2StatusCode::CTAP2_ERR_PIN_INVALID)
@@ -1217,17 +1255,17 @@ mod test {
             ),
         ];
         for (pin, result) in test_cases {
-            let old_pin_hash = storage::pin_hash(&mut env).unwrap();
+            let old_pin_hash = storage::pin_hash(&mut env, 0).unwrap();
             let new_pin_enc = encrypt_pin(shared_secret.as_ref(), pin);
 
             assert_eq!(
-                check_and_store_new_pin(&mut env, shared_secret.as_ref(), new_pin_enc),
+                check_and_store_new_pin(&mut env, 0, shared_secret.as_ref(), new_pin_enc),
                 result
             );
             if result.is_ok() {
-                assert_ne!(old_pin_hash, storage::pin_hash(&mut env).unwrap());
+                assert_ne!(old_pin_hash, storage::pin_hash(&mut env, 0).unwrap());
             } else {
-                assert_eq!(old_pin_hash, storage::pin_hash(&mut env).unwrap());
+                assert_eq!(old_pin_hash, storage::pin_hash(&mut env, 0).unwrap());
             }
         }
     }
@@ -1383,7 +1421,7 @@ mod test {
     #[test]
     fn test_has_permission() {
         let mut env = TestEnv::new();
-        let mut client_pin = ClientPin::new(env.rng());
+        let mut client_pin = ClientPin::new(&mut env);
         client_pin.pin_uv_auth_token_state.set_permissions(0x7F);
         for permission in PinPermission::into_enum_iter() {
             assert_eq!(
@@ -1407,7 +1445,7 @@ mod test {
     #[test]
     fn test_has_no_rp_id_permission() {
         let mut env = TestEnv::new();
-        let mut client_pin = ClientPin::new(env.rng());
+        let mut client_pin = ClientPin::new(&mut env);
         assert_eq!(client_pin.has_no_rp_id_permission(), Ok(()));
         client_pin
             .pin_uv_auth_token_state
@@ -1421,7 +1459,7 @@ mod test {
     #[test]
     fn test_has_no_or_rp_id_permission() {
         let mut env = TestEnv::new();
-        let mut client_pin = ClientPin::new(env.rng());
+        let mut client_pin = ClientPin::new(&mut env);
         assert_eq!(client_pin.has_no_or_rp_id_permission("example.com"), Ok(()));
         client_pin
             .pin_uv_auth_token_state
@@ -1436,7 +1474,7 @@ mod test {
     #[test]
     fn test_has_no_or_rp_id_hash_permission() {
         let mut env = TestEnv::new();
-        let mut client_pin = ClientPin::new(env.rng());
+        let mut client_pin = ClientPin::new(&mut env);
         let rp_id_hash = Sha256::hash(b"example.com");
         assert_eq!(
             client_pin.has_no_or_rp_id_hash_permission(&rp_id_hash),
@@ -1458,7 +1496,7 @@ mod test {
     #[test]
     fn test_ensure_rp_id_permission() {
         let mut env = TestEnv::new();
-        let mut client_pin = ClientPin::new(env.rng());
+        let mut client_pin = ClientPin::new(&mut env);
         assert_eq!(client_pin.ensure_rp_id_permission("example.com"), Ok(()));
         assert_eq!(
             client_pin
@@ -1476,7 +1514,7 @@ mod test {
     #[test]
     fn test_verify_pin_uv_auth_token() {
         let mut env = TestEnv::new();
-        let mut client_pin = ClientPin::new(env.rng());
+        let mut client_pin = ClientPin::new(&mut env);
         let message = [0xAA];
         client_pin
             .pin_uv_auth_token_state
@@ -1550,7 +1588,7 @@ mod test {
     #[test]
     fn test_verify_pin_uv_auth_token_not_in_use() {
         let mut env = TestEnv::new();
-        let client_pin = ClientPin::new(env.rng());
+        let client_pin = ClientPin::new(&mut env);
         let message = [0xAA];
 
         let pin_uv_auth_token_v1 = client_pin
@@ -1572,7 +1610,7 @@ mod test {
     #[test]
     fn test_reset() {
         let mut env = TestEnv::new();
-        let mut client_pin = ClientPin::new(env.rng());
+        let mut client_pin = ClientPin::new(&mut env);
         let public_key_v1 = client_pin.pin_protocol_v1.get_public_key();
         let public_key_v2 = client_pin.pin_protocol_v2.get_public_key();
         let token_v1 = *client_pin.pin_protocol_v1.get_pin_uv_auth_token();

--- a/src/ctap/credential_management.rs
+++ b/src/ctap/credential_management.rs
@@ -392,14 +392,18 @@ mod test {
         let mut env = TestEnv::new();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
-        let client_pin =
-            ClientPin::new_test(key_agreement_key, pin_uv_auth_token, pin_uv_auth_protocol);
+        let client_pin = ClientPin::new_test(
+            &mut env,
+            key_agreement_key,
+            pin_uv_auth_token,
+            pin_uv_auth_protocol,
+        );
         let credential_source = create_credential_source(&mut env);
 
         let mut ctap_state = CtapState::new(&mut env, CtapInstant::new(0));
         ctap_state.client_pin = client_pin;
 
-        storage::set_pin(&mut env, &[0u8; 16], 4).unwrap();
+        storage::set_pin(&mut env, 0, &[0u8; 16], 4).unwrap();
         let management_data = vec![CredentialManagementSubCommand::GetCredsMetadata as u8];
         let pin_uv_auth_param = authenticate_pin_uv_auth_token(
             &pin_uv_auth_token,
@@ -474,8 +478,12 @@ mod test {
         let mut env = TestEnv::new();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
-        let client_pin =
-            ClientPin::new_test(key_agreement_key, pin_uv_auth_token, PinUvAuthProtocol::V1);
+        let client_pin = ClientPin::new_test(
+            &mut env,
+            key_agreement_key,
+            pin_uv_auth_token,
+            PinUvAuthProtocol::V1,
+        );
         let credential_source1 = create_credential_source(&mut env);
         let mut credential_source2 = create_credential_source(&mut env);
         credential_source2.rp_id = "another.example.com".to_string();
@@ -486,7 +494,7 @@ mod test {
         storage::store_credential(&mut env, credential_source1).unwrap();
         storage::store_credential(&mut env, credential_source2).unwrap();
 
-        storage::set_pin(&mut env, &[0u8; 16], 4).unwrap();
+        storage::set_pin(&mut env, 0, &[0u8; 16], 4).unwrap();
         let pin_uv_auth_param = Some(vec![
             0x1A, 0xA4, 0x96, 0xDA, 0x62, 0x80, 0x28, 0x13, 0xEB, 0x32, 0xB9, 0xF1, 0xD2, 0xA9,
             0xD0, 0xD1,
@@ -568,8 +576,12 @@ mod test {
         let mut env = TestEnv::new();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
-        let client_pin =
-            ClientPin::new_test(key_agreement_key, pin_uv_auth_token, PinUvAuthProtocol::V1);
+        let client_pin = ClientPin::new_test(
+            &mut env,
+            key_agreement_key,
+            pin_uv_auth_token,
+            PinUvAuthProtocol::V1,
+        );
         let credential_source = create_credential_source(&mut env);
 
         let mut ctap_state = CtapState::new(&mut env, CtapInstant::new(0));
@@ -582,7 +594,7 @@ mod test {
             storage::store_credential(&mut env, credential).unwrap();
         }
 
-        storage::set_pin(&mut env, &[0u8; 16], 4).unwrap();
+        storage::set_pin(&mut env, 0, &[0u8; 16], 4).unwrap();
         let pin_uv_auth_param = Some(vec![
             0x1A, 0xA4, 0x96, 0xDA, 0x62, 0x80, 0x28, 0x13, 0xEB, 0x32, 0xB9, 0xF1, 0xD2, 0xA9,
             0xD0, 0xD1,
@@ -649,8 +661,12 @@ mod test {
         let mut env = TestEnv::new();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
-        let client_pin =
-            ClientPin::new_test(key_agreement_key, pin_uv_auth_token, PinUvAuthProtocol::V1);
+        let client_pin = ClientPin::new_test(
+            &mut env,
+            key_agreement_key,
+            pin_uv_auth_token,
+            PinUvAuthProtocol::V1,
+        );
         let credential_source1 = create_credential_source(&mut env);
         let mut credential_source2 = create_credential_source(&mut env);
         credential_source2.user_handle = vec![0x02];
@@ -664,7 +680,7 @@ mod test {
         storage::store_credential(&mut env, credential_source1).unwrap();
         storage::store_credential(&mut env, credential_source2).unwrap();
 
-        storage::set_pin(&mut env, &[0u8; 16], 4).unwrap();
+        storage::set_pin(&mut env, 0, &[0u8; 16], 4).unwrap();
         let pin_uv_auth_param = Some(vec![
             0xF8, 0xB0, 0x3C, 0xC1, 0xD5, 0x58, 0x9C, 0xB7, 0x4D, 0x42, 0xA1, 0x64, 0x14, 0x28,
             0x2B, 0x68,
@@ -751,8 +767,12 @@ mod test {
         let mut env = TestEnv::new();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
-        let client_pin =
-            ClientPin::new_test(key_agreement_key, pin_uv_auth_token, PinUvAuthProtocol::V1);
+        let client_pin = ClientPin::new_test(
+            &mut env,
+            key_agreement_key,
+            pin_uv_auth_token,
+            PinUvAuthProtocol::V1,
+        );
         let mut credential_source = create_credential_source(&mut env);
         credential_source.credential_id = vec![0x1D; 32];
 
@@ -761,7 +781,7 @@ mod test {
 
         storage::store_credential(&mut env, credential_source).unwrap();
 
-        storage::set_pin(&mut env, &[0u8; 16], 4).unwrap();
+        storage::set_pin(&mut env, 0, &[0u8; 16], 4).unwrap();
         let pin_uv_auth_param = Some(vec![
             0xBD, 0xE3, 0xEF, 0x8A, 0x77, 0x01, 0xB1, 0x69, 0x19, 0xE6, 0x62, 0xB9, 0x9B, 0x89,
             0x9C, 0x64,
@@ -821,8 +841,12 @@ mod test {
         let mut env = TestEnv::new();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
-        let client_pin =
-            ClientPin::new_test(key_agreement_key, pin_uv_auth_token, PinUvAuthProtocol::V1);
+        let client_pin = ClientPin::new_test(
+            &mut env,
+            key_agreement_key,
+            pin_uv_auth_token,
+            PinUvAuthProtocol::V1,
+        );
         let mut credential_source = create_credential_source(&mut env);
         credential_source.credential_id = vec![0x1D; 32];
 
@@ -831,7 +855,7 @@ mod test {
 
         storage::store_credential(&mut env, credential_source).unwrap();
 
-        storage::set_pin(&mut env, &[0u8; 16], 4).unwrap();
+        storage::set_pin(&mut env, 0, &[0u8; 16], 4).unwrap();
         let pin_uv_auth_param = Some(vec![
             0xA5, 0x55, 0x8F, 0x03, 0xC3, 0xD3, 0x73, 0x1C, 0x07, 0xDA, 0x1F, 0x8C, 0xC7, 0xBD,
             0x9D, 0xB7,
@@ -889,7 +913,7 @@ mod test {
         let mut env = TestEnv::new();
         let mut ctap_state = CtapState::new(&mut env, CtapInstant::new(0));
 
-        storage::set_pin(&mut env, &[0u8; 16], 4).unwrap();
+        storage::set_pin(&mut env, 0, &[0u8; 16], 4).unwrap();
 
         let cred_management_params = AuthenticatorCredentialManagementParameters {
             sub_command: CredentialManagementSubCommand::GetCredsMetadata,

--- a/src/ctap/ctap1.rs
+++ b/src/ctap/ctap1.rs
@@ -320,11 +320,12 @@ impl Ctap1Command {
                 return Err(Ctap1StatusCode::SW_COND_USE_NOT_SATISFIED);
             }
             ctap_state
-                .increment_global_signature_counter(env)
+                .increment_global_signature_counter(env, 0)
                 .map_err(|_| Ctap1StatusCode::SW_WRONG_DATA)?;
             let mut signature_data = ctap_state
                 .generate_auth_data(
                     env,
+                    0,
                     &application,
                     Ctap1Command::USER_PRESENCE_INDICATOR_BYTE,
                 )
@@ -651,7 +652,7 @@ mod test {
             Ctap1Command::process_command(&mut env, &message, &mut ctap_state, CtapInstant::new(0))
                 .unwrap();
         assert_eq!(response[0], 0x01);
-        let global_signature_counter = storage::global_signature_counter(&mut env).unwrap();
+        let global_signature_counter = storage::global_signature_counter(&mut env, 0).unwrap();
         check_signature_counter(
             &mut env,
             array_ref!(response, 1, 4),
@@ -684,7 +685,7 @@ mod test {
         )
         .unwrap();
         assert_eq!(response[0], 0x01);
-        let global_signature_counter = storage::global_signature_counter(&mut env).unwrap();
+        let global_signature_counter = storage::global_signature_counter(&mut env, 0).unwrap();
         check_signature_counter(
             &mut env,
             array_ref!(response, 1, 4),

--- a/src/ctap/large_blobs.rs
+++ b/src/ctap/large_blobs.rs
@@ -87,7 +87,9 @@ impl LargeBlobs {
             if offset != self.expected_next_offset {
                 return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_SEQ);
             }
-            if storage::pin_hash(env)?.is_some() || storage::has_always_uv(env)? {
+            // TODO: Get the slot id from active token state when multi-PIN is enabled.
+            let slot_id = 0;
+            if storage::pin_hash(env, slot_id)?.is_some() || storage::has_always_uv(env)? {
                 let pin_uv_auth_param =
                     pin_uv_auth_param.ok_or(Ctap2StatusCode::CTAP2_ERR_PUAT_REQUIRED)?;
                 let pin_uv_auth_protocol =
@@ -147,8 +149,12 @@ mod test {
         let mut env = TestEnv::new();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
-        let mut client_pin =
-            ClientPin::new_test(key_agreement_key, pin_uv_auth_token, PinUvAuthProtocol::V1);
+        let mut client_pin = ClientPin::new_test(
+            &mut env,
+            key_agreement_key,
+            pin_uv_auth_token,
+            PinUvAuthProtocol::V1,
+        );
         let mut large_blobs = LargeBlobs::new();
 
         let large_blob = vec![
@@ -178,8 +184,12 @@ mod test {
         let mut env = TestEnv::new();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
-        let mut client_pin =
-            ClientPin::new_test(key_agreement_key, pin_uv_auth_token, PinUvAuthProtocol::V1);
+        let mut client_pin = ClientPin::new_test(
+            &mut env,
+            key_agreement_key,
+            pin_uv_auth_token,
+            PinUvAuthProtocol::V1,
+        );
         let mut large_blobs = LargeBlobs::new();
 
         const BLOB_LEN: usize = 200;
@@ -240,8 +250,12 @@ mod test {
         let mut env = TestEnv::new();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
-        let mut client_pin =
-            ClientPin::new_test(key_agreement_key, pin_uv_auth_token, PinUvAuthProtocol::V1);
+        let mut client_pin = ClientPin::new_test(
+            &mut env,
+            key_agreement_key,
+            pin_uv_auth_token,
+            PinUvAuthProtocol::V1,
+        );
         let mut large_blobs = LargeBlobs::new();
 
         const BLOB_LEN: usize = 200;
@@ -286,8 +300,12 @@ mod test {
         let mut env = TestEnv::new();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
-        let mut client_pin =
-            ClientPin::new_test(key_agreement_key, pin_uv_auth_token, PinUvAuthProtocol::V1);
+        let mut client_pin = ClientPin::new_test(
+            &mut env,
+            key_agreement_key,
+            pin_uv_auth_token,
+            PinUvAuthProtocol::V1,
+        );
         let mut large_blobs = LargeBlobs::new();
 
         const BLOB_LEN: usize = 200;
@@ -332,8 +350,12 @@ mod test {
         let mut env = TestEnv::new();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
-        let mut client_pin =
-            ClientPin::new_test(key_agreement_key, pin_uv_auth_token, PinUvAuthProtocol::V1);
+        let mut client_pin = ClientPin::new_test(
+            &mut env,
+            key_agreement_key,
+            pin_uv_auth_token,
+            PinUvAuthProtocol::V1,
+        );
         let mut large_blobs = LargeBlobs::new();
 
         let large_blobs_params = AuthenticatorLargeBlobsParameters {
@@ -355,8 +377,12 @@ mod test {
         let mut env = TestEnv::new();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
-        let mut client_pin =
-            ClientPin::new_test(key_agreement_key, pin_uv_auth_token, PinUvAuthProtocol::V1);
+        let mut client_pin = ClientPin::new_test(
+            &mut env,
+            key_agreement_key,
+            pin_uv_auth_token,
+            PinUvAuthProtocol::V1,
+        );
         let mut large_blobs = LargeBlobs::new();
 
         const BLOB_LEN: usize = 20;
@@ -383,8 +409,12 @@ mod test {
         let mut env = TestEnv::new();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
-        let mut client_pin =
-            ClientPin::new_test(key_agreement_key, pin_uv_auth_token, pin_uv_auth_protocol);
+        let mut client_pin = ClientPin::new_test(
+            &mut env,
+            key_agreement_key,
+            pin_uv_auth_token,
+            pin_uv_auth_protocol,
+        );
         let mut large_blobs = LargeBlobs::new();
 
         const BLOB_LEN: usize = 20;
@@ -392,7 +422,7 @@ mod test {
         let mut large_blob = vec![0x1B; DATA_LEN];
         large_blob.extend_from_slice(&Sha256::hash(&large_blob[..])[..TRUNCATED_HASH_LEN]);
 
-        storage::set_pin(&mut env, &[0u8; 16], 4).unwrap();
+        storage::set_pin(&mut env, 0, &[0u8; 16], 4).unwrap();
         let mut large_blob_data = vec![0xFF; 32];
         // Command constant and offset bytes.
         large_blob_data.extend(&[0x0C, 0x00, 0x00, 0x00, 0x00, 0x00]);

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -556,7 +556,12 @@ pub fn has_force_pin_change(env: &mut impl Env, slot_id: usize) -> Result<bool, 
 
 /// Marks the PIN as outdated with respect to the new PIN policy.
 pub fn force_pin_change(env: &mut impl Env, slot_id: usize) -> Result<(), Ctap2StatusCode> {
-    Ok(concat::write(env.store(), key::FORCE_PIN_CHANGE, slot_id as u8, &[])?)
+    Ok(concat::write(
+        env.store(),
+        key::FORCE_PIN_CHANGE,
+        slot_id as u8,
+        &[],
+    )?)
 }
 
 /// Returns whether enterprise attestation is enabled.

--- a/src/ctap/storage/key.rs
+++ b/src/ctap/storage/key.rs
@@ -73,34 +73,11 @@ make_partition! {
     // - When adding a (non-persistent) key below this message, make sure its value is bigger or
     //   equal than NUM_PERSISTENT_KEYS.
 
-    // Start of key arrays for multi-PIN feature: these fields are separated for each slots, so
-    // a unique key is needed for each slot. However, we reuse the existing fields and rename them
-    // to `FIRST_{KEY_NAME}` so the upgrade is backward compatible.
-    // Depending on `Customization::slot_count()`, only a prefix of those keys is used.
-
-    /// Whether the PIN needs to be changed for each slot, except the first.
-    ///
-    /// If this entry exists and is empty, the PIN needs to be changed.
-    FORCE_PIN_CHANGE = 972..978;
-
-    /// The number of PIN retries for each slot, except the first.
-    ///
-    /// Depending on `Customization::slot_count()`, only a prefix of those keys is used.
-    /// If the entry is absent, the number of PIN retries is `Customization::max_pin_retries()`.
-    PIN_RETRIES = 979..985;
-
     /// The PIN hash and length for each slot, except the first.
     ///
     /// If the entry is absent, there is no PIN set. The first byte represents
     /// the length, the following are an array with the hash.
-    PIN_PROPERTIES = 986..992;
-
-    /// The global signature counters for each slot, except the first.
-    ///
-    /// If the entry is absent, the counter is 0.
-    GLOBAL_SIGNATURE_COUNTER = 993..999;
-
-    // End of key arrays for multi-PIN feature.
+    PIN_PROPERTIES = 993..1000;
 
     /// Reserved for future credential-related objects.
     ///
@@ -126,8 +103,13 @@ make_partition! {
     /// If this entry exists and is empty, enterprise attestation is enabled.
     ENTERPRISE_ATTESTATION = 2039;
 
-    /// If this entry exists and is empty, the PIN needs to be changed.
-    FIRST_FORCE_PIN_CHANGE = 2040;
+    /// Whether the PIN needs to be changed for each slot.
+    ///
+    /// The PIN at slot 0 needs to be changed if this entry exists and is empty,
+    /// for backward compatibility.
+    /// The PIN at slot x (including 0) needs to be changed if the xth element
+    /// in this entry is non-zero.
+    FORCE_PIN_CHANGE = 2040;
 
     /// The secret of the CredRandom feature.
     CRED_RANDOM_SECRET = 2041;
@@ -143,7 +125,8 @@ make_partition! {
     /// The number of PIN retries.
     ///
     /// If the entry is absent, the number of PIN retries is `Customization::max_pin_retries()`.
-    FIRST_PIN_RETRIES = 2044;
+    /// Otherwise, the number of PIN retries at slot x is the xth element in this entry.
+    PIN_RETRIES = 2044;
 
     /// The PIN hash and length.
     ///
@@ -154,10 +137,10 @@ make_partition! {
     /// Reserved for the key store implementation of the environment.
     _RESERVED_KEY_STORE = 2046;
 
-    /// The global signature counter.
+    /// The global signature counters for each slot, except the first.
     ///
     /// If the entry is absent, the counter is 0.
-    FIRST_GLOBAL_SIGNATURE_COUNTER = 2047;
+    GLOBAL_SIGNATURE_COUNTER = 2047;
 }
 
 #[cfg(test)]

--- a/src/ctap/storage/key.rs
+++ b/src/ctap/storage/key.rs
@@ -78,6 +78,11 @@ make_partition! {
     // to `FIRST_{KEY_NAME}` so the upgrade is backward compatible.
     // Depending on `Customization::slot_count()`, only a prefix of those keys is used.
 
+    /// Whether the PIN needs to be changed each slot.
+    ///
+    /// The PIN needs to be changed if the slot exists and its data is empty.
+    FORCE_PIN_CHANGE = 984;
+
     /// The number of PIN retries for each slot, except the first.
     PIN_RETRIES = 985..992;
 
@@ -118,13 +123,10 @@ make_partition! {
     /// If this entry exists and is empty, enterprise attestation is enabled.
     ENTERPRISE_ATTESTATION = 2039;
 
-    /// Whether the PIN needs to be changed for each slot.
+    /// Whether the PIN needs to be changed for the first slot.
     ///
-    /// The PIN at slot 0 needs to be changed if this entry exists and is empty,
-    /// for backward compatibility.
-    /// The PIN at slot x (including 0) needs to be changed if the xth element
-    /// in this entry is non-zero.
-    FORCE_PIN_CHANGE = 2040;
+    /// The PIN needs to be changed if this entry exists and is empty.
+    FIRST_FORCE_PIN_CHANGE = 2040;
 
     /// The secret of the CredRandom feature.
     CRED_RANDOM_SECRET = 2041;
@@ -137,7 +139,7 @@ make_partition! {
     /// If the entry is absent, the minimum PIN length is `Customization::default_min_pin_length()`.
     MIN_PIN_LENGTH = 2043;
 
-    /// The number of PIN retries.
+    /// The number of PIN retries for the first slot.
     ///
     /// If the entry is absent, the number of PIN retries is `Customization::max_pin_retries()`.
     FIRST_PIN_RETRIES = 2044;
@@ -151,7 +153,7 @@ make_partition! {
     /// Reserved for the key store implementation of the environment.
     _RESERVED_KEY_STORE = 2046;
 
-    /// The global signature counter.
+    /// The global signature counter for the first slot.
     FIRST_GLOBAL_SIGNATURE_COUNTER = 2047;
 }
 

--- a/src/ctap/storage/key.rs
+++ b/src/ctap/storage/key.rs
@@ -73,6 +73,35 @@ make_partition! {
     // - When adding a (non-persistent) key below this message, make sure its value is bigger or
     //   equal than NUM_PERSISTENT_KEYS.
 
+    // Start of key arrays for multi-PIN feature: these fields are separated for each slots, so
+    // a unique key is needed for each slot. However, we reuse the existing fields and rename them
+    // to `FIRST_{KEY_NAME}` so the upgrade is backward compatible.
+    // Depending on `Customization::slot_count()`, only a prefix of those keys is used.
+
+    /// Whether the PIN needs to be changed for each slot, except the first.
+    ///
+    /// If this entry exists and is empty, the PIN needs to be changed.
+    FORCE_PIN_CHANGE = 972..978;
+
+    /// The number of PIN retries for each slot, except the first.
+    ///
+    /// Depending on `Customization::slot_count()`, only a prefix of those keys is used.
+    /// If the entry is absent, the number of PIN retries is `Customization::max_pin_retries()`.
+    PIN_RETRIES = 979..985;
+
+    /// The PIN hash and length for each slot, except the first.
+    ///
+    /// If the entry is absent, there is no PIN set. The first byte represents
+    /// the length, the following are an array with the hash.
+    PIN_PROPERTIES = 986..992;
+
+    /// The global signature counters for each slot, except the first.
+    ///
+    /// If the entry is absent, the counter is 0.
+    GLOBAL_SIGNATURE_COUNTER = 993..999;
+
+    // End of key arrays for multi-PIN feature.
+
     /// Reserved for future credential-related objects.
     ///
     /// In particular, additional credentials could be added there by reducing the lower bound of
@@ -98,7 +127,7 @@ make_partition! {
     ENTERPRISE_ATTESTATION = 2039;
 
     /// If this entry exists and is empty, the PIN needs to be changed.
-    FORCE_PIN_CHANGE = 2040;
+    FIRST_FORCE_PIN_CHANGE = 2040;
 
     /// The secret of the CredRandom feature.
     CRED_RANDOM_SECRET = 2041;
@@ -114,13 +143,13 @@ make_partition! {
     /// The number of PIN retries.
     ///
     /// If the entry is absent, the number of PIN retries is `Customization::max_pin_retries()`.
-    PIN_RETRIES = 2044;
+    FIRST_PIN_RETRIES = 2044;
 
     /// The PIN hash and length.
     ///
     /// If the entry is absent, there is no PIN set. The first byte represents
     /// the length, the following are an array with the hash.
-    PIN_PROPERTIES = 2045;
+    FIRST_PIN_PROPERTIES = 2045;
 
     /// Reserved for the key store implementation of the environment.
     _RESERVED_KEY_STORE = 2046;
@@ -128,7 +157,7 @@ make_partition! {
     /// The global signature counter.
     ///
     /// If the entry is absent, the counter is 0.
-    GLOBAL_SIGNATURE_COUNTER = 2047;
+    FIRST_GLOBAL_SIGNATURE_COUNTER = 2047;
 }
 
 #[cfg(test)]

--- a/src/ctap/storage/key.rs
+++ b/src/ctap/storage/key.rs
@@ -73,11 +73,26 @@ make_partition! {
     // - When adding a (non-persistent) key below this message, make sure its value is bigger or
     //   equal than NUM_PERSISTENT_KEYS.
 
+    // Start of key arrays for multi-PIN feature: these fields are separated for each slots, so
+    // a unique key is needed for each slot. However, we reuse the existing fields and rename them
+    // to `FIRST_{KEY_NAME}` so the upgrade is backward compatible.
+    // Depending on `Customization::slot_count()`, only a prefix of those keys is used.
+
+    /// The number of PIN retries for each slot, except the first.
+    PIN_RETRIES = 979..986;
+
     /// The PIN hash and length for each slot, except the first.
     ///
     /// If the entry is absent, there is no PIN set. The first byte represents
     /// the length, the following are an array with the hash.
-    PIN_PROPERTIES = 993..1000;
+    PIN_PROPERTIES = 986..993;
+
+    /// The global signature counters for each slot, except the first.
+    ///
+    /// If the entry is absent, the counter is 0.
+    GLOBAL_SIGNATURE_COUNTER = 993..1000;
+
+    // End of key arrays for multi-PIN feature.
 
     /// Reserved for future credential-related objects.
     ///
@@ -125,8 +140,7 @@ make_partition! {
     /// The number of PIN retries.
     ///
     /// If the entry is absent, the number of PIN retries is `Customization::max_pin_retries()`.
-    /// Otherwise, the number of PIN retries at slot x is the xth element in this entry.
-    PIN_RETRIES = 2044;
+    FIRST_PIN_RETRIES = 2044;
 
     /// The PIN hash and length.
     ///
@@ -137,10 +151,8 @@ make_partition! {
     /// Reserved for the key store implementation of the environment.
     _RESERVED_KEY_STORE = 2046;
 
-    /// The global signature counters for each slot, except the first.
-    ///
-    /// If the entry is absent, the counter is 0.
-    GLOBAL_SIGNATURE_COUNTER = 2047;
+    /// The global signature counter.
+    FIRST_GLOBAL_SIGNATURE_COUNTER = 2047;
 }
 
 #[cfg(test)]

--- a/src/ctap/storage/key.rs
+++ b/src/ctap/storage/key.rs
@@ -79,13 +79,13 @@ make_partition! {
     // Depending on `Customization::slot_count()`, only a prefix of those keys is used.
 
     /// The number of PIN retries for each slot, except the first.
-    PIN_RETRIES = 979..986;
+    PIN_RETRIES = 985..992;
 
-    /// The PIN hash and length for each slot, except the first.
+    /// The PIN hash and length for each slot.
     ///
-    /// If the entry is absent, there is no PIN set. The first byte represents
+    /// If a slot is absent, there is no PIN set for that slot. The first byte represents
     /// the length, the following are an array with the hash.
-    PIN_PROPERTIES = 986..993;
+    PIN_PROPERTIES = 992;
 
     /// The global signature counters for each slot, except the first.
     ///
@@ -142,7 +142,7 @@ make_partition! {
     /// If the entry is absent, the number of PIN retries is `Customization::max_pin_retries()`.
     FIRST_PIN_RETRIES = 2044;
 
-    /// The PIN hash and length.
+    /// The PIN hash and length for the first slot.
     ///
     /// If the entry is absent, there is no PIN set. The first byte represents
     /// the length, the following are an array with the hash.

--- a/src/env/test/customization.rs
+++ b/src/env/test/customization.rs
@@ -33,6 +33,7 @@ pub struct TestCustomization {
     max_large_blob_array_size: usize,
     max_rp_ids_length: usize,
     max_supported_resident_keys: usize,
+    slot_count: usize,
 }
 
 impl TestCustomization {
@@ -112,6 +113,10 @@ impl Customization for TestCustomization {
     fn max_supported_resident_keys(&self) -> usize {
         self.max_supported_resident_keys
     }
+
+    fn slot_count(&self) -> usize {
+        self.slot_count
+    }
 }
 
 impl From<CustomizationImpl> for TestCustomization {
@@ -132,6 +137,7 @@ impl From<CustomizationImpl> for TestCustomization {
             max_large_blob_array_size,
             max_rp_ids_length,
             max_supported_resident_keys,
+            slot_count,
         } = c;
 
         let default_min_pin_length_rp_ids = default_min_pin_length_rp_ids
@@ -160,6 +166,7 @@ impl From<CustomizationImpl> for TestCustomization {
             max_large_blob_array_size,
             max_rp_ids_length,
             max_supported_resident_keys,
+            slot_count,
         }
     }
 }


### PR DESCRIPTION
- Reserve the storage keys for maximum of 8 user slots.
- Modify the storage functions to take a slot_id parameter.
- Add the slot_count() customization.
- Assume slot_id as a parameter when needed except these places:
  - Entrance functions of command processing that directly takes the
    command parameter structure. slot_id is set as 0, and will be
    parsed from the parameters when we enable the feature.
  - MakeCredential/GetAssertion/AuthenticatorConfig will take the
    slot_id from active token state when we enable the feature,
    resulting in an `Option<usize>`. Below code will act on the option
    value correctly. When the feature isn't enabled, we're always
    referring to the only PIN slot so set slot_id as Some(0).
  - GetInfo returns verdict of whether PIN is supported and enabled, and
    whether PIN needs to be forced changed. There will be new fields to
    represent those values when the feature is enabled, and the old
    fields will not be populated. So when the feature isn't enabled, we
    can treat slot_id as 0.

Not covered in this commit:
- Unittests for other slots. The existing tests all pass and I plan to
  add unittests for multi-slot case after the codebase allows enabling
  the feature.
- Persisting and checking the slot_id in credentials. This is planned to
  come in the next commit.