### PR TITLE
Update configure.py

### DIFF
--- a/tools/configure.py
+++ b/tools/configure.py
@@ -60,7 +60,7 @@ def get_opensk_devices(batch_mode):
     if (dev.descriptor.vid, dev.descriptor.pid) == OPENSK_VID_PID:
       if dev.capabilities & hid.CAPABILITY.CBOR:
         if batch_mode:
-          devices.append(ctap2.CTAP2(dev))
+          devices.append(ctap2.Ctap2(dev))
         else:
           return [ctap2.CTAP2(dev)]
   return devices


### PR DESCRIPTION
Change line 63 to stop error:
```
/tools/configure.py \
    --certificate=crypto_data/opensk_cert.pem \
    --private-key=crypto_data/opensk.key
info: Private key is valid.
info: Certificate is valid.
Traceback (most recent call last):
  File "/home/samit/GitClones/OpenSK/./tools/configure.py", line 196, in <module>
    main(parser.parse_args())
  File "/home/samit/GitClones/OpenSK/./tools/configure.py", line 127, in main
    for authenticator in tqdm(get_opensk_devices(args.batch)):
  File "/home/samit/GitClones/OpenSK/./tools/configure.py", line 65, in get_opensk_devices
    return [ctap2.CTAP2(dev)]
AttributeError: module 'fido2.ctap2' has no attribute 'CTAP2'. Did you mean: 'Ctap2'?
```

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR