### PR TITLE
Add storage test cases for multi-PIN

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,11 @@ sk-cbor = { path = "libraries/cbor" }
 uuid = { version = "0.8", features = ["v4"] }
 openssl = "0.10.36"
 
+# We explicitly lock the version of those transitive dependencies because their
+# Cargo.toml don't parse with the nightly compiler used by Tock. Remove this
+# whole block once CTAP is a library.
+once_cell = "=1.14" # transitive dependency of openssl
+
 [profile.dev]
 panic = "abort"
 lto = true # Link Time Optimization usually reduces size of binaries and static libraries

--- a/libraries/crypto/Cargo.toml
+++ b/libraries/crypto/Cargo.toml
@@ -25,6 +25,7 @@ regex = { version = "1", optional = true }
 # Cargo.toml don't parse with the nightly compiler used by Tock. Remove this
 # whole block once CTAP is a library.
 bumpalo = "=3.8.0" # transitive dependency of ring
+once_cell = { version = "=1.14", optional = true } # transitive dependency of ring
 
 [features]
 std = ["hex", "ring", "rng256/std", "untrusted", "serde", "serde_json", "regex"]

--- a/src/api/customization.rs
+++ b/src/api/customization.rs
@@ -294,7 +294,7 @@ pub const DEFAULT_CUSTOMIZATION: CustomizationImpl = CustomizationImpl {
     max_large_blob_array_size: 2048,
     max_rp_ids_length: 8,
     max_supported_resident_keys: 150,
-    slot_count: 1,
+    slot_count: 8,
 };
 
 impl Customization for CustomizationImpl {

--- a/src/ctap/client_pin.rs
+++ b/src/ctap/client_pin.rs
@@ -344,9 +344,8 @@ impl ClientPin {
 
         self.pin_protocol_v1.reset_pin_uv_auth_token(env.rng());
         self.pin_protocol_v2.reset_pin_uv_auth_token(env.rng());
-        // TODO: pass the slot_id parameter and store it in the state too.
         self.pin_uv_auth_token_state
-            .begin_using_pin_uv_auth_token(now);
+            .begin_using_pin_uv_auth_token(now, slot_id);
         self.pin_uv_auth_token_state.set_default_permissions();
         let pin_uv_auth_token = shared_secret.encrypt(
             env.rng(),
@@ -581,9 +580,15 @@ impl ClientPin {
         self.pin_uv_auth_token_state.has_permissions_rp_id(rp_id)
     }
 
+    /// Get the slot_id_in_use of the current pin_uv_auth_token_state, if any.
+    pub fn get_slot_id_in_use(&self) -> Option<usize> {
+        self.pin_uv_auth_token_state.slot_id_in_use()
+    }
+
     #[cfg(test)]
     pub fn new_test(
         env: &mut impl Env,
+        slot_id: usize,
         key_agreement_key: crypto::ecdh::SecKey,
         pin_uv_auth_token: [u8; PIN_TOKEN_LENGTH],
         pin_uv_auth_protocol: PinUvAuthProtocol,
@@ -594,7 +599,7 @@ impl ClientPin {
         };
         let mut pin_uv_auth_token_state = PinUvAuthTokenState::new();
         pin_uv_auth_token_state.set_permissions(0xFF);
-        pin_uv_auth_token_state.begin_using_pin_uv_auth_token(CtapInstant::new(0));
+        pin_uv_auth_token_state.begin_using_pin_uv_auth_token(CtapInstant::new(0), slot_id);
         ClientPin {
             pin_protocol_v1: PinProtocol::new_test(key_agreement_key_v1, pin_uv_auth_token),
             pin_protocol_v2: PinProtocol::new_test(key_agreement_key_v2, pin_uv_auth_token),
@@ -637,6 +642,7 @@ mod test {
     /// tests using the wrong combination of PIN protocol and shared secret
     /// should fail.
     fn create_client_pin_and_shared_secret(
+        slot_id: usize,
         pin_uv_auth_protocol: PinUvAuthProtocol,
     ) -> (ClientPin, Box<dyn SharedSecret>) {
         let mut env = TestEnv::new();
@@ -646,6 +652,7 @@ mod test {
         let pin_uv_auth_token = [0x91; PIN_TOKEN_LENGTH];
         let client_pin = ClientPin::new_test(
             &mut env,
+            slot_id,
             key_agreement_key,
             pin_uv_auth_token,
             pin_uv_auth_protocol,
@@ -665,7 +672,9 @@ mod test {
         sub_command: ClientPinSubCommand,
     ) -> (ClientPin, AuthenticatorClientPinParameters) {
         let mut env = TestEnv::new();
-        let (client_pin, shared_secret) = create_client_pin_and_shared_secret(pin_uv_auth_protocol);
+        // TODO: Make slot_id a passed parameter once we include it in AuthenticatorClientPinParameters.
+        let (client_pin, shared_secret) =
+            create_client_pin_and_shared_secret(0, pin_uv_auth_protocol);
 
         let pin = b"1234";
         let mut padded_pin = [0u8; 64];
@@ -1284,7 +1293,8 @@ mod test {
         salt: Vec<u8>,
     ) -> Result<Vec<u8>, Ctap2StatusCode> {
         let mut env = TestEnv::new();
-        let (client_pin, shared_secret) = create_client_pin_and_shared_secret(pin_uv_auth_protocol);
+        let (client_pin, shared_secret) =
+            create_client_pin_and_shared_secret(0, pin_uv_auth_protocol);
 
         let salt_enc = shared_secret.as_ref().encrypt(env.rng(), &salt).unwrap();
         let salt_auth = shared_secret.authenticate(&salt_enc);
@@ -1302,7 +1312,8 @@ mod test {
 
     fn test_helper_process_hmac_secret_bad_salt_auth(pin_uv_auth_protocol: PinUvAuthProtocol) {
         let mut env = TestEnv::new();
-        let (client_pin, shared_secret) = create_client_pin_and_shared_secret(pin_uv_auth_protocol);
+        let (client_pin, shared_secret) =
+            create_client_pin_and_shared_secret(0, pin_uv_auth_protocol);
         let cred_random = [0xC9; 32];
 
         let salt_enc = vec![0x01; 32];
@@ -1515,7 +1526,7 @@ mod test {
         let message = [0xAA];
         client_pin
             .pin_uv_auth_token_state
-            .begin_using_pin_uv_auth_token(CtapInstant::new(0));
+            .begin_using_pin_uv_auth_token(CtapInstant::new(0), 0);
 
         let pin_uv_auth_token_v1 = client_pin
             .get_pin_protocol(PinUvAuthProtocol::V1)
@@ -1532,6 +1543,7 @@ mod test {
         let pin_uv_auth_param_v2_from_v1_token =
             authenticate_pin_uv_auth_token(pin_uv_auth_token_v1, &message, PinUvAuthProtocol::V2);
 
+        assert_eq!(client_pin.get_slot_id_in_use(), Some(0));
         assert_eq!(
             client_pin.verify_pin_uv_auth_token(
                 &message,

--- a/src/ctap/config_command.rs
+++ b/src/ctap/config_command.rs
@@ -91,14 +91,10 @@ pub fn process_config(
         pin_uv_auth_protocol,
     } = params;
 
-    let slot_id = if storage::has_multi_pin(env)? {
-        client_pin.get_slot_id_in_use()
-    } else {
-        Some(0)
-    };
+    let slot_id = client_pin.get_slot_id_in_use_or_default(env)?;
     let enforce_uv =
         !matches!(sub_command, ConfigSubCommand::ToggleAlwaysUv) && storage::has_always_uv(env)?;
-    // If multi-PIN feature is enabled, no PIN is in used, and the command is to turn off alwaysUv,
+    // If multi-PIN feature is enabled, no PIN is in use, and the command is to turn off alwaysUv,
     // the PIN check will be skipped here but an OPERATION_DENIED will still be returned later,
     // which is correct behavior.
     if (slot_id.is_some() && storage::pin_hash(env, slot_id.unwrap())?.is_some()) || enforce_uv {

--- a/src/ctap/config_command.rs
+++ b/src/ctap/config_command.rs
@@ -91,10 +91,16 @@ pub fn process_config(
         pin_uv_auth_protocol,
     } = params;
 
-    // TODO: Get the slot id from active token state when multi-PIN is enabled.
-    let slot_id = Some(0);
+    let slot_id = if storage::has_multi_pin(env)? {
+        client_pin.get_slot_id_in_use()
+    } else {
+        Some(0)
+    };
     let enforce_uv =
         !matches!(sub_command, ConfigSubCommand::ToggleAlwaysUv) && storage::has_always_uv(env)?;
+    // If multi-PIN feature is enabled, no PIN is in used, and the command is to turn off alwaysUv,
+    // the PIN check will be skipped here but an OPERATION_DENIED will still be returned later,
+    // which is correct behavior.
     if (slot_id.is_some() && storage::pin_hash(env, slot_id.unwrap())?.is_some()) || enforce_uv {
         let pin_uv_auth_param =
             pin_uv_auth_param.ok_or(Ctap2StatusCode::CTAP2_ERR_PUAT_REQUIRED)?;
@@ -143,6 +149,7 @@ mod test {
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             PinUvAuthProtocol::V1,
@@ -174,6 +181,7 @@ mod test {
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             PinUvAuthProtocol::V1,
@@ -213,6 +221,7 @@ mod test {
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             pin_uv_auth_protocol,
@@ -287,6 +296,7 @@ mod test {
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             PinUvAuthProtocol::V1,
@@ -335,6 +345,7 @@ mod test {
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             PinUvAuthProtocol::V1,
@@ -415,6 +426,7 @@ mod test {
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             PinUvAuthProtocol::V1,
@@ -442,6 +454,7 @@ mod test {
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             PinUvAuthProtocol::V1,
@@ -477,6 +490,7 @@ mod test {
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             PinUvAuthProtocol::V1,

--- a/src/ctap/credential_management.rs
+++ b/src/ctap/credential_management.rs
@@ -394,6 +394,7 @@ mod test {
         let pin_uv_auth_token = [0x55; 32];
         let client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             pin_uv_auth_protocol,
@@ -480,6 +481,7 @@ mod test {
         let pin_uv_auth_token = [0x55; 32];
         let client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             PinUvAuthProtocol::V1,
@@ -578,6 +580,7 @@ mod test {
         let pin_uv_auth_token = [0x55; 32];
         let client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             PinUvAuthProtocol::V1,
@@ -663,6 +666,7 @@ mod test {
         let pin_uv_auth_token = [0x55; 32];
         let client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             PinUvAuthProtocol::V1,
@@ -769,6 +773,7 @@ mod test {
         let pin_uv_auth_token = [0x55; 32];
         let client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             PinUvAuthProtocol::V1,
@@ -843,6 +848,7 @@ mod test {
         let pin_uv_auth_token = [0x55; 32];
         let client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             PinUvAuthProtocol::V1,

--- a/src/ctap/large_blobs.rs
+++ b/src/ctap/large_blobs.rs
@@ -87,9 +87,9 @@ impl LargeBlobs {
             if offset != self.expected_next_offset {
                 return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_SEQ);
             }
-            // TODO: Get the slot id from active token state when multi-PIN is enabled.
-            let slot_id = 0;
-            if storage::pin_hash(env, slot_id)?.is_some() || storage::has_always_uv(env)? {
+            // We only check whether slot 0 has a PIN here because if multi-PIN is enabled,
+            // has_always_uv will always be true and the condition will always pass.
+            if storage::pin_hash(env, 0)?.is_some() || storage::has_always_uv(env)? {
                 let pin_uv_auth_param =
                     pin_uv_auth_param.ok_or(Ctap2StatusCode::CTAP2_ERR_PUAT_REQUIRED)?;
                 let pin_uv_auth_protocol =
@@ -151,6 +151,7 @@ mod test {
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             PinUvAuthProtocol::V1,
@@ -186,6 +187,7 @@ mod test {
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             PinUvAuthProtocol::V1,
@@ -252,6 +254,7 @@ mod test {
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             PinUvAuthProtocol::V1,
@@ -302,6 +305,7 @@ mod test {
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             PinUvAuthProtocol::V1,
@@ -352,6 +356,7 @@ mod test {
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             PinUvAuthProtocol::V1,
@@ -379,6 +384,7 @@ mod test {
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             PinUvAuthProtocol::V1,
@@ -411,6 +417,7 @@ mod test {
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             pin_uv_auth_protocol,

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -778,8 +778,11 @@ impl CtapState {
             enterprise_attestation,
         } = make_credential_params;
 
-        // TODO: Get the slot id from active token state when multi-PIN is enabled.
-        let slot_id = Some(0);
+        let slot_id = if storage::has_multi_pin(env)? {
+            self.client_pin.get_slot_id_in_use()
+        } else {
+            Some(0)
+        };
 
         self.pin_uv_auth_precheck(
             env,
@@ -1175,8 +1178,11 @@ impl CtapState {
             pin_uv_auth_protocol,
         } = get_assertion_params;
 
-        // TODO: Get the slot id from active token state when multi-PIN is enabled.
-        let slot_id = Some(0);
+        let slot_id = if storage::has_multi_pin(env)? {
+            self.client_pin.get_slot_id_in_use()
+        } else {
+            Some(0)
+        };
 
         self.pin_uv_auth_precheck(
             env,
@@ -2154,6 +2160,7 @@ mod test {
         let pin_uv_auth_token = [0x91; PIN_TOKEN_LENGTH];
         let client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             pin_uv_auth_protocol,
@@ -3067,6 +3074,7 @@ mod test {
         let pin_uv_auth_token = [0x88; 32];
         let client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             pin_uv_auth_protocol,
@@ -3800,6 +3808,7 @@ mod test {
         let pin_uv_auth_token = [0x55; 32];
         let client_pin = ClientPin::new_test(
             &mut env,
+            0,
             key_agreement_key,
             pin_uv_auth_token,
             PinUvAuthProtocol::V1,

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -778,11 +778,7 @@ impl CtapState {
             enterprise_attestation,
         } = make_credential_params;
 
-        let slot_id = if storage::has_multi_pin(env)? {
-            self.client_pin.get_slot_id_in_use()
-        } else {
-            Some(0)
-        };
+        let slot_id = self.client_pin.get_slot_id_in_use_or_default(env)?;
 
         self.pin_uv_auth_precheck(
             env,
@@ -1178,11 +1174,7 @@ impl CtapState {
             pin_uv_auth_protocol,
         } = get_assertion_params;
 
-        let slot_id = if storage::has_multi_pin(env)? {
-            self.client_pin.get_slot_id_in_use()
-        } else {
-            Some(0)
-        };
+        let slot_id = self.client_pin.get_slot_id_in_use_or_default(env)?;
 
         self.pin_uv_auth_precheck(
             env,

--- a/src/ctap/storage/key.rs
+++ b/src/ctap/storage/key.rs
@@ -73,7 +73,9 @@ make_partition! {
     // - When adding a (non-persistent) key below this message, make sure its value is bigger or
     //   equal than NUM_PERSISTENT_KEYS.
 
-    /// If this entry exists and is empty, multi-PIN is enabled.
+    /// Whether multi-PIN is enabled.
+    ///
+    /// The value must be empty. Only presence of the value matters.
     MULTI_PIN = 983;
 
     // Start of key arrays for multi-PIN feature: these fields are separated for each slots, so

--- a/src/ctap/storage/key.rs
+++ b/src/ctap/storage/key.rs
@@ -73,6 +73,9 @@ make_partition! {
     // - When adding a (non-persistent) key below this message, make sure its value is bigger or
     //   equal than NUM_PERSISTENT_KEYS.
 
+    /// If this entry exists and is empty, multi-PIN is enabled.
+    MULTI_PIN = 983;
+
     // Start of key arrays for multi-PIN feature: these fields are separated for each slots, so
     // a unique key is needed for each slot. However, we reuse the existing fields and rename them
     // to `FIRST_{KEY_NAME}` so the upgrade is backward compatible.


### PR DESCRIPTION
I was thinking after adding duplicate test cases for multi-PIN, should we remove the original test case as it is totally covered by mult-PIN case. Removing duplicate code is nice, but I think separating out multi-PIN tests also has advantage as multi-PIN isn't a common use case, and might make the original test case's logic look more complicated. WDYT?