### PR TITLE
Fix AuthenticatorConfig parameters

### DIFF
--- a/src/ctap/config_command.rs
+++ b/src/ctap/config_command.rs
@@ -81,8 +81,8 @@ pub fn process_config(
     let AuthenticatorConfigParameters {
         sub_command,
         sub_command_params,
-        pin_uv_auth_param,
         pin_uv_auth_protocol,
+        pin_uv_auth_param,
     } = params;
 
     let enforce_uv =


### PR DESCRIPTION
Fixes #593 

I noticed that Config we lacked the units tests in command. @kaczmarczyck You deserve this bug for forgetting.

Also I verify against an external source of truth, in this case libfido2. See the script in #593 .