### PR TITLE
Tool fixes

### DIFF
--- a/tools/configure.py
+++ b/tools/configure.py
@@ -169,7 +169,7 @@ def main(args):
             ("Failed to configure OpenSK (device is partially programmed but "
              "the given cert/key don't match the ones currently programmed)."))
       else:
-        error(f"Failed to configure OpenSK (unknown error: {ex}")
+        error(f"Failed to configure OpenSK (unknown error: {ex})")
   return responses
 
 

--- a/tools/deploy_partition.py
+++ b/tools/deploy_partition.py
@@ -150,8 +150,8 @@ def load_priv_key(priv_key_filename: str) -> Any:
         fatal("Private key must be 256 bits long.")
       info("Private key is valid.")
       return priv_key
-  except IOError:
-    fatal(f"Unable to open file: {priv_key_filename}")
+  except IOError as e:
+    fatal(f"Unable to open file: {priv_key_filename}\n{e}")
 
 
 def sign_firmware(data: bytes, priv_key: Any) -> bytes:

--- a/tools/deploy_partition.py
+++ b/tools/deploy_partition.py
@@ -97,7 +97,7 @@ def check_info(partition_address: int, authenticator: Any):
     if result[0x01] != partition_address:
       fatal("Identifiers do not match.")
   except ctap.CtapError as ex:
-    fatal(f"Failed to read OpenSK upgrade info (error: {ex}")
+    fatal(f"Failed to read OpenSK upgrade info (error: {ex})")
 
 
 def get_kernel(board: str) -> bytes:
@@ -139,16 +139,19 @@ def generate_firmware_image(board: str) -> bytes:
 
 def load_priv_key(priv_key_filename: str) -> Any:
   """Loads the ECDSA private key from the specified file."""
-  with open(priv_key_filename, "rb") as priv_key_file:
-    priv_key = get_private_key(priv_key_file.read())
-    if not isinstance(priv_key, ec.EllipticCurvePrivateKey):
-      fatal("Private key must be an Elliptic Curve one.")
-    if not isinstance(priv_key.curve, ec.SECP256R1):
-      fatal("Private key must use Secp256r1 curve.")
-    if priv_key.key_size != 256:
-      fatal("Private key must be 256 bits long.")
-    info("Private key is valid.")
-    return priv_key
+  try:
+    with open(priv_key_filename, "rb") as priv_key_file:
+      priv_key = get_private_key(priv_key_file.read())
+      if not isinstance(priv_key, ec.EllipticCurvePrivateKey):
+        fatal("Private key must be an Elliptic Curve one.")
+      if not isinstance(priv_key.curve, ec.SECP256R1):
+        fatal("Private key must use Secp256r1 curve.")
+      if priv_key.key_size != 256:
+        fatal("Private key must be 256 bits long.")
+      info("Private key is valid.")
+      return priv_key
+  except:
+    fatal(f"Unable to open file: {priv_key_filename}")
 
 
 def sign_firmware(data: bytes, priv_key: Any) -> bytes:
@@ -160,8 +163,6 @@ def sign_firmware(data: bytes, priv_key: Any) -> bytes:
 
 def main(args):
   colorama.init()
-  if not args.priv_key:
-    fatal("Please pass in a private key file using --private-key.")
 
   firmware_image = generate_firmware_image(args.board)
   partition_address = PARTITION_ADDRESS[args.board]

--- a/tools/deploy_partition.py
+++ b/tools/deploy_partition.py
@@ -97,7 +97,7 @@ def check_info(partition_address: int, authenticator: Any):
     if result[0x01] != partition_address:
       fatal("Identifiers do not match.")
   except ctap.CtapError as ex:
-    error(f"Failed to read OpenSK upgrade info (error: {ex}")
+    fatal(f"Failed to read OpenSK upgrade info (error: {ex}")
 
 
 def get_kernel(board: str) -> bytes:
@@ -137,17 +137,18 @@ def generate_firmware_image(board: str) -> bytes:
   return pad_to(kernel, KERNEL_SIZE) + pad_to(app, APP_SIZE)
 
 
-def load_priv_key(priv_key_file: argparse.FileType) -> Any:
+def load_priv_key(priv_key_filename: str) -> Any:
   """Loads the ECDSA private key from the specified file."""
-  priv_key = get_private_key(priv_key_file.read())
-  if not isinstance(priv_key, ec.EllipticCurvePrivateKey):
-    fatal("Private key must be an Elliptic Curve one.")
-  if not isinstance(priv_key.curve, ec.SECP256R1):
-    fatal("Private key must use Secp256r1 curve.")
-  if priv_key.key_size != 256:
-    fatal("Private key must be 256 bits long.")
-  info("Private key is valid.")
-  return priv_key
+  with open(priv_key_filename, "rb") as priv_key_file:
+    priv_key = get_private_key(priv_key_file.read())
+    if not isinstance(priv_key, ec.EllipticCurvePrivateKey):
+      fatal("Private key must be an Elliptic Curve one.")
+    if not isinstance(priv_key.curve, ec.SECP256R1):
+      fatal("Private key must use Secp256r1 curve.")
+    if priv_key.key_size != 256:
+      fatal("Private key must be 256 bits long.")
+    info("Private key is valid.")
+    return priv_key
 
 
 def sign_firmware(data: bytes, priv_key: Any) -> bytes:
@@ -159,6 +160,8 @@ def sign_firmware(data: bytes, priv_key: Any) -> bytes:
 
 def main(args):
   colorama.init()
+  if not args.priv_key:
+    fatal("Please pass in a private key file using --private-key.")
 
   firmware_image = generate_firmware_image(args.board)
   partition_address = PARTITION_ADDRESS[args.board]
@@ -213,14 +216,14 @@ def main(args):
         error(f"{message} (unsupported command).")
       elif ex.code.value == ctap.CtapError.ERR.INVALID_PARAMETER:
         error(f"{message} (invalid parameter, maybe a wrong byte array size?).")
-      elif ex.code.value == ctap.CtapError.ERR_INTEGRITY_FAILURE:
+      elif ex.code.value == ctap.CtapError.ERR.INTEGRITY_FAILURE:
         error(f"{message} (hashes or signature don't match).")
       elif ex.code.value == 0xF2:  # VENDOR_INTERNAL_ERROR
         error(f"{message} (internal conditions not met).")
       elif ex.code.value == 0xF3:  # VENDOR_HARDWARE_FAILURE
         error(f"{message} (internal hardware error).")
       else:
-        error(f"{message} (unexpected error: {ex}")
+        error(f"{message} (unexpected error: {ex})")
 
 
 if __name__ == "__main__":
@@ -247,7 +250,7 @@ if __name__ == "__main__":
   )
   parser.add_argument(
       "--private-key",
-      type=argparse.FileType("rb"),
+      type=str,
       default="crypto_data/opensk_upgrade.key",
       dest="priv_key",
       help=("PEM file for signing the firmware."),

--- a/tools/deploy_partition.py
+++ b/tools/deploy_partition.py
@@ -150,7 +150,7 @@ def load_priv_key(priv_key_filename: str) -> Any:
         fatal("Private key must be 256 bits long.")
       info("Private key is valid.")
       return priv_key
-  except:
+  except IOError:
     fatal(f"Unable to open file: {priv_key_filename}")
 
 


### PR DESCRIPTION
Fixes some issues in our Python scripts.

`load_priv_key` takes a string to make it easier to import and reuse this function. The argparse `FileType` has a few limitations, i.e. it is harder to make it optional.