### PR TITLE
Fix nRF52 boards with bootloader

### DIFF
--- a/patches/tock/06-update-uicr.patch
+++ b/patches/tock/06-update-uicr.patch
@@ -1,5 +1,31 @@
+diff --git a/boards/nordic/nrf52_components/src/startup.rs b/boards/nordic/nrf52_components/src/startup.rs
+index 9ddb414fd..de47f10a7 100644
+--- a/boards/nordic/nrf52_components/src/startup.rs
++++ b/boards/nordic/nrf52_components/src/startup.rs
+@@ -46,6 +46,9 @@ impl Component for NrfStartupComponent {
+             erase_uicr |= !uicr.is_nfc_pins_protection_enabled();
+         }
+ 
++        // Avoid killing the DFU bootloader if present
++        let (dfu_start_addr, dfu_settings_addr) = uicr.get_dfu_params();
++
+         if erase_uicr {
+             nrf52::nvmc::NVMC.erase_uicr();
+         }
+@@ -55,6 +58,11 @@ impl Component for NrfStartupComponent {
+ 
+         let mut needs_soft_reset: bool = false;
+ 
++        // Restore DFU bootloader settings if we erased
++        if erase_uicr {
++            uicr.set_dfu_params(dfu_start_addr, dfu_settings_addr);
++        }
++
+         // Configure reset pins
+         if uicr
+             .get_psel0_reset_pin()
 diff --git a/chips/nrf52/src/uicr.rs b/chips/nrf52/src/uicr.rs
-index 6bb6c86..3bb8b5a 100644
+index 6bb6c86b7..0b388d75c 100644
 --- a/chips/nrf52/src/uicr.rs
 +++ b/chips/nrf52/src/uicr.rs
 @@ -1,38 +1,45 @@
@@ -97,4 +123,22 @@ index 6bb6c86..3bb8b5a 100644
      /// Setting of pins dedicated to NFC functionality: NFC antenna or GPIO
      NfcPins [
          /// Setting pins dedicated to NFC functionality
-
+@@ -176,6 +199,18 @@ impl Uicr {
+         self.registers.nfcpins.matches_all(NfcPins::PROTECT::NFC)
+     }
+ 
++    pub fn get_dfu_params(&self) -> (u32, u32) {
++        (
++            self.registers.nrffw[0].get(), // DFU start address
++            self.registers.nrffw[1].get(), // DFU settings address
++        )
++    }
++
++    pub fn set_dfu_params(&self, dfu_start_addr: u32, dfu_settings_addr: u32) {
++        self.registers.nrffw[0].set(dfu_start_addr);
++        self.registers.nrffw[1].set(dfu_settings_addr);
++    }
++
+     pub fn is_ap_protect_enabled(&self) -> bool {
+         // Here we compare to DISABLED value because any other value should enable the protection.
+         !self


### PR DESCRIPTION
Backporting patch from develop branch which saves and restores the bootloader parameters in case we need to erase UICR at startup.

Fixes #544 

