### PR TITLE
Storage type

### DIFF
--- a/boards/nordic/nrf52840_dongle_opensk/src/main.rs
+++ b/boards/nordic/nrf52840_dongle_opensk/src/main.rs
@@ -69,12 +69,12 @@ static mut STORAGE_LOCATIONS: [kernel::StorageLocation; 2] = [
     kernel::StorageLocation {
         address: 0xC0000,
         size: 0x10000, // 16 pages
-        storage_type: kernel::StorageType::STORE,
+        storage_type: kernel::StorageType::Store,
     },
     kernel::StorageLocation {
         address: 0xD0000,
         size: 0x4000, // 4 pages
-        storage_type: kernel::StorageType::STORE,
+        storage_type: kernel::StorageType::Store,
     },
 ];
 

--- a/boards/nordic/nrf52840_mdk_dfu/src/main.rs
+++ b/boards/nordic/nrf52840_mdk_dfu/src/main.rs
@@ -63,12 +63,12 @@ static mut STORAGE_LOCATIONS: [kernel::StorageLocation; 2] = [
     kernel::StorageLocation {
         address: 0xC0000,
         size: 0x10000, // 16 pages
-        storage_type: kernel::StorageType::STORE,
+        storage_type: kernel::StorageType::Store,
     },
     kernel::StorageLocation {
         address: 0xD0000,
         size: 0x4000, // 4 pages
-        storage_type: kernel::StorageType::STORE,
+        storage_type: kernel::StorageType::Store,
     },
 ];
 

--- a/boards/nordic/nrf52840dk_opensk/build.rs
+++ b/boards/nordic/nrf52840dk_opensk/build.rs
@@ -16,12 +16,12 @@ static mut STORAGE_LOCATIONS: [kernel::StorageLocation; 2] = [
     kernel::StorageLocation {
         address: 0xC0000,
         size: 0x10000, // 16 pages
-        storage_type: kernel::StorageType::STORE,
+        storage_type: kernel::StorageType::Store,
     },
     kernel::StorageLocation {
         address: 0xD0000,
         size: 0x4000, // 4 pages
-        storage_type: kernel::StorageType::STORE,
+        storage_type: kernel::StorageType::Store,
     },
 ];
 "

--- a/boards/nordic/nrf52840dk_opensk_a/build.rs
+++ b/boards/nordic/nrf52840dk_opensk_a/build.rs
@@ -16,28 +16,28 @@ static mut STORAGE_LOCATIONS: [kernel::StorageLocation; 5] = [
     kernel::StorageLocation {
         address: 0xC0000,
         size: 0x10000, // 16 pages
-        storage_type: kernel::StorageType::STORE,
+        storage_type: kernel::StorageType::Store,
     },
     kernel::StorageLocation {
         address: 0xD0000,
         size: 0x4000, // 4 pages
-        storage_type: kernel::StorageType::STORE,
+        storage_type: kernel::StorageType::Store,
     },
     // Partitions can also be split to maximize MPU happiness.
     kernel::StorageLocation {
+        address: 0x5000,
+        size: 0x1000,
+        storage_type: kernel::StorageType::Partition,
+    },
+    kernel::StorageLocation {
         address: 0x60000,
         size: 0x20000,
-        storage_type: kernel::StorageType::PARTITION,
+        storage_type: kernel::StorageType::Partition,
     },
     kernel::StorageLocation {
         address: 0x80000,
         size: 0x20000,
-        storage_type: kernel::StorageType::PARTITION,
-    },
-    kernel::StorageLocation {
-        address: 0x5000,
-        size: 0x1000,
-        storage_type: kernel::StorageType::METADATA,
+        storage_type: kernel::StorageType::Partition,
     },
 ];
 "

--- a/boards/nordic/nrf52840dk_opensk_b/build.rs
+++ b/boards/nordic/nrf52840dk_opensk_b/build.rs
@@ -16,28 +16,28 @@ static mut STORAGE_LOCATIONS: [kernel::StorageLocation; 5] = [
     kernel::StorageLocation {
         address: 0xC0000,
         size: 0x10000, // 16 pages
-        storage_type: kernel::StorageType::STORE,
+        storage_type: kernel::StorageType::Store,
     },
     kernel::StorageLocation {
         address: 0xD0000,
         size: 0x4000, // 4 pages
-        storage_type: kernel::StorageType::STORE,
+        storage_type: kernel::StorageType::Store,
     },
     // Partitions can also be split to maximize MPU happiness.
     kernel::StorageLocation {
+        address: 0x4000,
+        size: 0x1000,
+        storage_type: kernel::StorageType::Partition,
+    },
+    kernel::StorageLocation {
         address: 0x20000,
         size: 0x20000,
-        storage_type: kernel::StorageType::PARTITION,
+        storage_type: kernel::StorageType::Partition,
     },
     kernel::StorageLocation {
         address: 0x40000,
         size: 0x20000,
-        storage_type: kernel::StorageType::PARTITION,
-    },
-    kernel::StorageLocation {
-        address: 0x4000,
-        size: 0x1000,
-        storage_type: kernel::StorageType::METADATA,
+        storage_type: kernel::StorageType::Partition,
     },
 ];
 "

--- a/patches/tock/06-upgrade-partitions.patch
+++ b/patches/tock/06-upgrade-partitions.patch
@@ -31,19 +31,18 @@ index 5465c95f4..e596648f7 100644
      }
  }
 diff --git a/kernel/src/sched.rs b/kernel/src/sched.rs
-index 8844bc6c3..692bad2d3 100644
+index 8844bc6c3..00c13a7c6 100644
 --- a/kernel/src/sched.rs
 +++ b/kernel/src/sched.rs
-@@ -118,10 +118,19 @@ pub enum SchedulingDecision {
+@@ -118,10 +118,18 @@ pub enum SchedulingDecision {
      TrySleep,
  }
  
 +/// Represents the type of a storage slice.
 +#[derive(Copy, Clone)]
 +pub enum StorageType {
-+    STORE = 1,
-+    PARTITION = 2,
-+    METADATA = 3,
++    Store = 1,
++    Partition = 2,
 +}
 +
  /// Represents a storage location in flash.

--- a/patches/tock/09-add-vendor-hid-usb-interface.patch
+++ b/patches/tock/09-add-vendor-hid-usb-interface.patch
@@ -156,7 +156,7 @@ index f7899d8c5..6956523c6 100644
                          hil::usb::CtrlSetupResult::ErrGeneric
                      }
 diff --git a/capsules/src/usb/usbc_ctap_hid.rs b/capsules/src/usb/usbc_ctap_hid.rs
-index 642039120..adb7fde14 100644
+index 642039120..abf224f97 100644
 --- a/capsules/src/usb/usbc_ctap_hid.rs
 +++ b/capsules/src/usb/usbc_ctap_hid.rs
 @@ -44,21 +44,59 @@ static CTAP_REPORT_DESCRIPTOR: &'static [u8] = &[

--- a/patches/tock/10-avoid-app-reentry.patch
+++ b/patches/tock/10-avoid-app-reentry.patch
@@ -262,7 +262,7 @@ index da3d16d85..e8f1a87a4 100644
                                  if !app.waiting {
                                      // The call to receive_packet() collected a pending packet.
 diff --git a/capsules/src/usb/usbc_ctap_hid.rs b/capsules/src/usb/usbc_ctap_hid.rs
-index adb7fde14..f6762b4b9 100644
+index abf224f97..d47e5f644 100644
 --- a/capsules/src/usb/usbc_ctap_hid.rs
 +++ b/capsules/src/usb/usbc_ctap_hid.rs
 @@ -11,6 +11,7 @@ use super::descriptors::HIDSubordinateDescriptor;

--- a/patches/tock/11-connect-vendor-hid-usb-interface.patch
+++ b/patches/tock/11-connect-vendor-hid-usb-interface.patch
@@ -108,7 +108,7 @@ index e8f1a87a4..2c91c0968 100644
                              } else {
                                  // Cannot cancel now because the transaction is already in process.
 diff --git a/capsules/src/usb/usbc_ctap_hid.rs b/capsules/src/usb/usbc_ctap_hid.rs
-index f6762b4b9..16b80cb10 100644
+index d47e5f644..76f6af73b 100644
 --- a/capsules/src/usb/usbc_ctap_hid.rs
 +++ b/capsules/src/usb/usbc_ctap_hid.rs
 @@ -18,13 +18,27 @@ use core::cell::Cell;


### PR DESCRIPTION
First part of the upgrade rework.

The StorageType variant names are properly capitalized. Metadata is removed, as it will merge into the partition in the following PRs. To maintain functionality, we manually detect which partition is metadata and keep the rest of the logic as is.