### PR TITLE
Public Key plain byte encoding

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -51,10 +51,7 @@ fn main() {
         .public_key()
         .to_bytes(&group, conversion_form, &mut ctx)
         .unwrap();
-    const POINT_LEN: usize = 32;
-    assert_eq!(raw_bytes.len(), 1 + 2 * POINT_LEN);
-    assert_eq!(raw_bytes[0], 0x04);
     let upgrade_pubkey_path = Path::new(&out_dir).join("opensk_upgrade_pubkey.bin");
     let mut upgrade_pub_bin_file = File::create(&upgrade_pubkey_path).unwrap();
-    upgrade_pub_bin_file.write_all(&raw_bytes[1..]).unwrap();
+    upgrade_pub_bin_file.write_all(&raw_bytes).unwrap();
 }

--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,6 @@
 extern crate alloc;
 
 use openssl::{bn, ec, nid};
-use sk_cbor::cbor_map;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
@@ -55,22 +54,7 @@ fn main() {
     const POINT_LEN: usize = 32;
     assert_eq!(raw_bytes.len(), 1 + 2 * POINT_LEN);
     assert_eq!(raw_bytes[0], 0x04);
-    let x_bytes = &raw_bytes[1..][..POINT_LEN];
-    let y_bytes = &raw_bytes[1 + POINT_LEN..][..POINT_LEN];
-
-    const EC2_KEY_TYPE: i64 = 2;
-    const P_256_CURVE: i64 = 1;
-    const ES256_ALGORITHM: i64 = -7;
-    let pub_key_cbor = sk_cbor::cbor_map! {
-        1 => EC2_KEY_TYPE,
-        3 => ES256_ALGORITHM,
-        -1 => P_256_CURVE,
-        -2 => x_bytes,
-        -3 => y_bytes,
-    };
-    let mut cbor_bytes = vec![];
-    sk_cbor::writer::write(pub_key_cbor, &mut cbor_bytes).unwrap();
-    let upgrade_pubkey_path = Path::new(&out_dir).join("opensk_upgrade_pubkey_cbor.bin");
+    let upgrade_pubkey_path = Path::new(&out_dir).join("opensk_upgrade_pubkey.bin");
     let mut upgrade_pub_bin_file = File::create(&upgrade_pubkey_path).unwrap();
-    upgrade_pub_bin_file.write_all(&cbor_bytes).unwrap();
+    upgrade_pub_bin_file.write_all(&raw_bytes[1..]).unwrap();
 }

--- a/libraries/crypto/src/ec/point.rs
+++ b/libraries/crypto/src/ec/point.rs
@@ -16,9 +16,8 @@ use super::exponent256::ExponentP256;
 use super::gfp256::GFP256;
 use super::int256::Int256;
 use super::montgomery::Montgomery;
-#[cfg(test)]
-use arrayref::array_mut_ref;
 #[cfg(feature = "std")]
+use arrayref::array_mut_ref;
 use arrayref::array_ref;
 use core::ops::Add;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
@@ -45,7 +44,6 @@ impl PointP256 {
     /** Serialization **/
     // This uses uncompressed point format from "SEC 1: Elliptic Curve Cryptography" ("Standards for
     // Efficient Cryptography").
-    #[cfg(feature = "std")]
     pub fn from_bytes_uncompressed_vartime(bytes: &[u8]) -> Option<PointP256> {
         if bytes.len() != 65 || bytes[0] != 0x04 {
             None
@@ -57,7 +55,7 @@ impl PointP256 {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(feature = "std")]
     pub fn to_bytes_uncompressed(&self, bytes: &mut [u8; 65]) {
         bytes[0] = 0x04;
         self.x.to_int().to_bin(array_mut_ref![bytes, 1, 32]);

--- a/libraries/crypto/src/ecdsa.rs
+++ b/libraries/crypto/src/ecdsa.rs
@@ -231,13 +231,12 @@ impl PubKey {
             .map(|p| PubKey { p })
     }
 
-    #[cfg(feature = "std")]
     pub fn from_bytes_uncompressed(bytes: &[u8]) -> Option<PubKey> {
         PointP256::from_bytes_uncompressed_vartime(bytes).map(|p| PubKey { p })
     }
 
-    #[cfg(test)]
-    fn to_bytes_uncompressed(&self, bytes: &mut [u8; 65]) {
+    #[cfg(feature = "std")]
+    pub fn to_bytes_uncompressed(&self, bytes: &mut [u8; 65]) {
         self.p.to_bytes_uncompressed(bytes);
     }
 

--- a/src/ctap/data_formats.rs
+++ b/src/ctap/data_formats.rs
@@ -836,8 +836,8 @@ impl From<ecdh::PubKey> for CoseKey {
 
 impl From<ecdsa::PubKey> for CoseKey {
     fn from(pk: ecdsa::PubKey) -> Self {
-        let mut x_bytes = [0; ecdh::NBYTES];
-        let mut y_bytes = [0; ecdh::NBYTES];
+        let mut x_bytes = [0; ecdsa::NBYTES];
+        let mut y_bytes = [0; ecdsa::NBYTES];
         pk.to_coordinates(&mut x_bytes, &mut y_bytes);
         CoseKey {
             x_bytes,

--- a/src/ctap/key_material.rs
+++ b/src/ctap/key_material.rs
@@ -14,7 +14,7 @@
 
 pub const ATTESTATION_PRIVATE_KEY_LENGTH: usize = 32;
 pub const AAGUID_LENGTH: usize = 16;
-pub const UPGRADE_PUBLIC_KEY_LENGTH: usize = 64;
+pub const UPGRADE_PUBLIC_KEY_LENGTH: usize = 65;
 
 pub const AAGUID: &[u8; AAGUID_LENGTH] =
     include_bytes!(concat!(env!("OUT_DIR"), "/opensk_aaguid.bin"));

--- a/src/ctap/key_material.rs
+++ b/src/ctap/key_material.rs
@@ -14,9 +14,9 @@
 
 pub const ATTESTATION_PRIVATE_KEY_LENGTH: usize = 32;
 pub const AAGUID_LENGTH: usize = 16;
-pub const UPGRADE_PUBLIC_KEY_LENGTH: usize = 77;
+pub const UPGRADE_PUBLIC_KEY_LENGTH: usize = 64;
 
 pub const AAGUID: &[u8; AAGUID_LENGTH] =
     include_bytes!(concat!(env!("OUT_DIR"), "/opensk_aaguid.bin"));
 pub const UPGRADE_PUBLIC_KEY: &[u8; UPGRADE_PUBLIC_KEY_LENGTH] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/opensk_upgrade_pubkey_cbor.bin"));
+    include_bytes!(concat!(env!("OUT_DIR"), "/opensk_upgrade_pubkey.bin"));


### PR DESCRIPTION
Encoding the public key with it's bytes directly is similar to other hardware platforms. We don't lose flexibilty in practise, since upgrade to a different signature algorithm requires an upgrade that understands it anyway.

Also includes a small fix in `data_formats.rs` I discovered on the way.