### PR TITLE
Fixes new clippy lints on the latest nightly

### DIFF
--- a/libraries/opensk/src/api/upgrade_storage/helper.rs
+++ b/libraries/opensk/src/api/upgrade_storage/helper.rs
@@ -150,15 +150,12 @@ impl ModRange {
     }
 }
 
+#[derive(Default)]
 pub struct Partition {
     ranges: Vec<ModRange>,
 }
 
 impl Partition {
-    pub fn new() -> Partition {
-        Partition { ranges: Vec::new() }
-    }
-
     /// Total length of all ranges.
     pub fn length(&self) -> usize {
         self.ranges.iter().map(|r| r.length()).sum()
@@ -339,7 +336,7 @@ mod tests {
 
     #[test]
     fn partition_append() {
-        let mut partition = Partition::new();
+        let mut partition = Partition::default();
         partition.append(ModRange::new(0x4000, 0x1000));
         partition.append(ModRange::new(0x20000, 0x20000));
         partition.append(ModRange::new(0x40000, 0x20000));
@@ -349,7 +346,7 @@ mod tests {
 
     #[test]
     fn partition_find_address() {
-        let mut partition = Partition::new();
+        let mut partition = Partition::default();
         partition.append(ModRange::new(0x4000, 0x1000));
         partition.append(ModRange::new(0x20000, 0x20000));
         partition.append(ModRange::new(0x40000, 0x20000));
@@ -364,7 +361,7 @@ mod tests {
 
     #[test]
     fn partition_ranges_from() {
-        let mut partition = Partition::new();
+        let mut partition = Partition::default();
         partition.append(ModRange::new(0x4000, 0x1000));
         partition.append(ModRange::new(0x20000, 0x20000));
         partition.append(ModRange::new(0x40000, 0x20000));

--- a/libraries/opensk/src/ctap/apdu.rs
+++ b/libraries/opensk/src/ctap/apdu.rs
@@ -118,7 +118,7 @@ impl TryFrom<&[u8]> for Apdu {
     type Error = ApduStatusCode;
 
     fn try_from(frame: &[u8]) -> Result<Self, ApduStatusCode> {
-        if frame.len() < APDU_HEADER_LEN as usize {
+        if frame.len() < APDU_HEADER_LEN {
             return Err(ApduStatusCode::SW_WRONG_DATA);
         }
         //        +-----+-----+----+----+

--- a/libraries/opensk/src/ctap/client_pin.rs
+++ b/libraries/opensk/src/ctap/client_pin.rs
@@ -1224,7 +1224,7 @@ mod test {
             ),
             // Reject PIN "12'\0'4" (a zero byte at index 2).
             (
-                b"12\x004".to_vec(),
+                [b'1', b'2', 0, b'4'].to_vec(),
                 Err(Ctap2StatusCode::CTAP2_ERR_PIN_POLICY_VIOLATION),
             ),
             // PINs must be at most 63 bytes long, to allow for a trailing 0u8 padding.

--- a/libraries/opensk/src/ctap/client_pin.rs
+++ b/libraries/opensk/src/ctap/client_pin.rs
@@ -1224,7 +1224,7 @@ mod test {
             ),
             // Reject PIN "12'\0'4" (a zero byte at index 2).
             (
-                b"12\04".to_vec(),
+                b"12\x004".to_vec(),
                 Err(Ctap2StatusCode::CTAP2_ERR_PIN_POLICY_VIOLATION),
             ),
             // PINs must be at most 63 bytes long, to allow for a trailing 0u8 padding.

--- a/libraries/opensk/src/ctap/mod.rs
+++ b/libraries/opensk/src/ctap/mod.rs
@@ -1513,6 +1513,8 @@ mod test {
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
         let info_reponse = ctap_state.process_command(&mut env, &[0x04], DUMMY_CHANNEL);
 
+        // Fails when removing `to_vec` for `SUPPORTED_CRED_PARAMS` as linted.
+        #[allow(clippy::unnecessary_to_owned)]
         let expected_cbor = cbor_map_options! {
              0x01 => cbor_array_vec![vec![
                     #[cfg(feature = "with_ctap1")]

--- a/src/env/tock/storage.rs
+++ b/src/env/tock/storage.rs
@@ -261,7 +261,7 @@ impl TockUpgradeStorage {
     pub fn new() -> StorageResult<TockUpgradeStorage> {
         let mut locations = TockUpgradeStorage {
             page_size: get_info(command_nr::get_info_nr::PAGE_SIZE, 0)?,
-            partition: Partition::new(),
+            partition: Partition::default(),
             metadata: ModRange::new_empty(),
             running_metadata: ModRange::new_empty(),
             identifier: Self::PARTITION_ADDRESS_A as u32,


### PR DESCRIPTION
Now that we can use a later toolchain, we see more lints. Overlaps with #580 , but I didn't reproduce all lints. Missing are all changes like:

```
-                large_blob_data.extend(&[0x0C, 0x00]);
+                large_blob_data.extend([0x0C, 0x00]);
```

Not sure what toolchain version these are coming from.

On a side note, other libraries still have lints that need to be fixed on the current nightly.