### PR TITLE
fatal-message: fix the incorrect output of low nrfutil version.

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -745,7 +745,7 @@ class OpenSKInstaller:
       nrfutil_version = __import__("nordicsemi.version").version.NRFUTIL_VERSION
       if not nrfutil_version.startswith("6."):
         fatal(("You need to install nrfutil python3 package v6.0 or above. "
-               "Found: {nrfutil_version}"))
+               f"Found: v{nrfutil_version}"))
       if not SUPPORTED_BOARDS[self.args.board].nordic_dfu:
         fatal("This board doesn't support flashing over DFU.")
 


### PR DESCRIPTION
Fixes the incorrect fatal-message output when the nrfutil is too low.

- [*] Tests pass
- [No Need] Appropriate changes to README are included in PR