### PR TITLE
Move Metadata parser to Env

### DIFF
--- a/src/ctap/key_material.rs
+++ b/src/ctap/key_material.rs
@@ -14,9 +14,6 @@
 
 pub const ATTESTATION_PRIVATE_KEY_LENGTH: usize = 32;
 pub const AAGUID_LENGTH: usize = 16;
-pub const UPGRADE_PUBLIC_KEY_LENGTH: usize = 65;
 
 pub const AAGUID: &[u8; AAGUID_LENGTH] =
     include_bytes!(concat!(env!("OUT_DIR"), "/opensk_aaguid.bin"));
-pub const UPGRADE_PUBLIC_KEY: &[u8; UPGRADE_PUBLIC_KEY_LENGTH] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/opensk_upgrade_pubkey.bin"));


### PR DESCRIPTION
Moves metadata parsing logic from `ctap` to `env`.

The only logic change in this PR is the error codes. Before, it was a guess what CTAP error code likely fits the best. Now we simply map all errors to `CTAP1_ERR_INVALID_PARAMETER` or `CTAP2_ERR_INTEGRITY_FAILURE`.