### PR TITLE
Simplifies Env upgrade API

### DIFF
--- a/src/api/upgrade_storage/mod.rs
+++ b/src/api/upgrade_storage/mod.rs
@@ -19,22 +19,20 @@ pub(crate) mod helper;
 
 /// Accessors to storage locations used for upgrading from a CTAP command.
 pub trait UpgradeStorage {
-    /// Writes the given data to the given offset address, if within bounds of the partition.
+    /// Writes the given data as part of an upgrade.
     ///
-    /// The offset is relative to the start of the partition, excluding holes. The partition is
-    /// presented as one connected component. Therefore, the offset does not easily translate
-    /// to physical memory address address of the slice.
+    /// The offset indicates the data location inside the bundle.
     ///
     /// The hash is the SHA256 of the data slice. This hash is not a security feature, use it to
     /// check your data integrity.
     ///
     /// # Errors
     ///
-    /// - Returns [`StorageError::OutOfBounds`] if the data does not fit the partition.
+    /// - Returns [`StorageError::OutOfBounds`] if the data does not fit.
     /// - Returns [`StorageError::CustomError`] if any Metadata or hash check fails.
-    fn write_bundle(&mut self, offset: usize, data: Vec<u8>, hash: &[u8; 32]) -> StorageResult<()>;
+    fn write_bundle(&mut self, offset: usize, data: Vec<u8>) -> StorageResult<()>;
 
-    /// Returns an identifier for the partition.
+    /// Returns an identifier for the requested bundle.
     ///
     /// Use this to determine whether you are writing to A or B.
     fn bundle_identifier(&self) -> u32;

--- a/src/api/upgrade_storage/mod.rs
+++ b/src/api/upgrade_storage/mod.rs
@@ -18,35 +18,25 @@ pub(crate) mod helper;
 
 /// Accessors to storage locations used for upgrading from a CTAP command.
 pub trait UpgradeStorage {
-    /// Reads a slice of the partition, if within bounds.
-    ///
-    /// The offset is relative to the start of the partition, excluding holes. The partition is
-    /// presented as one connected component. Therefore, the offset does not easily translate
-    /// to physical memory address address of the slice.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`StorageError::OutOfBounds`] if the requested slice is not inside the partition.
-    fn read_partition(&self, offset: usize, length: usize) -> StorageResult<&[u8]>;
-
     /// Writes the given data to the given offset address, if within bounds of the partition.
     ///
     /// The offset is relative to the start of the partition, excluding holes.
     /// See `read_partition`.
     ///
+    /// The hash is the SHA256 of the data slice. This hash is not a security feature, use it to
+    /// check your data integrity.
+    ///
     /// # Errors
     ///
     /// - Returns [`StorageError::OutOfBounds`] if the data does not fit the partition.
-    /// - Returns [`StorageError::CustomError`] if any Metadata check fails.
-    fn write_partition(&mut self, offset: usize, data: &[u8]) -> StorageResult<()>;
+    /// - Returns [`StorageError::CustomError`] if any Metadata or hash check fails.
+    fn write_partition(&mut self, offset: usize, data: &[u8], hash: &[u8; 32])
+        -> StorageResult<()>;
 
     /// Returns an identifier for the partition.
     ///
     /// Use this to determine whether you are writing to A or B.
     fn partition_identifier(&self) -> u32;
-
-    /// Returns the length of the partition.
-    fn partition_length(&self) -> usize;
 
     /// Returns the currently running firmware version.
     fn running_firmware_version(&self) -> u64;

--- a/src/api/upgrade_storage/mod.rs
+++ b/src/api/upgrade_storage/mod.rs
@@ -19,17 +19,14 @@ pub(crate) mod helper;
 
 /// Accessors to storage locations used for upgrading from a CTAP command.
 pub trait UpgradeStorage {
-    /// Writes the given data as part of an upgrade.
+    /// Processes the given data as part of an upgrade.
     ///
     /// The offset indicates the data location inside the bundle.
-    ///
-    /// The hash is the SHA256 of the data slice. This hash is not a security feature, use it to
-    /// check your data integrity.
     ///
     /// # Errors
     ///
     /// - Returns [`StorageError::OutOfBounds`] if the data does not fit.
-    /// - Returns [`StorageError::CustomError`] if any Metadata or hash check fails.
+    /// - Returns [`StorageError::CustomError`] if any Metadata or other check fails.
     fn write_bundle(&mut self, offset: usize, data: Vec<u8>) -> StorageResult<()>;
 
     /// Returns an identifier for the requested bundle.

--- a/src/api/upgrade_storage/mod.rs
+++ b/src/api/upgrade_storage/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use alloc::vec::Vec;
 use persistent_store::StorageResult;
 
 pub(crate) mod helper;
@@ -20,8 +21,9 @@ pub(crate) mod helper;
 pub trait UpgradeStorage {
     /// Writes the given data to the given offset address, if within bounds of the partition.
     ///
-    /// The offset is relative to the start of the partition, excluding holes.
-    /// See `read_partition`.
+    /// The offset is relative to the start of the partition, excluding holes. The partition is
+    /// presented as one connected component. Therefore, the offset does not easily translate
+    /// to physical memory address address of the slice.
     ///
     /// The hash is the SHA256 of the data slice. This hash is not a security feature, use it to
     /// check your data integrity.
@@ -30,13 +32,12 @@ pub trait UpgradeStorage {
     ///
     /// - Returns [`StorageError::OutOfBounds`] if the data does not fit the partition.
     /// - Returns [`StorageError::CustomError`] if any Metadata or hash check fails.
-    fn write_partition(&mut self, offset: usize, data: &[u8], hash: &[u8; 32])
-        -> StorageResult<()>;
+    fn write_bundle(&mut self, offset: usize, data: Vec<u8>, hash: &[u8; 32]) -> StorageResult<()>;
 
     /// Returns an identifier for the partition.
     ///
     /// Use this to determine whether you are writing to A or B.
-    fn partition_identifier(&self) -> u32;
+    fn bundle_identifier(&self) -> u32;
 
     /// Returns the currently running firmware version.
     fn running_firmware_version(&self) -> u64;

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -1401,7 +1401,7 @@ impl CtapState {
         let AuthenticatorVendorUpgradeParameters { offset, data, hash } = params;
         env.upgrade_storage()
             .ok_or(Ctap2StatusCode::CTAP1_ERR_INVALID_COMMAND)?
-            .write_partition(offset, &data, &hash)
+            .write_bundle(offset, data, &hash)
             .map_err(|_| Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER)?;
         Ok(ResponseData::AuthenticatorVendorUpgrade)
     }
@@ -1415,7 +1415,7 @@ impl CtapState {
             .ok_or(Ctap2StatusCode::CTAP1_ERR_INVALID_COMMAND)?;
         Ok(ResponseData::AuthenticatorVendorUpgradeInfo(
             AuthenticatorVendorUpgradeInfoResponse {
-                info: upgrade_locations.partition_identifier(),
+                info: upgrade_locations.bundle_identifier(),
             },
         ))
     }
@@ -3478,14 +3478,14 @@ mod test {
     fn test_vendor_upgrade_info() {
         let mut env = TestEnv::new();
         let ctap_state = CtapState::new(&mut env, CtapInstant::new(0));
-        let partition_identifier = env.upgrade_storage().unwrap().partition_identifier();
+        let bundle_identifier = env.upgrade_storage().unwrap().bundle_identifier();
 
         let upgrade_info_reponse = ctap_state.process_vendor_upgrade_info(&mut env);
         assert_eq!(
             upgrade_info_reponse,
             Ok(ResponseData::AuthenticatorVendorUpgradeInfo(
                 AuthenticatorVendorUpgradeInfoResponse {
-                    info: partition_identifier,
+                    info: bundle_identifier,
                 }
             ))
         );

--- a/src/env/tock/storage.rs
+++ b/src/env/tock/storage.rs
@@ -352,7 +352,7 @@ impl TockUpgradeStorage {
 }
 
 impl UpgradeStorage for TockUpgradeStorage {
-    fn write_bundle(&mut self, offset: usize, data: Vec<u8>, hash: &[u8; 32]) -> StorageResult<()> {
+    fn write_bundle(&mut self, offset: usize, data: Vec<u8>) -> StorageResult<()> {
         if data.is_empty() {
             return Err(StorageError::OutOfBounds);
         }
@@ -373,8 +373,7 @@ impl UpgradeStorage for TockUpgradeStorage {
         }
         write_slice(address, &data)?;
         let written_slice = unsafe { read_slice(address, data.len()) };
-        let written_hash = Sha256::hash(written_slice);
-        if hash != &written_hash {
+        if written_slice != data {
             return Err(StorageError::CustomError);
         }
         // Case: Last slice is written.


### PR DESCRIPTION
The CTAP command logic is now a 1-liner, taking the CBOR-parsed data and calling the corresponding Env API.