### PR TITLE
Customization to disable PIN protcol v1

### DIFF
--- a/src/api/customization.rs
+++ b/src/api/customization.rs
@@ -26,6 +26,12 @@ pub trait Customization {
     // Constants for adjusting privacy and protection levels.
     // ###########################################################################
 
+    /// Removes support for PIN protocol v1.
+    ///
+    /// We support PIN protocol v2, "intended to aid FIPS certification".
+    /// To certify, you might want to remove support for v1 using this customization.
+    fn allows_pin_protocol_v1(&self) -> bool;
+
     /// Changes the default level for the credProtect extension.
     ///
     /// You can change this value to one of the following for more privacy:
@@ -245,6 +251,7 @@ pub trait Customization {
 
 #[derive(Clone)]
 pub struct CustomizationImpl {
+    pub allows_pin_protocol_v1: bool,
     pub default_cred_protect: Option<CredentialProtectionPolicy>,
     pub default_min_pin_length: u8,
     pub default_min_pin_length_rp_ids: &'static [&'static str],
@@ -263,6 +270,7 @@ pub struct CustomizationImpl {
 }
 
 pub const DEFAULT_CUSTOMIZATION: CustomizationImpl = CustomizationImpl {
+    allows_pin_protocol_v1: true,
     default_cred_protect: None,
     default_min_pin_length: 4,
     default_min_pin_length_rp_ids: &[],
@@ -281,6 +289,10 @@ pub const DEFAULT_CUSTOMIZATION: CustomizationImpl = CustomizationImpl {
 };
 
 impl Customization for CustomizationImpl {
+    fn allows_pin_protocol_v1(&self) -> bool {
+        self.allows_pin_protocol_v1
+    }
+
     fn default_cred_protect(&self) -> Option<CredentialProtectionPolicy> {
         self.default_cred_protect
     }

--- a/src/env/test/customization.rs
+++ b/src/env/test/customization.rs
@@ -18,6 +18,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 pub struct TestCustomization {
+    allows_pin_protocol_v1: bool,
     default_cred_protect: Option<CredentialProtectionPolicy>,
     default_min_pin_length: u8,
     default_min_pin_length_rp_ids: Vec<String>,
@@ -36,6 +37,10 @@ pub struct TestCustomization {
 }
 
 impl TestCustomization {
+    pub fn set_allows_pin_protocol_v1(&mut self, is_allowed: bool) {
+        self.allows_pin_protocol_v1 = is_allowed;
+    }
+
     pub fn setup_enterprise_attestation(
         &mut self,
         mode: Option<EnterpriseAttestationMode>,
@@ -49,6 +54,10 @@ impl TestCustomization {
 }
 
 impl Customization for TestCustomization {
+    fn allows_pin_protocol_v1(&self) -> bool {
+        self.allows_pin_protocol_v1
+    }
+
     fn default_cred_protect(&self) -> Option<CredentialProtectionPolicy> {
         self.default_cred_protect
     }
@@ -117,6 +126,7 @@ impl Customization for TestCustomization {
 impl From<CustomizationImpl> for TestCustomization {
     fn from(c: CustomizationImpl) -> Self {
         let CustomizationImpl {
+            allows_pin_protocol_v1,
             default_cred_protect,
             default_min_pin_length,
             default_min_pin_length_rp_ids,
@@ -145,6 +155,7 @@ impl From<CustomizationImpl> for TestCustomization {
             .collect::<Vec<_>>();
 
         Self {
+            allows_pin_protocol_v1,
             default_cred_protect,
             default_min_pin_length,
             default_min_pin_length_rp_ids,


### PR DESCRIPTION
Makes it easier to use OpenSK for FIPS compliant devices by disabling PIN protocol V1.

We don't remove the code for V1, we just make it inaccessible.