### PR TITLE
Moves TockRng to env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,6 @@ name = "rng256"
 version = "0.1.0"
 dependencies = [
  "arrayref",
- "libtock_drivers",
  "rand 0.6.5",
 ]
 

--- a/examples/crypto_bench.rs
+++ b/examples/crypto_bench.rs
@@ -21,11 +21,11 @@ use alloc::format;
 use alloc::vec::Vec;
 use core::fmt::Write;
 use crypto::{aes256, cbc, ecdsa, sha256, Hash256};
+use ctap2::env::tock::TockRng256;
 use libtock_drivers::console::Console;
 use libtock_drivers::result::FlexUnwrap;
 use libtock_drivers::timer;
 use libtock_drivers::timer::{Timer, Timestamp};
-use rng256::TockRng256;
 
 libtock_core::stack_size! {0x800}
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -605,7 +605,6 @@ name = "rng256"
 version = "0.1.0"
 dependencies = [
  "arrayref",
- "libtock_drivers",
  "rand 0.6.5",
 ]
 

--- a/libraries/crypto/Cargo.lock
+++ b/libraries/crypto/Cargo.lock
@@ -127,29 +127,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
 
 [[package]]
-name = "libtock_codegen"
-version = "0.1.0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "libtock_core"
-version = "0.1.0"
-dependencies = [
- "libtock_codegen",
-]
-
-[[package]]
-name = "libtock_drivers"
-version = "0.1.0"
-dependencies = [
- "libtock_core",
-]
-
-[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,7 +317,6 @@ name = "rng256"
 version = "0.1.0"
 dependencies = [
  "arrayref",
- "libtock_drivers",
  "rand",
 ]
 

--- a/libraries/rng256/Cargo.lock
+++ b/libraries/rng256/Cargo.lock
@@ -51,47 +51,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
 
 [[package]]
-name = "libtock_codegen"
-version = "0.1.0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "libtock_core"
-version = "0.1.0"
-dependencies = [
- "libtock_codegen",
-]
-
-[[package]]
-name = "libtock_drivers"
-version = "0.1.0"
-dependencies = [
- "libtock_core",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
-dependencies = [
- "proc-macro2",
-]
-
-[[package]]
 name = "rand"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,26 +170,8 @@ name = "rng256"
 version = "0.1.0"
 dependencies = [
  "arrayref",
- "libtock_drivers",
  "rand",
 ]
-
-[[package]]
-name = "syn"
-version = "1.0.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "unicode-ident"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "winapi"

--- a/libraries/rng256/Cargo.toml
+++ b/libraries/rng256/Cargo.toml
@@ -10,7 +10,6 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-libtock_drivers = { path = "../../third_party/libtock-drivers" }
 arrayref = "0.3.6"
 rand = { version = "0.6.5", optional = true }
 

--- a/libraries/rng256/src/lib.rs
+++ b/libraries/rng256/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 Google LLC
+// Copyright 2019-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use arrayref::array_ref;
-use libtock_drivers::rng;
 #[cfg(feature = "std")]
 use rand::Rng;
 
@@ -39,17 +38,6 @@ fn bytes_to_u32(bytes: [u8; 32]) -> [u32; 8] {
         *r = u32::from_ne_bytes(*array_ref![bytes, 4 * i, 4]);
     }
     result
-}
-
-// RNG backed by the TockOS rng driver.
-pub struct TockRng256 {}
-
-impl Rng256 for TockRng256 {
-    fn gen_uniform_u8x32(&mut self) -> [u8; 32] {
-        let mut buf: [u8; 32] = [Default::default(); 32];
-        rng::fill_buffer(&mut buf);
-        buf
-    }
 }
 
 // For tests on the desktop, we use the cryptographically secure thread rng as entropy source.

--- a/src/env/tock/mod.rs
+++ b/src/env/tock/mod.rs
@@ -31,12 +31,23 @@ use libtock_drivers::buttons::{self, ButtonState};
 use libtock_drivers::console::Console;
 use libtock_drivers::result::{FlexUnwrap, TockError};
 use libtock_drivers::timer::Duration;
-use libtock_drivers::{crp, led, timer, usb_ctap_hid};
+use libtock_drivers::{crp, led, rng, timer, usb_ctap_hid};
 use persistent_store::{StorageResult, Store};
-use rng256::TockRng256;
+use rng256::Rng256;
 
 mod clock;
 mod storage;
+
+/// RNG backed by the TockOS rng driver.
+pub struct TockRng256 {}
+
+impl Rng256 for TockRng256 {
+    fn gen_uniform_u8x32(&mut self) -> [u8; 32] {
+        let mut buf: [u8; 32] = [Default::default(); 32];
+        rng::fill_buffer(&mut buf);
+        buf
+    }
+}
 
 pub struct TockHidConnection {
     endpoint: UsbEndpoint,


### PR DESCRIPTION
Frees our libraries of Tock dependencies.

The generated Cargo.lock files suggest that we are soon ready to move the CTAP code into its own library. The API isn't clean yet, but at least independent of Tock and thus somewhat easier to reuse.