### PR TITLE
Maintenance PR for clippy, license and authors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = [
   "Fabian Kaczmarczyck <kaczmarczyck@google.com>",
   "Guillaume Endignoux <guillaumee@google.com>",
   "Jean-Michel Picod <jmichel@google.com>",
+  "Julien Cretin <cretin@google.com>",
 ]
 license = "Apache-2.0"
 edition = "2018"

--- a/fuzz/fuzz_helper/src/lib.rs
+++ b/fuzz/fuzz_helper/src/lib.rs
@@ -85,7 +85,7 @@ fn initialize(ctap: &mut Ctap<TestEnv>) -> ChannelID {
         cmd: CtapHidCommand::Init,
         payload: nonce,
     };
-    let mut assembler_reply = MessageAssembler::new();
+    let mut assembler_reply = MessageAssembler::default();
     let mut result_cid: ChannelID = Default::default();
     for pkt_request in HidPacketIterator::new(message).unwrap() {
         for pkt_reply in ctap.process_hid_packet(&pkt_request, Transport::MainHid) {
@@ -124,7 +124,7 @@ fn is_type(data: &[u8], input_type: InputType) -> bool {
 fn process_message(data: &[u8], ctap: &mut Ctap<TestEnv>) {
     let message = raw_to_message(data);
     if let Some(hid_packet_iterator) = HidPacketIterator::new(message) {
-        let mut assembler_reply = MessageAssembler::new();
+        let mut assembler_reply = MessageAssembler::default();
         for pkt_request in hid_packet_iterator {
             for pkt_reply in ctap.process_hid_packet(&pkt_request, Transport::MainHid) {
                 // Only checks for assembling crashes, not for semantics.
@@ -140,7 +140,7 @@ fn process_message(data: &[u8], ctap: &mut Ctap<TestEnv>) {
 pub fn process_ctap_any_type(data: &[u8]) -> arbitrary::Result<()> {
     let mut unstructured = Unstructured::new(data);
 
-    let mut env = TestEnv::new();
+    let mut env = TestEnv::default();
     env.rng().seed_from_u64(u64::arbitrary(&mut unstructured)?);
 
     let data = unstructured.take_rest();
@@ -187,7 +187,7 @@ fn setup_state(
 pub fn process_ctap_specific_type(data: &[u8], input_type: InputType) -> arbitrary::Result<()> {
     let mut unstructured = Unstructured::new(data);
 
-    let mut env = TestEnv::new();
+    let mut env = TestEnv::default();
     env.rng().seed_from_u64(u64::arbitrary(&mut unstructured)?);
 
     let data = unstructured.take_rest();
@@ -221,7 +221,7 @@ pub fn process_ctap_specific_type(data: &[u8], input_type: InputType) -> arbitra
 pub fn process_ctap_structured(data: &[u8], input_type: InputType) -> FuzzResult<()> {
     let unstructured = &mut Unstructured::new(data);
 
-    let mut env = TestEnv::new();
+    let mut env = TestEnv::default();
     env.rng().seed_from_u64(u64::arbitrary(unstructured)?);
     setup_customization(unstructured, env.customization_mut())?;
 
@@ -258,13 +258,13 @@ pub fn process_ctap_structured(data: &[u8], input_type: InputType) -> FuzzResult
 pub fn split_assemble_hid_packets(data: &[u8]) -> arbitrary::Result<()> {
     let mut unstructured = Unstructured::new(data);
 
-    let mut env = TestEnv::new();
+    let mut env = TestEnv::default();
     env.rng().seed_from_u64(u64::arbitrary(&mut unstructured)?);
 
     let data = unstructured.take_rest();
     let message = raw_to_message(data);
     if let Some(hid_packet_iterator) = HidPacketIterator::new(message.clone()) {
-        let mut assembler = MessageAssembler::new();
+        let mut assembler = MessageAssembler::default();
         let packets: Vec<HidPacket> = hid_packet_iterator.collect();
         if let Some((last_packet, first_packets)) = packets.split_last() {
             for packet in first_packets {

--- a/libraries/crypto/Cargo.toml
+++ b/libraries/crypto/Cargo.toml
@@ -5,7 +5,6 @@ authors = [
   "Fabian Kaczmarczyck <kaczmarczyck@google.com>",
   "Guillaume Endignoux <guillaumee@google.com>",
   "Jean-Michel Picod <jmichel@google.com>",
-  "Julien Cretin <cretin@google.com>",
 ]
 license = "Apache-2.0"
 edition = "2018"

--- a/libraries/crypto/Cargo.toml
+++ b/libraries/crypto/Cargo.toml
@@ -5,6 +5,7 @@ authors = [
   "Fabian Kaczmarczyck <kaczmarczyck@google.com>",
   "Guillaume Endignoux <guillaumee@google.com>",
   "Jean-Michel Picod <jmichel@google.com>",
+  "Julien Cretin <cretin@google.com>",
 ]
 license = "Apache-2.0"
 edition = "2018"

--- a/libraries/rng256/Cargo.toml
+++ b/libraries/rng256/Cargo.toml
@@ -5,7 +5,6 @@ authors = [
   "Fabian Kaczmarczyck <kaczmarczyck@google.com>",
   "Guillaume Endignoux <guillaumee@google.com>",
   "Jean-Michel Picod <jmichel@google.com>",
-  "Julien Cretin <cretin@google.com>",
 ]
 license = "Apache-2.0"
 edition = "2018"

--- a/libraries/rng256/Cargo.toml
+++ b/libraries/rng256/Cargo.toml
@@ -5,6 +5,7 @@ authors = [
   "Fabian Kaczmarczyck <kaczmarczyck@google.com>",
   "Guillaume Endignoux <guillaumee@google.com>",
   "Jean-Michel Picod <jmichel@google.com>",
+  "Julien Cretin <cretin@google.com>",
 ]
 license = "Apache-2.0"
 edition = "2018"

--- a/run_desktop_tests.sh
+++ b/run_desktop_tests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2019 Google LLC
+# Copyright 2019-2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,9 +37,9 @@ cargo fmt --all -- --check
 cd ..
 
 echo "Running Clippy lints..."
-cargo clippy --all-targets --features std -- -A clippy::new_without_default -D warnings
-cargo clippy --all-targets --features std,with_ctap1,ed25519,vendor_hid -- -A clippy::new_without_default -D warnings
-cargo clippy --all-targets --features std,with_ctap1,with_nfc,ed25519,vendor_hid -- -A clippy::new_without_default -D warnings
+cargo clippy --all-targets --features std -- -D warnings
+cargo clippy --all-targets --features std,with_ctap1,ed25519,vendor_hid -- -D warnings
+cargo clippy --all-targets --features std,with_ctap1,with_nfc,ed25519,vendor_hid -- -D warnings
 
 echo "Building sha256sum tool..."
 cargo build --manifest-path third_party/tock/tools/sha256sum/Cargo.toml

--- a/src/api/attestation_store.rs
+++ b/src/api/attestation_store.rs
@@ -1,3 +1,17 @@
+// Copyright 2022-2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use alloc::vec::Vec;
 use persistent_store::{StoreError, StoreUpdate};
 

--- a/src/api/connection.rs
+++ b/src/api/connection.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2022-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/api/customization.rs
+++ b/src/api/customization.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2022-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/api/firmware_protection.rs
+++ b/src/api/firmware_protection.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2022-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/api/key_store.rs
+++ b/src/api/key_store.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2022-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -123,7 +123,7 @@ mod test {
 
     #[test]
     fn test_key_store() {
-        let mut env = crate::env::test::TestEnv::new();
+        let mut env = crate::env::test::TestEnv::default();
         let key_store = env.key_store();
 
         // Master keys are well-defined and stable.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2022-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/api/upgrade_storage/helper.rs
+++ b/src/api/upgrade_storage/helper.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 Google LLC
+// Copyright 2019-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/api/upgrade_storage/mod.rs
+++ b/src/api/upgrade_storage/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 Google LLC
+// Copyright 2021-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/api/user_presence.rs
+++ b/src/api/user_presence.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2022-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ctap/apdu.rs
+++ b/src/ctap/apdu.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Google LLC
+// Copyright 2020-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ctap/client_pin.rs
+++ b/src/ctap/client_pin.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Google LLC
+// Copyright 2020-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -597,7 +597,7 @@ mod test {
     /// Fails on PINs bigger than 64 bytes.
     fn encrypt_pin(shared_secret: &dyn SharedSecret, pin: Vec<u8>) -> Vec<u8> {
         assert!(pin.len() <= 64);
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut padded_pin = [0u8; 64];
         padded_pin[..pin.len()].copy_from_slice(&pin[..]);
         shared_secret.encrypt(env.rng(), &padded_pin).unwrap()
@@ -612,7 +612,7 @@ mod test {
     fn create_client_pin_and_shared_secret(
         pin_uv_auth_protocol: PinUvAuthProtocol,
     ) -> (ClientPin<TestEnv>, Box<dyn SharedSecret>) {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pk = key_agreement_key.genpk();
         let key_agreement = CoseKey::from(pk);
@@ -637,7 +637,7 @@ mod test {
         pin_uv_auth_protocol: PinUvAuthProtocol,
         sub_command: ClientPinSubCommand,
     ) -> (ClientPin<TestEnv>, AuthenticatorClientPinParameters) {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let (client_pin, shared_secret) = create_client_pin_and_shared_secret(pin_uv_auth_protocol);
 
         let pin = b"1234";
@@ -679,7 +679,7 @@ mod test {
 
     #[test]
     fn test_mix_pin_protocols() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let client_pin = ClientPin::<TestEnv>::new(&mut env);
         let pin_protocol_v1 = client_pin.get_pin_protocol(PinUvAuthProtocol::V1);
         let pin_protocol_v2 = client_pin.get_pin_protocol(PinUvAuthProtocol::V2);
@@ -720,7 +720,7 @@ mod test {
     }
 
     fn test_helper_verify_pin_hash_enc(pin_uv_auth_protocol: PinUvAuthProtocol) {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut client_pin = ClientPin::<TestEnv>::new(&mut env);
         let pin_protocol = client_pin.get_pin_protocol(pin_uv_auth_protocol);
         let shared_secret = pin_protocol
@@ -812,7 +812,7 @@ mod test {
             pin_uv_auth_protocol,
             ClientPinSubCommand::GetPinRetries,
         );
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let expected_response = Some(AuthenticatorClientPinResponse {
             key_agreement: None,
             pin_uv_auth_token: None,
@@ -852,7 +852,7 @@ mod test {
             pin_uv_auth_protocol,
             ClientPinSubCommand::GetKeyAgreement,
         );
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let expected_response = Some(AuthenticatorClientPinResponse {
             key_agreement: params.key_agreement.clone(),
             pin_uv_auth_token: None,
@@ -881,7 +881,7 @@ mod test {
             PinUvAuthProtocol::V1,
             ClientPinSubCommand::GetKeyAgreement,
         );
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         env.customization_mut().set_allows_pin_protocol_v1(false);
         assert_eq!(
             client_pin.process_command(&mut env, params),
@@ -892,7 +892,7 @@ mod test {
     fn test_helper_process_set_pin(pin_uv_auth_protocol: PinUvAuthProtocol) {
         let (mut client_pin, params) =
             create_client_pin_and_parameters(pin_uv_auth_protocol, ClientPinSubCommand::SetPin);
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         assert_eq!(
             client_pin.process_command(&mut env, params),
             Ok(ResponseData::AuthenticatorClientPin(None))
@@ -919,7 +919,7 @@ mod test {
                 params.pin_uv_auth_protocol,
             )
             .unwrap();
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         set_standard_pin(&mut env);
 
         let mut auth_param_data = params.new_pin_enc.clone().unwrap();
@@ -969,7 +969,7 @@ mod test {
                 params.pin_uv_auth_protocol,
             )
             .unwrap();
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         set_standard_pin(&mut env);
 
         let response = client_pin
@@ -1029,7 +1029,7 @@ mod test {
             pin_uv_auth_protocol,
             ClientPinSubCommand::GetPinToken,
         );
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         set_standard_pin(&mut env);
 
         assert_eq!(storage::force_pin_change(&mut env), Ok(()));
@@ -1063,7 +1063,7 @@ mod test {
                 params.pin_uv_auth_protocol,
             )
             .unwrap();
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         set_standard_pin(&mut env);
 
         let response = client_pin
@@ -1139,7 +1139,7 @@ mod test {
             pin_uv_auth_protocol,
             ClientPinSubCommand::GetPinUvAuthTokenUsingPinWithPermissions,
         );
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         set_standard_pin(&mut env);
 
         assert_eq!(storage::force_pin_change(&mut env), Ok(()));
@@ -1164,7 +1164,7 @@ mod test {
     }
 
     fn test_helper_decrypt_pin(pin_uv_auth_protocol: PinUvAuthProtocol) {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let pin_protocol = PinProtocol::new(env.rng());
         let shared_secret = pin_protocol
             .decapsulate(pin_protocol.get_public_key(), pin_uv_auth_protocol)
@@ -1208,7 +1208,7 @@ mod test {
     }
 
     fn test_helper_check_and_store_new_pin(pin_uv_auth_protocol: PinUvAuthProtocol) {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let pin_protocol = PinProtocol::new(env.rng());
         let shared_secret = pin_protocol
             .decapsulate(pin_protocol.get_public_key(), pin_uv_auth_protocol)
@@ -1265,7 +1265,7 @@ mod test {
         cred_random: &[u8; 32],
         salt: Vec<u8>,
     ) -> Result<Vec<u8>, Ctap2StatusCode> {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let (client_pin, shared_secret) = create_client_pin_and_shared_secret(pin_uv_auth_protocol);
 
         let salt_enc = shared_secret.as_ref().encrypt(env.rng(), &salt).unwrap();
@@ -1283,7 +1283,7 @@ mod test {
     }
 
     fn test_helper_process_hmac_secret_bad_salt_auth(pin_uv_auth_protocol: PinUvAuthProtocol) {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let (client_pin, shared_secret) = create_client_pin_and_shared_secret(pin_uv_auth_protocol);
         let cred_random = [0xC9; 32];
 
@@ -1399,7 +1399,7 @@ mod test {
 
     #[test]
     fn test_has_permission() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut client_pin = ClientPin::<TestEnv>::new(&mut env);
         client_pin.pin_uv_auth_token_state.set_permissions(0x7F);
         for permission in PinPermission::into_enum_iter() {
@@ -1423,7 +1423,7 @@ mod test {
 
     #[test]
     fn test_has_no_rp_id_permission() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut client_pin = ClientPin::<TestEnv>::new(&mut env);
         assert_eq!(client_pin.has_no_rp_id_permission(), Ok(()));
         client_pin
@@ -1437,7 +1437,7 @@ mod test {
 
     #[test]
     fn test_has_no_or_rp_id_permission() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut client_pin = ClientPin::<TestEnv>::new(&mut env);
         assert_eq!(client_pin.has_no_or_rp_id_permission("example.com"), Ok(()));
         client_pin
@@ -1452,7 +1452,7 @@ mod test {
 
     #[test]
     fn test_has_no_or_rp_id_hash_permission() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut client_pin = ClientPin::<TestEnv>::new(&mut env);
         let rp_id_hash = Sha256::hash(b"example.com");
         assert_eq!(
@@ -1474,7 +1474,7 @@ mod test {
 
     #[test]
     fn test_ensure_rp_id_permission() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut client_pin = ClientPin::<TestEnv>::new(&mut env);
         assert_eq!(client_pin.ensure_rp_id_permission("example.com"), Ok(()));
         assert_eq!(
@@ -1492,7 +1492,7 @@ mod test {
 
     #[test]
     fn test_verify_pin_uv_auth_token() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut client_pin = ClientPin::<TestEnv>::new(&mut env);
         let message = [0xAA];
         client_pin
@@ -1566,7 +1566,7 @@ mod test {
 
     #[test]
     fn test_verify_pin_uv_auth_token_not_in_use() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let client_pin = ClientPin::<TestEnv>::new(&mut env);
         let message = [0xAA];
 
@@ -1588,7 +1588,7 @@ mod test {
 
     #[test]
     fn test_reset() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut client_pin = ClientPin::<TestEnv>::new(&mut env);
         let public_key_v1 = client_pin.pin_protocol_v1.get_public_key();
         let public_key_v2 = client_pin.pin_protocol_v2.get_public_key();
@@ -1624,7 +1624,7 @@ mod test {
             PinUvAuthProtocol::V2,
             ClientPinSubCommand::GetPinUvAuthTokenUsingPinWithPermissions,
         );
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         set_standard_pin(&mut env);
         params.permissions = Some(0xFF);
 
@@ -1668,7 +1668,7 @@ mod test {
             PinUvAuthProtocol::V2,
             ClientPinSubCommand::GetPinUvAuthTokenUsingPinWithPermissions,
         );
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         set_standard_pin(&mut env);
         params.permissions = Some(0xFF);
 

--- a/src/ctap/command.rs
+++ b/src/ctap/command.rs
@@ -740,7 +740,7 @@ mod test {
 
     #[test]
     fn test_from_cbor_client_pin_parameters() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let sk = crypto::ecdh::SecKey::gensk(env.rng());
         let pk = sk.genpk();
         let cose_key = CoseKey::from(pk);

--- a/src/ctap/config_command.rs
+++ b/src/ctap/config_command.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Google LLC
+// Copyright 2020-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -130,7 +130,7 @@ mod test {
 
     #[test]
     fn test_process_enable_enterprise_attestation() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::<TestEnv>::new_test(
@@ -161,7 +161,7 @@ mod test {
 
     #[test]
     fn test_process_toggle_always_uv() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::<TestEnv>::new_test(
@@ -200,7 +200,7 @@ mod test {
     }
 
     fn test_helper_process_toggle_always_uv_with_pin(pin_uv_auth_protocol: PinUvAuthProtocol) {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::<TestEnv>::new_test(
@@ -274,7 +274,7 @@ mod test {
 
     #[test]
     fn test_process_set_min_pin_length() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::<TestEnv>::new_test(
@@ -322,7 +322,7 @@ mod test {
 
     #[test]
     fn test_process_set_min_pin_length_rp_ids() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::<TestEnv>::new_test(
@@ -402,7 +402,7 @@ mod test {
 
     #[test]
     fn test_process_set_min_pin_length_force_pin_change_implicit() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::<TestEnv>::new_test(
@@ -429,7 +429,7 @@ mod test {
 
     #[test]
     fn test_process_set_min_pin_length_force_pin_change_explicit() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::<TestEnv>::new_test(
@@ -464,7 +464,7 @@ mod test {
 
     #[test]
     fn test_process_config_vendor_prototype() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::<TestEnv>::new_test(

--- a/src/ctap/credential_id.rs
+++ b/src/ctap/credential_id.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2022-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -277,7 +277,7 @@ mod test {
     const UNSUPPORTED_CREDENTIAL_ID_VERSION: u8 = 0x80;
 
     fn test_encrypt_decrypt_credential(signature_algorithm: SignatureAlgorithm) {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let private_key = PrivateKey::new(&mut env, signature_algorithm);
 
         let rp_id_hash = [0x55; 32];
@@ -303,7 +303,7 @@ mod test {
 
     #[test]
     fn test_encrypt_decrypt_bad_version() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let private_key = PrivateKey::new(&mut env, SignatureAlgorithm::Es256);
 
         let rp_id_hash = [0x55; 32];
@@ -323,7 +323,7 @@ mod test {
     }
 
     fn test_encrypt_decrypt_bad_hmac(signature_algorithm: SignatureAlgorithm) {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let private_key = PrivateKey::new(&mut env, signature_algorithm);
 
         let rp_id_hash = [0x55; 32];
@@ -351,7 +351,7 @@ mod test {
     }
 
     fn test_decrypt_credential_missing_blocks(signature_algorithm: SignatureAlgorithm) {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let private_key = PrivateKey::new(&mut env, signature_algorithm);
 
         let rp_id_hash = [0x55; 32];
@@ -400,7 +400,7 @@ mod test {
 
     #[test]
     fn test_encrypt_decrypt_credential_legacy() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let private_key = PrivateKey::new_ecdsa(&mut env);
         let ecdsa_key = private_key.ecdsa_key(&mut env).unwrap();
 
@@ -418,7 +418,7 @@ mod test {
 
     #[test]
     fn test_encrypt_credential_size() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let private_key = PrivateKey::new(&mut env, SignatureAlgorithm::Es256);
 
         let rp_id_hash = [0x55; 32];
@@ -431,7 +431,7 @@ mod test {
     fn test_encrypt_credential_max_cbor_size() {
         // The cbor encoding length is variadic and depends on size of fields. Try to put maximum length
         // for each encoded field and ensure that it doesn't go over the padding size.
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         // Currently all private key types have same length when transformed to bytes.
         let private_key = PrivateKey::new(&mut env, SignatureAlgorithm::Es256);
         let rp_id_hash = [0x55; 32];
@@ -451,7 +451,7 @@ mod test {
 
     #[test]
     fn test_cred_protect_persisted() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let private_key = PrivateKey::new(&mut env, SignatureAlgorithm::Es256);
 
         let rp_id_hash = [0x55; 32];
@@ -476,7 +476,7 @@ mod test {
 
     #[test]
     fn test_cred_blob_persisted() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let private_key = PrivateKey::new(&mut env, SignatureAlgorithm::Es256);
 
         let rp_id_hash = [0x55; 32];

--- a/src/ctap/credential_management.rs
+++ b/src/ctap/credential_management.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Google LLC
+// Copyright 2020-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -383,7 +383,7 @@ mod test {
     }
 
     fn test_helper_process_get_creds_metadata(pin_uv_auth_protocol: PinUvAuthProtocol) {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let client_pin = ClientPin::<TestEnv>::new_test(
@@ -467,7 +467,7 @@ mod test {
 
     #[test]
     fn test_process_enumerate_rps_with_uv() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let client_pin = ClientPin::<TestEnv>::new_test(
@@ -562,7 +562,7 @@ mod test {
 
     #[test]
     fn test_process_enumerate_rps_completeness() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let client_pin = ClientPin::<TestEnv>::new_test(
@@ -645,7 +645,7 @@ mod test {
 
     #[test]
     fn test_process_enumerate_credentials_with_uv() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let client_pin = ClientPin::<TestEnv>::new_test(
@@ -748,7 +748,7 @@ mod test {
 
     #[test]
     fn test_process_delete_credential() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let client_pin = ClientPin::<TestEnv>::new_test(
@@ -820,7 +820,7 @@ mod test {
 
     #[test]
     fn test_process_update_user_information() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let client_pin = ClientPin::<TestEnv>::new_test(
@@ -891,7 +891,7 @@ mod test {
 
     #[test]
     fn test_process_credential_management_invalid_pin_uv_auth_param() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::new(&mut env);
 
         storage::set_pin(&mut env, &[0u8; 16], 4).unwrap();

--- a/src/ctap/crypto_wrapper.rs
+++ b/src/ctap/crypto_wrapper.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2021-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -226,7 +226,7 @@ mod test {
 
     #[test]
     fn test_encrypt_decrypt_with_iv() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let aes_enc_key = crypto::aes256::EncryptionKey::new(&[0xC2; 32]);
         let plaintext = vec![0xAA; 64];
         let ciphertext = aes256_cbc_encrypt(env.rng(), &aes_enc_key, &plaintext, true).unwrap();
@@ -236,7 +236,7 @@ mod test {
 
     #[test]
     fn test_encrypt_decrypt_without_iv() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let aes_enc_key = crypto::aes256::EncryptionKey::new(&[0xC2; 32]);
         let plaintext = vec![0xAA; 64];
         let ciphertext = aes256_cbc_encrypt(env.rng(), &aes_enc_key, &plaintext, false).unwrap();
@@ -246,7 +246,7 @@ mod test {
 
     #[test]
     fn test_correct_iv_usage() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let aes_enc_key = crypto::aes256::EncryptionKey::new(&[0xC2; 32]);
         let plaintext = vec![0xAA; 64];
         let mut ciphertext_no_iv =
@@ -259,7 +259,7 @@ mod test {
 
     #[test]
     fn test_iv_manipulation_property() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let aes_enc_key = crypto::aes256::EncryptionKey::new(&[0xC2; 32]);
         let plaintext = vec![0xAA; 64];
         let mut ciphertext = aes256_cbc_encrypt(env.rng(), &aes_enc_key, &plaintext, true).unwrap();
@@ -274,7 +274,7 @@ mod test {
 
     #[test]
     fn test_chaining() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let aes_enc_key = crypto::aes256::EncryptionKey::new(&[0xC2; 32]);
         let plaintext = vec![0xAA; 64];
         let ciphertext1 = aes256_cbc_encrypt(env.rng(), &aes_enc_key, &plaintext, true).unwrap();
@@ -291,7 +291,7 @@ mod test {
 
     #[test]
     fn test_new_ecdsa_from_bytes() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let private_key = PrivateKey::new(&mut env, SignatureAlgorithm::Es256);
         let key_bytes = private_key.to_bytes();
         assert_eq!(
@@ -303,7 +303,7 @@ mod test {
     #[test]
     #[cfg(feature = "ed25519")]
     fn test_new_ed25519_from_bytes() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let private_key = PrivateKey::new(&mut env, SignatureAlgorithm::Eddsa);
         let key_bytes = private_key.to_bytes();
         assert_eq!(
@@ -331,7 +331,7 @@ mod test {
 
     #[test]
     fn test_private_key_get_pub_key() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let private_key = PrivateKey::new_ecdsa(&mut env);
         let ecdsa_key = private_key.ecdsa_key(&mut env).unwrap();
         let public_key = ecdsa_key.genpk();
@@ -343,7 +343,7 @@ mod test {
 
     #[test]
     fn test_private_key_sign_and_encode() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let message = [0x5A; 32];
         let private_key = PrivateKey::new_ecdsa(&mut env);
         let ecdsa_key = private_key.ecdsa_key(&mut env).unwrap();
@@ -355,7 +355,7 @@ mod test {
     }
 
     fn test_private_key_signature_algorithm(signature_algorithm: SignatureAlgorithm) {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let private_key = PrivateKey::new(&mut env, signature_algorithm);
         assert_eq!(private_key.signature_algorithm(), signature_algorithm);
     }
@@ -372,7 +372,7 @@ mod test {
     }
 
     fn test_private_key_from_to_cbor(signature_algorithm: SignatureAlgorithm) {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let private_key = PrivateKey::new(&mut env, signature_algorithm);
         let cbor = cbor::Value::from(&private_key);
         assert_eq!(PrivateKey::try_from(cbor), Ok(private_key),);

--- a/src/ctap/ctap1.rs
+++ b/src/ctap/ctap1.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 Google LLC
+// Copyright 2019-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -388,7 +388,7 @@ mod test {
 
     #[test]
     fn test_process_allowed() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         env.user_presence()
             .set(|| panic!("Unexpected user presence check in CTAP1"));
         let mut ctap_state = CtapState::new(&mut env);
@@ -404,7 +404,7 @@ mod test {
 
     #[test]
     fn test_process_register() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         env.user_presence()
             .set(|| panic!("Unexpected user presence check in CTAP1"));
         let mut ctap_state = CtapState::new(&mut env);
@@ -445,7 +445,7 @@ mod test {
 
     #[test]
     fn test_process_register_bad_message() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         env.user_presence()
             .set(|| panic!("Unexpected user presence check in CTAP1"));
         let mut ctap_state = CtapState::new(&mut env);
@@ -463,7 +463,7 @@ mod test {
         let application = [0x0A; 32];
         let message = create_register_message(&application);
 
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         env.user_presence()
             .set(|| panic!("Unexpected user presence check in CTAP1"));
         let mut ctap_state = CtapState::new(&mut env);
@@ -477,7 +477,7 @@ mod test {
 
     #[test]
     fn test_process_authenticate_check_only() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         env.user_presence()
             .set(|| panic!("Unexpected user presence check in CTAP1"));
         let sk = PrivateKey::new(&mut env, SignatureAlgorithm::Es256);
@@ -494,7 +494,7 @@ mod test {
 
     #[test]
     fn test_process_authenticate_check_only_wrong_rp() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         env.user_presence()
             .set(|| panic!("Unexpected user presence check in CTAP1"));
         let sk = PrivateKey::new(&mut env, SignatureAlgorithm::Es256);
@@ -512,7 +512,7 @@ mod test {
 
     #[test]
     fn test_process_authenticate_check_only_wrong_length() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         env.user_presence()
             .set(|| panic!("Unexpected user presence check in CTAP1"));
         let sk = PrivateKey::new(&mut env, SignatureAlgorithm::Es256);
@@ -546,7 +546,7 @@ mod test {
 
     #[test]
     fn test_process_authenticate_check_only_wrong_cla() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         env.user_presence()
             .set(|| panic!("Unexpected user presence check in CTAP1"));
         let sk = PrivateKey::new(&mut env, SignatureAlgorithm::Es256);
@@ -565,7 +565,7 @@ mod test {
 
     #[test]
     fn test_process_authenticate_check_only_wrong_ins() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         env.user_presence()
             .set(|| panic!("Unexpected user presence check in CTAP1"));
         let sk = PrivateKey::new(&mut env, SignatureAlgorithm::Es256);
@@ -584,7 +584,7 @@ mod test {
 
     #[test]
     fn test_process_authenticate_check_only_wrong_flags() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         env.user_presence()
             .set(|| panic!("Unexpected user presence check in CTAP1"));
         let sk = PrivateKey::new(&mut env, SignatureAlgorithm::Es256);
@@ -611,7 +611,7 @@ mod test {
 
     #[test]
     fn test_process_authenticate_enforce() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         env.user_presence()
             .set(|| panic!("Unexpected user presence check in CTAP1"));
         let sk = PrivateKey::new(&mut env, SignatureAlgorithm::Es256);
@@ -637,7 +637,7 @@ mod test {
 
     #[test]
     fn test_process_authenticate_dont_enforce() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         env.user_presence()
             .set(|| panic!("Unexpected user presence check in CTAP1"));
         let sk = PrivateKey::new(&mut env, SignatureAlgorithm::Es256);
@@ -670,7 +670,7 @@ mod test {
         let message =
             create_authenticate_message(&application, Ctap1Flags::EnforceUpAndSign, &key_handle);
 
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         env.user_presence()
             .set(|| panic!("Unexpected user presence check in CTAP1"));
         let mut ctap_state = CtapState::new(&mut env);
@@ -688,7 +688,7 @@ mod test {
         let message =
             create_authenticate_message(&application, Ctap1Flags::EnforceUpAndSign, &key_handle);
 
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         env.user_presence()
             .set(|| panic!("Unexpected user presence check in CTAP1"));
         let mut ctap_state = CtapState::new(&mut env);

--- a/src/ctap/data_formats.rs
+++ b/src/ctap/data_formats.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 Google LLC
+// Copyright 2019-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1733,7 +1733,7 @@ mod test {
 
     #[test]
     fn test_from_get_assertion_extensions_default_protocol() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let sk = crypto::ecdh::SecKey::gensk(env.rng());
         let pk = sk.genpk();
         let cose_key = CoseKey::from(pk);
@@ -1763,7 +1763,7 @@ mod test {
 
     #[test]
     fn test_from_get_assertion_extensions_with_protocol() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let sk = crypto::ecdh::SecKey::gensk(env.rng());
         let pk = sk.genpk();
         let cose_key = CoseKey::from(pk);
@@ -1938,7 +1938,7 @@ mod test {
 
     #[test]
     fn test_from_into_cose_key_ecdh() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let sk = crypto::ecdh::SecKey::gensk(env.rng());
         let pk = sk.genpk();
         let cose_key = CoseKey::from(pk.clone());
@@ -1948,7 +1948,7 @@ mod test {
 
     #[test]
     fn test_into_cose_key_ecdsa() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let sk = crypto::ecdsa::SecKey::gensk(env.rng());
         let pk = sk.genpk();
         let cose_key = CoseKey::from(pk);
@@ -2108,7 +2108,7 @@ mod test {
 
     #[test]
     fn test_credential_source_cbor_round_trip() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let private_key = PrivateKey::new_ecdsa(&mut env);
         let credential = PublicKeyCredentialSource {
             key_type: PublicKeyCredentialType::PublicKey,
@@ -2193,7 +2193,7 @@ mod test {
 
     #[test]
     fn test_credential_source_cbor_read_legacy() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let private_key = PrivateKey::new_ecdsa(&mut env);
         let key_bytes = private_key.to_bytes();
         let credential = PublicKeyCredentialSource {
@@ -2225,7 +2225,7 @@ mod test {
 
     #[test]
     fn test_credential_source_cbor_legacy_error() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let private_key = PrivateKey::new_ecdsa(&mut env);
         let key_bytes = private_key.to_bytes();
         let credential = PublicKeyCredentialSource {

--- a/src/ctap/hid/mod.rs
+++ b/src/ctap/hid/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 Google LLC
+// Copyright 2019-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -200,7 +200,7 @@ impl<E: Env> CtapHid<E> {
     /// The capabilities passed in are reported to the client in Init.
     pub fn new(capabilities: u8) -> CtapHid<E> {
         Self {
-            assembler: MessageAssembler::new(),
+            assembler: MessageAssembler::default(),
             allocated_cids: 0,
             capabilities,
         }
@@ -396,7 +396,7 @@ impl<E: Env> CtapHid<E> {
     pub fn new_initialized() -> (Self, ChannelID) {
         (
             Self {
-                assembler: MessageAssembler::new(),
+                assembler: MessageAssembler::default(),
                 allocated_cids: 1,
                 capabilities: 0x0D,
             },
@@ -411,7 +411,7 @@ mod test {
 
     #[test]
     fn test_split_assemble() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         for payload_len in 0..7609 {
             let message = Message {
                 cid: [0x12, 0x34, 0x56, 0x78],
@@ -420,7 +420,7 @@ mod test {
             };
 
             let mut messages = Vec::new();
-            let mut assembler = MessageAssembler::<TestEnv>::new();
+            let mut assembler = MessageAssembler::<TestEnv>::default();
             for packet in HidPacketIterator::new(message.clone()).unwrap() {
                 match assembler.parse_packet(&mut env, &packet) {
                     Ok(Some(msg)) => messages.push(msg),
@@ -435,7 +435,7 @@ mod test {
 
     #[test]
     fn test_spurious_continuation_packet() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_hid = CtapHid::<TestEnv>::new(0x0D);
         let mut packet = [0x00; 64];
         packet[0..7].copy_from_slice(&[0xC1, 0xC1, 0xC1, 0xC1, 0x00, 0x51, 0x51]);
@@ -470,7 +470,7 @@ mod test {
 
     #[test]
     fn test_command_init_for_sync() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let (mut ctap_hid, cid) = CtapHid::<TestEnv>::new_initialized();
 
         // Ping packet with a length longer than one packet.
@@ -502,7 +502,7 @@ mod test {
 
     #[test]
     fn test_command_ping() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let (mut ctap_hid, cid) = CtapHid::<TestEnv>::new_initialized();
 
         let mut ping_packet = [0x00; 64];
@@ -520,7 +520,7 @@ mod test {
 
     #[test]
     fn test_command_cancel() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let (mut ctap_hid, cid) = CtapHid::<TestEnv>::new_initialized();
 
         let mut cancel_packet = [0x00; 64];

--- a/src/ctap/hid/receive.rs
+++ b/src/ctap/hid/receive.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 Google LLC
+// Copyright 2019-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,8 +42,8 @@ pub struct MessageAssembler<E: Env> {
     payload: Vec<u8>,
 }
 
-impl<E: Env> MessageAssembler<E> {
-    pub fn new() -> MessageAssembler<E> {
+impl<E: Env> Default for MessageAssembler<E> {
+    fn default() -> MessageAssembler<E> {
         MessageAssembler {
             idle: true,
             cid: [0, 0, 0, 0],
@@ -54,7 +54,9 @@ impl<E: Env> MessageAssembler<E> {
             payload: Vec::new(),
         }
     }
+}
 
+impl<E: Env> MessageAssembler<E> {
     // Resets the message assembler to the idle state.
     // The caller can reset the assembler for example due to a timeout.
     fn reset(&mut self) {
@@ -207,8 +209,8 @@ mod test {
 
     #[test]
     fn test_empty_payload() {
-        let mut env = TestEnv::new();
-        let mut assembler = MessageAssembler::new();
+        let mut env = TestEnv::default();
+        let mut assembler = MessageAssembler::default();
         assert_eq!(
             assembler.parse_packet(&mut env, &zero_extend(&[0x12, 0x34, 0x56, 0x78, 0x90])),
             Ok(Some(Message {
@@ -221,8 +223,8 @@ mod test {
 
     #[test]
     fn test_one_packet() {
-        let mut env = TestEnv::new();
-        let mut assembler = MessageAssembler::new();
+        let mut env = TestEnv::default();
+        let mut assembler = MessageAssembler::default();
         assert_eq!(
             assembler.parse_packet(
                 &mut env,
@@ -238,11 +240,11 @@ mod test {
 
     #[test]
     fn test_nonzero_padding() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         // CTAP specification (version 20190130) section 8.1.4
         // It is written that "Unused bytes SHOULD be set to zero", so we test that non-zero
         // padding is accepted as well.
-        let mut assembler = MessageAssembler::new();
+        let mut assembler = MessageAssembler::default();
         assert_eq!(
             assembler.parse_packet(
                 &mut env,
@@ -258,8 +260,8 @@ mod test {
 
     #[test]
     fn test_two_packets() {
-        let mut env = TestEnv::new();
-        let mut assembler = MessageAssembler::new();
+        let mut env = TestEnv::default();
+        let mut assembler = MessageAssembler::default();
         assert_eq!(
             assembler.parse_packet(
                 &mut env,
@@ -279,8 +281,8 @@ mod test {
 
     #[test]
     fn test_three_packets() {
-        let mut env = TestEnv::new();
-        let mut assembler = MessageAssembler::new();
+        let mut env = TestEnv::default();
+        let mut assembler = MessageAssembler::default();
         assert_eq!(
             assembler.parse_packet(
                 &mut env,
@@ -304,8 +306,8 @@ mod test {
 
     #[test]
     fn test_max_packets() {
-        let mut env = TestEnv::new();
-        let mut assembler = MessageAssembler::new();
+        let mut env = TestEnv::default();
+        let mut assembler = MessageAssembler::default();
         assert_eq!(
             assembler.parse_packet(
                 &mut env,
@@ -331,9 +333,9 @@ mod test {
 
     #[test]
     fn test_multiple_messages() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         // Check that after yielding a message, the assembler is ready to process new messages.
-        let mut assembler = MessageAssembler::new();
+        let mut assembler = MessageAssembler::default();
         for i in 0..10 {
             // Introduce some variability in the messages.
             let cmd = CtapHidCommand::from(i + 1);
@@ -372,9 +374,9 @@ mod test {
 
     #[test]
     fn test_channel_switch() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         // Check that the assembler can process messages from multiple channels, sequentially.
-        let mut assembler = MessageAssembler::new();
+        let mut assembler = MessageAssembler::default();
         for i in 0..10 {
             // Introduce some variability in the messages.
             let cid = 0x78 + i;
@@ -407,8 +409,8 @@ mod test {
 
     #[test]
     fn test_unexpected_channel() {
-        let mut env = TestEnv::new();
-        let mut assembler = MessageAssembler::new();
+        let mut env = TestEnv::default();
+        let mut assembler = MessageAssembler::default();
         assert_eq!(
             assembler.parse_packet(
                 &mut env,
@@ -443,11 +445,11 @@ mod test {
 
     #[test]
     fn test_spurious_continuation_packets() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         // CTAP specification (version 20190130) section 8.1.5.4
         // Spurious continuation packets appearing without a prior initialization packet will be
         // ignored.
-        let mut assembler = MessageAssembler::new();
+        let mut assembler = MessageAssembler::default();
         for i in 0..0x80 {
             // Some legit packet.
             let byte = 2 * i;
@@ -477,8 +479,8 @@ mod test {
 
     #[test]
     fn test_unexpected_init() {
-        let mut env = TestEnv::new();
-        let mut assembler = MessageAssembler::new();
+        let mut env = TestEnv::default();
+        let mut assembler = MessageAssembler::default();
         assert_eq!(
             assembler.parse_packet(
                 &mut env,
@@ -494,8 +496,8 @@ mod test {
 
     #[test]
     fn test_unexpected_seq() {
-        let mut env = TestEnv::new();
-        let mut assembler = MessageAssembler::new();
+        let mut env = TestEnv::default();
+        let mut assembler = MessageAssembler::default();
         assert_eq!(
             assembler.parse_packet(
                 &mut env,
@@ -511,8 +513,8 @@ mod test {
 
     #[test]
     fn test_timed_out_packet() {
-        let mut env = TestEnv::new();
-        let mut assembler = MessageAssembler::new();
+        let mut env = TestEnv::default();
+        let mut assembler = MessageAssembler::default();
         assert_eq!(
             assembler.parse_packet(
                 &mut env,
@@ -529,11 +531,11 @@ mod test {
 
     #[test]
     fn test_just_in_time_packets() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         // Delay between each packet is just below the threshold.
         let delay = TIMEOUT_DURATION_MS - 1;
 
-        let mut assembler = MessageAssembler::new();
+        let mut assembler = MessageAssembler::default();
         assert_eq!(
             assembler.parse_packet(
                 &mut env,
@@ -561,8 +563,8 @@ mod test {
 
     #[test]
     fn test_init_sync() {
-        let mut env = TestEnv::new();
-        let mut assembler = MessageAssembler::new();
+        let mut env = TestEnv::default();
+        let mut assembler = MessageAssembler::default();
         // Ping packet with a length longer than one packet.
         assert_eq!(
             assembler.parse_packet(

--- a/src/ctap/hid/send.rs
+++ b/src/ctap/hid/send.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 Google LLC
+// Copyright 2019-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ctap/large_blobs.rs
+++ b/src/ctap/large_blobs.rs
@@ -144,7 +144,7 @@ mod test {
 
     #[test]
     fn test_process_command_get_empty() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::<TestEnv>::new_test(
@@ -179,7 +179,7 @@ mod test {
 
     #[test]
     fn test_process_command_commit_and_get() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::<TestEnv>::new_test(
@@ -245,7 +245,7 @@ mod test {
 
     #[test]
     fn test_process_command_commit_unexpected_offset() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::<TestEnv>::new_test(
@@ -295,7 +295,7 @@ mod test {
 
     #[test]
     fn test_process_command_commit_unexpected_length() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::<TestEnv>::new_test(
@@ -345,7 +345,7 @@ mod test {
 
     #[test]
     fn test_process_command_commit_end_offset_overflow() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::<TestEnv>::new_test(
@@ -372,7 +372,7 @@ mod test {
 
     #[test]
     fn test_process_command_commit_unexpected_hash() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::<TestEnv>::new_test(
@@ -404,7 +404,7 @@ mod test {
     }
 
     fn test_helper_process_command_commit_with_pin(pin_uv_auth_protocol: PinUvAuthProtocol) {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let mut client_pin = ClientPin::<TestEnv>::new_test(

--- a/src/ctap/main_hid.rs
+++ b/src/ctap/main_hid.rs
@@ -31,9 +31,9 @@ pub struct MainHid<E: Env> {
     wink_permission: <E::Clock as Clock>::Timer,
 }
 
-impl<E: Env> MainHid<E> {
+impl<E: Env> Default for MainHid<E> {
     /// Instantiates a HID handler for CTAP1, CTAP2 and Wink.
-    pub fn new() -> Self {
+    fn default() -> Self {
         #[cfg(feature = "with_ctap1")]
         let capabilities = CtapHid::<E>::CAPABILITY_WINK | CtapHid::<E>::CAPABILITY_CBOR;
         #[cfg(not(feature = "with_ctap1"))]
@@ -48,7 +48,9 @@ impl<E: Env> MainHid<E> {
             wink_permission,
         }
     }
+}
 
+impl<E: Env> MainHid<E> {
     /// Processes an incoming USB HID packet, and returns an iterator for all outgoing packets.
     pub fn process_hid_packet(
         &mut self,
@@ -165,7 +167,7 @@ mod test {
 
     #[test]
     fn test_process_hid_packet() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
         let (mut main_hid, cid) = new_initialized();
 
@@ -180,7 +182,7 @@ mod test {
 
     #[test]
     fn test_process_hid_packet_empty() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
         let (mut main_hid, cid) = new_initialized();
 
@@ -194,7 +196,7 @@ mod test {
 
     #[test]
     fn test_wink() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
         let (mut main_hid, cid) = new_initialized();
         assert!(!main_hid.should_wink(&mut env));

--- a/src/ctap/mod.rs
+++ b/src/ctap/mod.rs
@@ -1509,7 +1509,7 @@ mod test {
 
     #[test]
     fn test_get_info() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
         let info_reponse = ctap_state.process_command(&mut env, &[0x04], DUMMY_CHANNEL);
 
@@ -1563,7 +1563,7 @@ mod test {
 
     #[test]
     fn test_get_info_no_pin_protocol_v1() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         env.customization_mut().set_allows_pin_protocol_v1(false);
         let ctap_state = CtapState::new(&mut env);
         let info_response = ctap_state.process_get_info(&mut env).unwrap();
@@ -1654,7 +1654,7 @@ mod test {
 
     #[test]
     fn test_resident_process_make_credential() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         let make_credential_params = create_minimal_make_credential_parameters();
@@ -1672,7 +1672,7 @@ mod test {
 
     #[test]
     fn test_non_resident_process_make_credential() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         let mut make_credential_params = create_minimal_make_credential_parameters();
@@ -1691,7 +1691,7 @@ mod test {
 
     #[test]
     fn test_process_make_credential_unsupported_algorithm() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         let mut make_credential_params = create_minimal_make_credential_parameters();
@@ -1707,7 +1707,7 @@ mod test {
 
     #[test]
     fn test_process_make_credential_credential_excluded() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let excluded_private_key = PrivateKey::new_ecdsa(&mut env);
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
@@ -1740,7 +1740,7 @@ mod test {
 
     #[test]
     fn test_process_make_credential_credential_with_cred_protect() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         let test_policy = CredentialProtectionPolicy::UserVerificationOptionalWithCredentialIdList;
@@ -1791,7 +1791,7 @@ mod test {
 
     #[test]
     fn test_non_resident_process_make_credential_credential_with_cred_protect() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::new(&mut env);
 
         let test_policy = CredentialProtectionPolicy::UserVerificationOptionalWithCredentialIdList;
@@ -1834,7 +1834,7 @@ mod test {
 
     #[test]
     fn test_process_make_credential_hmac_secret() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         let extensions = MakeCredentialExtensions {
@@ -1861,7 +1861,7 @@ mod test {
 
     #[test]
     fn test_process_make_credential_hmac_secret_resident_key() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         let extensions = MakeCredentialExtensions {
@@ -1887,7 +1887,7 @@ mod test {
 
     #[test]
     fn test_process_make_credential_min_pin_length() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         // First part: The extension is ignored, since the RP ID is not on the list.
@@ -1936,7 +1936,7 @@ mod test {
 
     #[test]
     fn test_process_make_credential_cred_blob_ok() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         let extensions = MakeCredentialExtensions {
@@ -1968,7 +1968,7 @@ mod test {
 
     #[test]
     fn test_process_make_credential_cred_blob_too_big() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         let extensions = MakeCredentialExtensions {
@@ -2000,7 +2000,7 @@ mod test {
 
     #[test]
     fn test_process_make_credential_large_blob_key() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         let extensions = MakeCredentialExtensions {
@@ -2030,7 +2030,7 @@ mod test {
     fn test_helper_process_make_credential_with_pin_and_uv(
         pin_uv_auth_protocol: PinUvAuthProtocol,
     ) {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x91; PIN_TOKEN_LENGTH];
         let client_pin = ClientPin::<TestEnv>::new_test(
@@ -2088,7 +2088,7 @@ mod test {
 
     #[test]
     fn test_non_resident_process_make_credential_with_pin() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
         storage::set_pin(&mut env, &[0x88; 16], 4).unwrap();
 
@@ -2108,7 +2108,7 @@ mod test {
 
     #[test]
     fn test_resident_process_make_credential_with_pin() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
         storage::set_pin(&mut env, &[0x88; 16], 4).unwrap();
 
@@ -2123,7 +2123,7 @@ mod test {
 
     #[test]
     fn test_process_make_credential_with_pin_always_uv() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         storage::toggle_always_uv(&mut env).unwrap();
@@ -2159,7 +2159,7 @@ mod test {
 
     #[test]
     fn test_process_make_credential_with_enterprise_attestation_vendor_facilitated() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         env.customization_mut().setup_enterprise_attestation(
             Some(EnterpriseAttestationMode::VendorFacilitated),
             Some(vec!["example.com".to_string()]),
@@ -2205,7 +2205,7 @@ mod test {
 
     #[test]
     fn test_process_make_credential_with_enterprise_attestation_platform_managed() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         env.customization_mut().setup_enterprise_attestation(
             Some(EnterpriseAttestationMode::PlatformManaged),
             Some(vec!["example.com".to_string()]),
@@ -2241,7 +2241,7 @@ mod test {
 
     #[test]
     fn test_process_make_credential_with_enterprise_attestation_invalid() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         env.customization_mut()
             .setup_enterprise_attestation(Some(EnterpriseAttestationMode::PlatformManaged), None);
 
@@ -2270,7 +2270,7 @@ mod test {
 
     #[test]
     fn test_process_make_credential_cancelled() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         env.user_presence().set(|| Err(UserPresenceError::Canceled));
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
@@ -2366,7 +2366,7 @@ mod test {
 
     #[test]
     fn test_resident_process_get_assertion() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         let make_credential_params = create_minimal_make_credential_parameters();
@@ -2398,7 +2398,7 @@ mod test {
         credential_id: Option<Vec<u8>>,
         pin_uv_auth_protocol: PinUvAuthProtocol,
     ) -> AuthenticatorGetAssertionParameters {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let platform_public_key = key_agreement_key.genpk();
         let public_key = match key_agreement_response {
             ResponseData::AuthenticatorClientPin(Some(client_pin_response)) => {
@@ -2446,7 +2446,7 @@ mod test {
     }
 
     fn test_helper_process_get_assertion_hmac_secret(pin_uv_auth_protocol: PinUvAuthProtocol) {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
@@ -2502,7 +2502,7 @@ mod test {
     fn test_helper_resident_process_get_assertion_hmac_secret(
         pin_uv_auth_protocol: PinUvAuthProtocol,
     ) {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
@@ -2552,7 +2552,7 @@ mod test {
 
     #[test]
     fn test_resident_process_get_assertion_with_cred_protect() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let private_key = PrivateKey::new_ecdsa(&mut env);
         let credential_id = env.rng().gen_uniform_u8x32().to_vec();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
@@ -2654,7 +2654,7 @@ mod test {
 
     #[test]
     fn test_non_resident_process_get_assertion_with_cred_protect() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::new(&mut env);
 
         let test_policy = CredentialProtectionPolicy::UserVerificationOptionalWithCredentialIdList;
@@ -2727,7 +2727,7 @@ mod test {
 
     #[test]
     fn test_process_get_assertion_with_cred_blob() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let private_key = PrivateKey::new_ecdsa(&mut env);
         let credential_id = env.rng().gen_uniform_u8x32().to_vec();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
@@ -2781,7 +2781,7 @@ mod test {
 
     #[test]
     fn test_non_resident_process_get_assertion_with_cred_blob() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::new(&mut env);
 
         let extensions = MakeCredentialExtensions {
@@ -2846,7 +2846,7 @@ mod test {
 
     #[test]
     fn test_process_get_assertion_with_large_blob_key() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let private_key = PrivateKey::new_ecdsa(&mut env);
         let credential_id = env.rng().gen_uniform_u8x32().to_vec();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
@@ -2897,7 +2897,7 @@ mod test {
     fn test_helper_process_get_next_assertion_two_credentials_with_uv(
         pin_uv_auth_protocol: PinUvAuthProtocol,
     ) {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x88; 32];
         let client_pin = ClientPin::<TestEnv>::new_test(
@@ -2995,7 +2995,7 @@ mod test {
 
     #[test]
     fn test_process_get_next_assertion_three_credentials_no_uv() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         let mut make_credential_params = create_minimal_make_credential_parameters();
@@ -3060,7 +3060,7 @@ mod test {
 
     #[test]
     fn test_process_get_next_assertion_not_allowed() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         let get_assertion_response = ctap_state.process_get_next_assertion(&mut env);
@@ -3120,7 +3120,7 @@ mod test {
 
     #[test]
     fn test_process_reset() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let private_key = PrivateKey::new_ecdsa(&mut env);
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
@@ -3150,7 +3150,7 @@ mod test {
 
     #[test]
     fn test_process_reset_cancelled() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         env.user_presence().set(|| Err(UserPresenceError::Canceled));
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
@@ -3164,7 +3164,7 @@ mod test {
 
     #[test]
     fn test_process_reset_not_first() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         // This is a GetNextAssertion command.
@@ -3176,7 +3176,7 @@ mod test {
 
     #[test]
     fn test_process_credential_management_unknown_subcommand() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         // The subcommand 0xEE does not exist.
@@ -3188,7 +3188,7 @@ mod test {
 
     #[test]
     fn test_process_unknown_command() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         // This command does not exist.
@@ -3199,7 +3199,7 @@ mod test {
 
     #[test]
     fn test_signature_counter() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         let mut last_counter = storage::global_signature_counter(&mut env).unwrap();
@@ -3216,7 +3216,7 @@ mod test {
 
     #[test]
     fn test_vendor_configure() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         // Nothing should be configured at the beginning
@@ -3324,7 +3324,7 @@ mod test {
         // The test partition storage has size 0x40000.
         // The test metadata storage has size 0x1000.
         // The test identifier matches partition B.
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         const METADATA_LEN: usize = 0x1000;
@@ -3402,7 +3402,7 @@ mod test {
 
     #[test]
     fn test_vendor_upgrade_no_second_partition() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         env.disable_upgrade_storage();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
@@ -3421,7 +3421,7 @@ mod test {
 
     #[test]
     fn test_vendor_upgrade_info() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let ctap_state = CtapState::<TestEnv>::new(&mut env);
         let bundle_identifier = env.upgrade_storage().unwrap().bundle_identifier();
 
@@ -3438,7 +3438,7 @@ mod test {
 
     #[test]
     fn test_permission_timeout() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         // Write 2 credentials for later assertions.
@@ -3490,7 +3490,7 @@ mod test {
 
     #[test]
     fn test_reset_timeout() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         env.clock().advance(RESET_TIMEOUT_DURATION_MS);
@@ -3501,7 +3501,7 @@ mod test {
 
     #[test]
     fn test_credential_management_timeout() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let key_agreement_key = crypto::ecdh::SecKey::gensk(env.rng());
         let pin_uv_auth_token = [0x55; 32];
         let client_pin = ClientPin::<TestEnv>::new_test(
@@ -3594,7 +3594,7 @@ mod test {
     #[test]
     fn test_check_user_presence() {
         // This TestEnv always returns successful user_presence checks.
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let response = check_user_presence(&mut env, DUMMY_CHANNEL);
         assert!(matches!(response, Ok(_)));
     }
@@ -3606,7 +3606,7 @@ mod test {
             Err(UserPresenceError::Timeout)
         }
 
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         env.user_presence().set(user_presence_timeout);
         let response = check_user_presence(&mut env, DUMMY_CHANNEL);
         assert!(matches!(
@@ -3617,7 +3617,7 @@ mod test {
 
     #[test]
     fn test_channel_interleaving() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
         const NEW_CHANNEL: Channel = Channel::MainHid([0xAA, 0xAA, 0xAA, 0xAA]);
 
@@ -3683,7 +3683,7 @@ mod test {
 
     #[test]
     fn test_get_info_command() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         let response = ctap_state.process_parsed_command(
@@ -3712,7 +3712,7 @@ mod test {
     #[test]
     #[cfg(feature = "vendor_hid")]
     fn test_vendor_hid_does_not_support_fido_command() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::new(&mut env);
         let response = ctap_state.process_parsed_command(
             &mut env,
@@ -3725,7 +3725,7 @@ mod test {
     #[test]
     #[cfg(feature = "vendor_hid")]
     fn test_vendor_hid() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         let response = ctap_state.process_parsed_command(

--- a/src/ctap/pin_protocol.rs
+++ b/src/ctap/pin_protocol.rs
@@ -234,7 +234,7 @@ mod test {
 
     #[test]
     fn test_pin_protocol_public_key() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut pin_protocol = PinProtocol::new(env.rng());
         let public_key = pin_protocol.get_public_key();
         pin_protocol.regenerate(env.rng());
@@ -244,7 +244,7 @@ mod test {
 
     #[test]
     fn test_pin_protocol_pin_uv_auth_token() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut pin_protocol = PinProtocol::new(env.rng());
         let token = *pin_protocol.get_pin_uv_auth_token();
         pin_protocol.reset_pin_uv_auth_token(env.rng());
@@ -254,7 +254,7 @@ mod test {
 
     #[test]
     fn test_shared_secret_v1_encrypt_decrypt() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let shared_secret = SharedSecretV1::new([0x55; 32]);
         let plaintext = vec![0xAA; 64];
         let ciphertext = shared_secret.encrypt(env.rng(), &plaintext).unwrap();
@@ -290,7 +290,7 @@ mod test {
 
     #[test]
     fn test_shared_secret_v2_encrypt_decrypt() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let shared_secret = SharedSecretV2::new([0x55; 32]);
         let plaintext = vec![0xAA; 64];
         let ciphertext = shared_secret.encrypt(env.rng(), &plaintext).unwrap();
@@ -327,7 +327,7 @@ mod test {
 
     #[test]
     fn test_decapsulate_symmetric() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let pin_protocol1 = PinProtocol::new(env.rng());
         let pin_protocol2 = PinProtocol::new(env.rng());
         for &protocol in &[PinUvAuthProtocol::V1, PinUvAuthProtocol::V2] {

--- a/src/ctap/response.rs
+++ b/src/ctap/response.rs
@@ -506,7 +506,7 @@ mod test {
 
     #[test]
     fn test_used_client_pin_into_cbor() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let sk = crypto::ecdh::SecKey::gensk(env.rng());
         let pk = sk.genpk();
         let cose_key = CoseKey::from(pk);
@@ -550,7 +550,7 @@ mod test {
 
     #[test]
     fn test_used_credential_management_optionals_into_cbor() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let sk = crypto::ecdh::SecKey::gensk(env.rng());
         let rp = PublicKeyCredentialRpEntity {
             rp_id: String::from("example.com"),

--- a/src/ctap/storage.rs
+++ b/src/ctap/storage.rs
@@ -652,7 +652,7 @@ mod test {
 
     #[test]
     fn test_store() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         assert_eq!(count_credentials(&mut env).unwrap(), 0);
         let credential_source = create_credential_source(&mut env, "example.com", vec![]);
         assert!(store_credential(&mut env, credential_source).is_ok());
@@ -661,7 +661,7 @@ mod test {
 
     #[test]
     fn test_delete_credential() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         assert_eq!(count_credentials(&mut env).unwrap(), 0);
 
         let mut credential_ids = vec![];
@@ -682,7 +682,7 @@ mod test {
 
     #[test]
     fn test_update_credential() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let user = PublicKeyCredentialUserEntity {
             // User ID is ignored.
             user_id: vec![0x00],
@@ -715,7 +715,7 @@ mod test {
 
     #[test]
     fn test_credential_order() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let credential_source = create_credential_source(&mut env, "example.com", vec![]);
         let current_latest_creation = credential_source.creation_order;
         assert!(store_credential(&mut env, credential_source).is_ok());
@@ -729,7 +729,7 @@ mod test {
 
     #[test]
     fn test_fill_store() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         assert_eq!(count_credentials(&mut env).unwrap(), 0);
 
         let max_supported_resident_keys = env.customization().max_supported_resident_keys();
@@ -756,7 +756,7 @@ mod test {
 
     #[test]
     fn test_overwrite() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         init(&mut env).unwrap();
 
         assert_eq!(count_credentials(&mut env).unwrap(), 0);
@@ -801,7 +801,7 @@ mod test {
 
     #[test]
     fn test_get_credential() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let credential_source0 = create_credential_source(&mut env, "example.com", vec![0x00]);
         let credential_source1 = create_credential_source(&mut env, "example.com", vec![0x01]);
         let credential_source2 =
@@ -818,7 +818,7 @@ mod test {
 
     #[test]
     fn test_find() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         assert_eq!(count_credentials(&mut env).unwrap(), 0);
         let credential_source0 = create_credential_source(&mut env, "example.com", vec![0x00]);
         let credential_source1 = create_credential_source(&mut env, "example.com", vec![0x01]);
@@ -849,7 +849,7 @@ mod test {
 
     #[test]
     fn test_cred_random_secret() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         init(&mut env).unwrap();
 
         // CredRandom secrets stay the same within the same CTAP reset cycle.
@@ -871,7 +871,7 @@ mod test {
 
     #[test]
     fn test_pin_hash_and_length() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
 
         // Pin hash is initially not set.
         assert!(pin_hash(&mut env).unwrap().is_none());
@@ -899,7 +899,7 @@ mod test {
 
     #[test]
     fn test_pin_retries() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
 
         // The pin retries is initially at the maximum.
         assert_eq!(
@@ -927,7 +927,7 @@ mod test {
 
     #[test]
     fn test_persistent_keys() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         init(&mut env).unwrap();
 
         // Make sure the attestation are absent. There is no batch attestation in tests.
@@ -955,7 +955,7 @@ mod test {
 
     #[test]
     fn test_min_pin_length() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
 
         // The minimum PIN length is initially at the default.
         assert_eq!(
@@ -971,7 +971,7 @@ mod test {
 
     #[test]
     fn test_min_pin_length_rp_ids() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
 
         // The minimum PIN length RP IDs are initially at the default.
         assert_eq!(
@@ -992,7 +992,7 @@ mod test {
 
     #[test]
     fn test_max_large_blob_array_size() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
 
         assert!(
             env.customization().max_large_blob_array_size()
@@ -1003,7 +1003,7 @@ mod test {
 
     #[test]
     fn test_commit_get_large_blob_array() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
 
         let large_blob_array = vec![0x01, 0x02, 0x03];
         assert!(commit_large_blob_array(&mut env, &large_blob_array).is_ok());
@@ -1023,7 +1023,7 @@ mod test {
 
     #[test]
     fn test_commit_get_large_blob_array_overwrite() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
 
         let large_blob_array = vec![0x11; 5];
         assert!(commit_large_blob_array(&mut env, &large_blob_array).is_ok());
@@ -1042,7 +1042,7 @@ mod test {
 
     #[test]
     fn test_commit_get_large_blob_array_no_commit() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
 
         let empty_blob_array = vec![
             0x80, 0x76, 0xBE, 0x8B, 0x52, 0x8D, 0x00, 0x75, 0xF7, 0xAA, 0xE9, 0x8D, 0x6F, 0xA5,
@@ -1058,7 +1058,7 @@ mod test {
 
     #[test]
     fn test_global_signature_counter() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
 
         let mut counter_value = 1;
         assert_eq!(global_signature_counter(&mut env).unwrap(), counter_value);
@@ -1071,7 +1071,7 @@ mod test {
 
     #[test]
     fn test_force_pin_change() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
 
         assert!(!has_force_pin_change(&mut env).unwrap());
         assert_eq!(force_pin_change(&mut env), Ok(()));
@@ -1082,7 +1082,7 @@ mod test {
 
     #[test]
     fn test_enterprise_attestation() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
 
         let dummy_attestation = Attestation {
             private_key: [0x41; ATTESTATION_PRIVATE_KEY_LENGTH],
@@ -1101,7 +1101,7 @@ mod test {
 
     #[test]
     fn test_always_uv() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
 
         if env.customization().enforce_always_uv() {
             assert!(has_always_uv(&mut env).unwrap());
@@ -1120,7 +1120,7 @@ mod test {
 
     #[test]
     fn test_serialize_deserialize_credential() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let private_key = PrivateKey::new_ecdsa(&mut env);
         let credential = PublicKeyCredentialSource {
             key_type: PublicKeyCredentialType::PublicKey,

--- a/src/ctap/storage/key.rs
+++ b/src/ctap/storage/key.rs
@@ -140,7 +140,7 @@ mod test {
 
     #[test]
     fn enough_credentials() {
-        let env = TestEnv::new();
+        let env = TestEnv::default();
         assert!(
             env.customization().max_supported_resident_keys()
                 <= CREDENTIALS.end - CREDENTIALS.start

--- a/src/ctap/token_state.rs
+++ b/src/ctap/token_state.rs
@@ -160,7 +160,7 @@ mod test {
 
     #[test]
     fn test_observer() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut token_state = PinUvAuthTokenState::<TestEnv>::new();
         token_state.begin_using_pin_uv_auth_token(&mut env);
         assert!(token_state.is_in_use());
@@ -174,7 +174,7 @@ mod test {
 
     #[test]
     fn test_stop() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut token_state = PinUvAuthTokenState::<TestEnv>::new();
         token_state.begin_using_pin_uv_auth_token(&mut env);
         assert!(token_state.is_in_use());
@@ -260,7 +260,7 @@ mod test {
 
     #[test]
     fn test_user_verified_flag() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut token_state = PinUvAuthTokenState::<TestEnv>::new();
         assert!(!token_state.get_user_verified_flag_value());
         token_state.begin_using_pin_uv_auth_token(&mut env);

--- a/src/ctap/u2f_up.rs
+++ b/src/ctap/u2f_up.rs
@@ -104,7 +104,7 @@ mod test {
 
     #[test]
     fn test_grant_up_timeout() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         grant_up_timeout(&mut env);
         env.clock().advance(big_positive());
         grant_up_timeout(&mut env);
@@ -112,7 +112,7 @@ mod test {
 
     #[test]
     fn test_need_up_timeout() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         need_up_timeout(&mut env);
         env.clock().advance(big_positive());
         need_up_timeout(&mut env);
@@ -120,7 +120,7 @@ mod test {
 
     #[test]
     fn test_grant_up_when_needed() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         grant_up_when_needed(&mut env);
         env.clock().advance(big_positive());
         grant_up_when_needed(&mut env);
@@ -128,7 +128,7 @@ mod test {
 
     #[test]
     fn test_grant_up_without_need() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut u2f_state = U2fUserPresenceState::new();
         u2f_state.grant_up(&mut env);
         assert!(!u2f_state.is_up_needed(&mut env));

--- a/src/ctap/vendor_hid.rs
+++ b/src/ctap/vendor_hid.rs
@@ -25,13 +25,15 @@ pub struct VendorHid<E: Env> {
     hid: CtapHid<E>,
 }
 
-impl<E: Env> VendorHid<E> {
+impl<E: Env> Default for VendorHid<E> {
     /// Instantiates a HID handler for CTAP1, CTAP2 and Wink.
-    pub fn new() -> Self {
+    fn default() -> Self {
         let hid = CtapHid::<E>::new(CtapHid::<E>::CAPABILITY_CBOR | CtapHid::<E>::CAPABILITY_NMSG);
         VendorHid { hid }
     }
+}
 
+impl<E: Env> VendorHid<E> {
     /// Processes an incoming USB HID packet, and returns an iterator for all outgoing packets.
     pub fn process_hid_packet(
         &mut self,
@@ -94,7 +96,7 @@ mod test {
 
     #[test]
     fn test_process_hid_packet() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
         let (mut vendor_hid, cid) = new_initialized();
 
@@ -109,7 +111,7 @@ mod test {
 
     #[test]
     fn test_process_hid_packet_empty() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
         let (mut vendor_hid, cid) = new_initialized();
 
@@ -123,7 +125,7 @@ mod test {
 
     #[test]
     fn test_blocked_commands() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
         let (mut vendor_hid, cid) = new_initialized();
 

--- a/src/env/test/customization.rs
+++ b/src/env/test/customization.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2022-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/env/test/mod.rs
+++ b/src/env/test/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2022-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -128,8 +128,8 @@ impl HidConnection for TestEnv {
     }
 }
 
-impl TestEnv {
-    pub fn new() -> Self {
+impl Default for TestEnv {
+    fn default() -> Self {
         let rng = TestRng256 {
             rng: StdRng::seed_from_u64(0),
         };
@@ -150,7 +150,9 @@ impl TestEnv {
             clock,
         }
     }
+}
 
+impl TestEnv {
     pub fn disable_upgrade_storage(&mut self) {
         self.upgrade_storage = None;
     }

--- a/src/env/test/upgrade_storage.rs
+++ b/src/env/test/upgrade_storage.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2021-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/env/tock/mod.rs
+++ b/src/env/tock/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2022-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -89,13 +89,13 @@ pub struct TockEnv {
     clock: TockClock,
 }
 
-impl TockEnv {
+impl Default for TockEnv {
     /// Returns the unique instance of the Tock environment.
     ///
     /// # Panics
     ///
     /// - If called a second time.
-    pub fn new() -> Self {
+    fn default() -> Self {
         // We rely on `take_storage` to ensure that this function is called only once.
         let storage = take_storage().unwrap();
         let store = Store::new(storage).ok().unwrap();

--- a/src/env/tock/storage.rs
+++ b/src/env/tock/storage.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 Google LLC
+// Copyright 2019-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -475,7 +475,7 @@ mod test {
 
     #[test]
     fn test_check_metadata() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let private_key = crypto::ecdsa::SecKey::gensk(env.rng());
         let upgrade_locations = env.upgrade_storage().unwrap();
 
@@ -536,7 +536,7 @@ mod test {
 
     #[test]
     fn test_verify_signature() {
-        let mut env = TestEnv::new();
+        let mut env = TestEnv::default();
         let private_key = crypto::ecdsa::SecKey::gensk(env.rng());
         let message = [0x44; 64];
         let signed_hash = Sha256::hash(&message);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 Google LLC
+// Copyright 2019-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -65,9 +65,9 @@ impl<E: Env> Ctap<E> {
     // clock is part of the environment.
     pub fn new(mut env: E) -> Self {
         let state = CtapState::<E>::new(&mut env);
-        let hid = MainHid::new();
+        let hid = MainHid::default();
         #[cfg(feature = "vendor_hid")]
-        let vendor_hid = VendorHid::new();
+        let vendor_hid = VendorHid::default();
         Ctap {
             env,
             state,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -114,7 +114,7 @@ fn main() {
         panic!("Cannot setup USB driver");
     }
 
-    let env = TockEnv::new();
+    let env = TockEnv::default();
     let mut ctap = ctap2::Ctap::new(env);
 
     let mut led_counter = 0;

--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2022-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR does 3 hopefully boring things:

- update license headers in `src/` to go to 2023 (or add them where missing)
- add one author in a few `Cargo.toml` files
- apply the clippy default suggestion by `impl Default for T` instead of having a `new` in `impl T`