### PR TITLE
New metadata format

### DIFF
--- a/bootloader/src/main.rs
+++ b/bootloader/src/main.rs
@@ -48,12 +48,9 @@ unsafe fn read_page(address: usize) -> Page {
 /// Parsed metadata for a firmware partition.
 struct Metadata {
     checksum: [u8; 32],
-    timestamp: u32,
+    _signature: [u8; 64],
+    version: u64,
     address: u32,
-}
-
-impl Metadata {
-    pub const DATA_LEN: usize = 40;
 }
 
 /// Reads the metadata from a flash page.
@@ -61,8 +58,9 @@ impl From<Page> for Metadata {
     fn from(page: Page) -> Self {
         Metadata {
             checksum: page[0..32].try_into().unwrap(),
-            timestamp: LittleEndian::read_u32(&page[32..36]),
-            address: LittleEndian::read_u32(&page[36..Metadata::DATA_LEN]),
+            _signature: page[32..96].try_into().unwrap(),
+            version: LittleEndian::read_u64(&page[140..][..8]),
+            address: LittleEndian::read_u32(&page[148..][..4]),
         }
     }
 }
@@ -77,14 +75,14 @@ impl BootPartition {
     const FIRMWARE_LENGTH: usize = 0x00040000;
 
     /// Reads the metadata, returns the timestamp if all checks pass.
-    pub fn read_timestamp(&self) -> Result<u32, ()> {
+    pub fn read_version(&self) -> Result<u64, ()> {
         let metadata_page = unsafe { read_page(self.metadata_address) };
         let hash_value = self.compute_upgrade_hash(&metadata_page);
         let metadata = Metadata::from(metadata_page);
         if self.firmware_address != metadata.address as usize {
             #[cfg(debug_assertions)]
             rprintln!(
-                "Firmware address mismatch: expected 0x{:08X}, metadata 0x{:08X}",
+                "Partition address mismatch: expected 0x{:08X}, metadata 0x{:08X}",
                 self.firmware_address,
                 metadata.address as usize
             );
@@ -95,7 +93,7 @@ impl BootPartition {
             rprintln!("Hash mismatch");
             return Err(());
         }
-        Ok(metadata.timestamp)
+        Ok(metadata.version)
     }
 
     /// Computes the SHA256 of metadata information and partition data.
@@ -107,11 +105,14 @@ impl BootPartition {
         debug_assert!(self.firmware_address % PAGE_SIZE == 0);
         debug_assert!(BootPartition::FIRMWARE_LENGTH % PAGE_SIZE == 0);
         let cc310 = crypto_cell::CryptoCell310::new();
+        cc310.update(&metadata_page[128..], false);
         for page_offset in (0..BootPartition::FIRMWARE_LENGTH).step_by(PAGE_SIZE) {
             let page = unsafe { read_page(self.firmware_address + page_offset) };
-            cc310.update(&page, false);
+            cc310.update(
+                &page,
+                page_offset + PAGE_SIZE == BootPartition::FIRMWARE_LENGTH,
+            );
         }
-        cc310.update(&metadata_page[32..Metadata::DATA_LEN], true);
         cc310.finalize_and_clear()
     }
 
@@ -156,12 +157,12 @@ fn main() -> ! {
     };
     #[cfg(debug_assertions)]
     rprintln!("Reading partition A");
-    let timestamp_a = partition_a.read_timestamp();
+    let version_a = partition_a.read_version();
     #[cfg(debug_assertions)]
     rprintln!("Reading partition B");
-    let timestamp_b = partition_b.read_timestamp();
+    let version_b = partition_b.read_version();
 
-    match (timestamp_a, timestamp_b) {
+    match (version_a, version_b) {
         (Ok(t1), Ok(t2)) => {
             if t1 >= t2 {
                 partition_a.boot()

--- a/bootloader/src/main.rs
+++ b/bootloader/src/main.rs
@@ -74,7 +74,7 @@ struct BootPartition {
 impl BootPartition {
     const FIRMWARE_LENGTH: usize = 0x00040000;
 
-    /// Reads the metadata, returns the timestamp if all checks pass.
+    /// Reads the metadata, returns the firmware version if all checks pass.
     pub fn read_version(&self) -> Result<u64, ()> {
         let metadata_page = unsafe { read_page(self.metadata_address) };
         let hash_value = self.compute_upgrade_hash(&metadata_page);

--- a/docs/boards/nrf52840dk.md
+++ b/docs/boards/nrf52840dk.md
@@ -55,15 +55,15 @@ There are variants of the board that introduce A/B partitions for upgrading the
 firmware. You can bootstrap an upgradable board using one of the two commands:
 
 ```shell
-./deploy.py --board=nrf52840dk_opensk_a --opensk
-./deploy.py --board=nrf52840dk_opensk_b --opensk
+./deploy.py --board=nrf52840dk_opensk_a --opensk --version=0
+./deploy.py --board=nrf52840dk_opensk_b --opensk --version=0
 ```
 
 Afterwards, you can upgrade the other partition with
 
 ```shell
-./tools/perform_upgrade.sh nrf52840dk_opensk_b
-./tools/perform_upgrade.sh nrf52840dk_opensk_a
+./tools/perform_upgrade.sh nrf52840dk_opensk_b --version=1
+./tools/perform_upgrade.sh nrf52840dk_opensk_a --version=1
 ```
 
 respectively. You can only upgrade the partition that is not currently running,
@@ -75,6 +75,6 @@ If you deploy with `--vendor-hid`, also add this flag to `perform_upgrade.sh`,
 for example:
 
 ```shell
-./deploy.py --board=nrf52840dk_opensk_a --opensk --vendor-hid
-./tools/perform_upgrade.sh nrf52840dk_opensk_b --vendor-hid
+./deploy.py --board=nrf52840dk_opensk_a --opensk --version=0 --vendor-hid
+./tools/perform_upgrade.sh nrf52840dk_opensk_b --version=1 --vendor-hid
 ```

--- a/tools/deploy_partition.py
+++ b/tools/deploy_partition.py
@@ -87,7 +87,8 @@ def create_metadata(firmware_image: bytes, partition_address: int, version: int,
   version_bytes = struct.pack("<Q", version)
   partition_start = struct.pack("<I", partition_address)
   # Prefix sizes that are a multiple of 64 suit our bootloader's SHA.
-  signed_metadata = pad_to(version_bytes + partition_start, PAGE_SIZE - METADATA_SIGN_OFFSET)
+  signed_metadata = pad_to(version_bytes + partition_start,
+                           PAGE_SIZE - METADATA_SIGN_OFFSET)
   signed_data = signed_metadata + firmware_image
   checksum = hash_message(signed_data)
   signature = sign_firmware(signed_data, priv_key)


### PR DESCRIPTION
This PR changes to metadata format to include the signature, and a version instead of a timestamp.

tl;dr tell me how to shuffle the format around:
- 32 B upgrade hash (SHA256)
- 64 B signature,
- 32 B padding,
- 20 B version (8 byte used) and
-  4 B partition address in little endian encoding.

There are a few things we can discuss about the format:

1. The version is currently `u64`, since the GetInfo command returns an integer, and our CBOR parser works with up to 63 bit integers. We could make it more sophisticated like SEMVER, but would have to convert it to 63 bit eventually.
2. More padding before the signed part of the metadata starts. Would allow us to write different / bigger / PQC signatures there. I wanted to get your opinions before deciding on a number.

Some things are missing:
- Versions are only checked in the bootloader, but not yet in CTAP. This is consistent with existing behavior, but will probably be stricter soon.
- Code has not moved to TockEnv yet. The command will stay in CTAP, but the Metadata logic will end up there.