### PR TITLE
Removes nrfutil from default install

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,6 +1,6 @@
 name: CIFuzz
 on: 
-  pull_request:
+  push:
     branches:
       - develop
 jobs:

--- a/docs/install.md
+++ b/docs/install.md
@@ -25,6 +25,8 @@ following:
 *   python3 and pip (can be installed with the `python3-pip` package on Debian)
 *   the OpenSSL command line tool (can be installed and configured with the
     `libssl-dev` and `pkg-config` packages on Debian)
+*   `nrfutil` (can be installed using `pip3 install nrfutil`) if you want to flash
+    a device with DFU
 *   `uuid-runtime` if you are missing the `uuidgen` command.
 *   `llvm` if you want to use the upgradability feature.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,3 @@ colorama
 tqdm
 cryptography
 fido2 >= 1.0.0
-
-# DFU install
-nrfutil


### PR DESCRIPTION
Fixes our CI by reverting part of #591 

We will need a better solution for nrfutil eventually, see the discussion in #588. Until then, it shouldn't fail our CI.