### PR TITLE
Style fix and new Cargo.lock files

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -263,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "linked_list_allocator"
-version = "0.8.11"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822add9edb1860698b79522510da17bef885171f75aa395cff099d770c609c24"
+checksum = "e322f259d225fbae43a1b053b2dc6a5968a6bdf8b205f5de684dab485b95030e"
 
 [[package]]
 name = "log"

--- a/src/ctap/hid/mod.rs
+++ b/src/ctap/hid/mod.rs
@@ -344,8 +344,8 @@ impl CtapHid {
     }
 
     /// Helper function to parse a raw packet.
-    pub fn process_single_packet(packet: &HidPacket) -> (&ChannelID, ProcessedPacket) {
-        let (cid, rest) = array_refs![packet, 4, 60];
+    pub fn process_single_packet(packet: &HidPacket) -> (ChannelID, ProcessedPacket) {
+        let (&cid, rest) = array_refs![packet, 4, 60];
         if rest[0] & CtapHid::PACKET_TYPE_MASK != 0 {
             let cmd = rest[0] & !CtapHid::PACKET_TYPE_MASK;
             let len = (rest[1] as usize) << 8 | (rest[2] as usize);
@@ -605,7 +605,7 @@ mod test {
         packet[..4].copy_from_slice(&cid);
         packet[4..9].copy_from_slice(&[0x81, 0x00, 0x02, 0x99, 0x99]);
         let (processed_cid, processed_packet) = CtapHid::process_single_packet(&packet);
-        assert_eq!(processed_cid, &cid);
+        assert_eq!(processed_cid, cid);
         let expected_packet = ProcessedPacket::InitPacket {
             cmd: CtapHidCommand::Ping as u8,
             len: 2,

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -251,7 +251,7 @@ fn send_keepalive_up_needed(
 
                 // We only parse one packet, because we only care about CANCEL.
                 let (received_cid, processed_packet) = CtapHid::process_single_packet(&pkt);
-                if received_cid != &cid {
+                if received_cid != cid {
                     debug_ctap!(
                         env,
                         "Received a packet on channel ID {:?} while sending a KEEPALIVE packet",

--- a/third_party/lang-items/Cargo.lock
+++ b/third_party/lang-items/Cargo.lock
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "linked_list_allocator"
-version = "0.8.11"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822add9edb1860698b79522510da17bef885171f75aa395cff099d770c609c24"
+checksum = "e322f259d225fbae43a1b053b2dc6a5968a6bdf8b205f5de684dab485b95030e"
 
 [[package]]
 name = "proc-macro2"


### PR DESCRIPTION
The Rust code change is removing references to a Copy type.

The lock files are related to #574.