### PR TITLE
SHA and HMAC for the Crypto trait

### DIFF
--- a/libraries/opensk/Cargo.toml
+++ b/libraries/opensk/Cargo.toml
@@ -24,6 +24,8 @@ rand = { version = "0.8.4", optional = true }
 ed25519-compact = { version = "1", default-features = false, optional = true }
 p256 = { version = "0.13.0", features = ["ecdh"], optional = true }
 rand_core = { version = "0.6.4", optional = true }
+sha2 = { version = "0.10.6", optional = true }
+hmac = { version = "0.12.1", optional = true }
 
 [features]
 debug_ctap = []
@@ -32,7 +34,7 @@ with_ctap1 = ["crypto/with_ctap1"]
 vendor_hid = []
 fuzz = ["arbitrary", "std"]
 ed25519 = ["ed25519-compact"]
-rust_crypto = ["p256", "rand_core"]
+rust_crypto = ["p256", "rand_core", "sha2", "hmac"]
 
 [dev-dependencies]
 enum-iterator = "0.6.0"

--- a/libraries/opensk/src/api/crypto/hmac256.rs
+++ b/libraries/opensk/src/api/crypto/hmac256.rs
@@ -21,14 +21,14 @@ pub trait Hmac256 {
 
     /// Verifies the HMAC.
     ///
-    /// When implementing, make sure that you don't leak side channel information about the key,
-    /// i.e. by using constant time comparisons of the computed and given MAC.
+    /// This function does best effort to not leak information about the key through side-channels
+    /// (e.g. usage of constant time comparison).
     fn verify(key: &[u8; HMAC_KEY_SIZE], data: &[u8], mac: &[u8; HASH_SIZE]) -> bool;
 
     /// Verifies the first bytes of an HMAC.
     ///
-    /// When implementing, make sure that you don't leak side channel information about the key,
-    /// i.e. by using constant time comparisons of the computed and given truncated MAC.
+    /// This function does best effort to not leak information about the key through side-channels
+    /// (e.g. usage of constant time comparison).
     fn verify_truncated_left(
         key: &[u8; HMAC_KEY_SIZE],
         data: &[u8],

--- a/libraries/opensk/src/api/crypto/hmac256.rs
+++ b/libraries/opensk/src/api/crypto/hmac256.rs
@@ -1,0 +1,31 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{HASH_SIZE, HMAC_KEY_SIZE, TRUNCATED_HMAC_SIZE};
+
+/// For a given hash function, computes and verifies the HMAC.
+pub trait Hmac256 {
+    /// Computes the HMAC.
+    fn mac(key: &[u8; HMAC_KEY_SIZE], data: &[u8]) -> [u8; HASH_SIZE];
+
+    /// Verifies the HMAC.
+    fn verify(key: &[u8; HMAC_KEY_SIZE], data: &[u8], mac: &[u8; HASH_SIZE]) -> bool;
+
+    /// Verifies the first bytes of an HMAC.
+    fn verify_truncated_left(
+        key: &[u8; HMAC_KEY_SIZE],
+        data: &[u8],
+        mac: &[u8; TRUNCATED_HMAC_SIZE],
+    ) -> bool;
+}

--- a/libraries/opensk/src/api/crypto/hmac256.rs
+++ b/libraries/opensk/src/api/crypto/hmac256.rs
@@ -20,9 +20,15 @@ pub trait Hmac256 {
     fn mac(key: &[u8; HMAC_KEY_SIZE], data: &[u8]) -> [u8; HASH_SIZE];
 
     /// Verifies the HMAC.
+    ///
+    /// When implementing, make sure that you don't leak side channel information about the key,
+    /// i.e. by using constant time comparisons of the computed and given MAC.
     fn verify(key: &[u8; HMAC_KEY_SIZE], data: &[u8], mac: &[u8; HASH_SIZE]) -> bool;
 
     /// Verifies the first bytes of an HMAC.
+    ///
+    /// When implementing, make sure that you don't leak side channel information about the key,
+    /// i.e. by using constant time comparisons of the computed and given truncated MAC.
     fn verify_truncated_left(
         key: &[u8; HMAC_KEY_SIZE],
         data: &[u8],

--- a/libraries/opensk/src/api/crypto/mod.rs
+++ b/libraries/opensk/src/api/crypto/mod.rs
@@ -37,10 +37,12 @@ pub const EC_SIGNATURE_SIZE: usize = 2 * EC_FIELD_SIZE;
 /// The size in bytes of a SHA256.
 pub const HASH_SIZE: usize = 32;
 
-/// The size in bytes of truncated HMAC.
+/// The size in bytes of an HMAC.
 pub const HMAC_KEY_SIZE: usize = 32;
 
-/// The size in bytes of truncated HMAC.
+/// The size in bytes of a truncated HMAC.
+///
+/// Truncated HMACs are used in PIN protocol V1 in CTAP2.
 pub const TRUNCATED_HMAC_SIZE: usize = 16;
 
 /// Necessary cryptographic primitives for CTAP.

--- a/libraries/opensk/src/api/crypto/mod.rs
+++ b/libraries/opensk/src/api/crypto/mod.rs
@@ -20,9 +20,13 @@ pub mod rust_crypto;
 pub mod software_crypto;
 #[cfg(feature = "rust_crypto")]
 pub use rust_crypto as software_crypto;
+pub mod hmac256;
+pub mod sha256;
 
 use self::ecdh::Ecdh;
 use self::ecdsa::Ecdsa;
+use self::hmac256::Hmac256;
+use self::sha256::Sha256;
 
 /// The size of field elements in the elliptic curve P256.
 pub const EC_FIELD_SIZE: usize = 32;
@@ -30,8 +34,19 @@ pub const EC_FIELD_SIZE: usize = 32;
 /// The size of a serialized ECDSA signature.
 pub const EC_SIGNATURE_SIZE: usize = 2 * EC_FIELD_SIZE;
 
+/// The size in bytes of a SHA256.
+pub const HASH_SIZE: usize = 32;
+
+/// The size in bytes of truncated HMAC.
+pub const HMAC_KEY_SIZE: usize = 32;
+
+/// The size in bytes of truncated HMAC.
+pub const TRUNCATED_HMAC_SIZE: usize = 16;
+
 /// Necessary cryptographic primitives for CTAP.
 pub trait Crypto {
     type Ecdh: Ecdh;
     type Ecdsa: Ecdsa;
+    type Sha256: Sha256;
+    type Hmac256: Hmac256;
 }

--- a/libraries/opensk/src/api/crypto/sha256.rs
+++ b/libraries/opensk/src/api/crypto/sha256.rs
@@ -1,0 +1,34 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::HASH_SIZE;
+
+/// Hashes data using SHA256.
+pub trait Sha256: Sized {
+    /// Computes the hash of a given message directly.
+    fn digest(data: &[u8]) -> [u8; HASH_SIZE] {
+        let mut hasher = Self::new();
+        hasher.update(data);
+        hasher.finalize()
+    }
+
+    /// Create a new object that can be incrementally updated for digesting.
+    fn new() -> Self;
+
+    /// Digest the next part of the message to hash.
+    fn update(&mut self, data: &[u8]);
+
+    /// Finalizes the hashing process, returns the hash value.
+    fn finalize(self) -> [u8; HASH_SIZE];
+}

--- a/libraries/opensk/src/ctap/token_state.rs
+++ b/libraries/opensk/src/ctap/token_state.rs
@@ -13,12 +13,11 @@
 // limitations under the License.
 
 use crate::api::clock::Clock;
+use crate::api::crypto::sha256::Sha256;
 use crate::ctap::client_pin::PinPermission;
 use crate::ctap::status_code::Ctap2StatusCode;
-use crate::env::Env;
+use crate::env::{Env, Sha};
 use alloc::string::String;
-use crypto::sha256::Sha256;
-use crypto::Hash256;
 
 /// Timeout for auth tokens.
 ///
@@ -87,7 +86,7 @@ impl<E: Env> PinUvAuthTokenState<E> {
     /// Checks if the permissions RPID's association matches the hash.
     pub fn has_permissions_rp_id_hash(&self, rp_id_hash: &[u8]) -> Result<(), Ctap2StatusCode> {
         match &self.permissions_rp_id {
-            Some(p) if rp_id_hash == Sha256::hash(p.as_bytes()) => Ok(()),
+            Some(p) if rp_id_hash == Sha::<E>::digest(p.as_bytes()) => Ok(()),
             _ => Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID),
         }
     }
@@ -210,7 +209,7 @@ mod test {
     #[test]
     fn test_permissions_rp_id_none() {
         let mut token_state = PinUvAuthTokenState::<TestEnv>::new();
-        let example_hash = Sha256::hash(b"example.com");
+        let example_hash = Sha::<TestEnv>::digest(b"example.com");
         token_state.set_permissions_rp_id(None);
         assert_eq!(token_state.has_no_permissions_rp_id(), Ok(()));
         assert_eq!(
@@ -226,7 +225,7 @@ mod test {
     #[test]
     fn test_permissions_rp_id_some() {
         let mut token_state = PinUvAuthTokenState::<TestEnv>::new();
-        let example_hash = Sha256::hash(b"example.com");
+        let example_hash = Sha::<TestEnv>::digest(b"example.com");
         token_state.set_permissions_rp_id(Some(String::from("example.com")));
 
         assert_eq!(

--- a/libraries/opensk/src/env/mod.rs
+++ b/libraries/opensk/src/env/mod.rs
@@ -33,6 +33,8 @@ pub type EcdhSk<E> = <<<E as Env>::Crypto as Crypto>::Ecdh as Ecdh>::SecretKey;
 pub type EcdhPk<E> = <<<E as Env>::Crypto as Crypto>::Ecdh as Ecdh>::PublicKey;
 pub type EcdsaSk<E> = <<<E as Env>::Crypto as Crypto>::Ecdsa as Ecdsa>::SecretKey;
 pub type EcdsaPk<E> = <<<E as Env>::Crypto as Crypto>::Ecdsa as Ecdsa>::PublicKey;
+pub type Sha<E> = <<E as Env>::Crypto as Crypto>::Sha256;
+pub type Hmac<E> = <<E as Env>::Crypto as Crypto>::Hmac256;
 
 /// Describes what CTAP needs to function.
 pub trait Env {


### PR DESCRIPTION
Continuation of #606 . Same style, and I found a missing ECDSA private key in CTAP1 that I also ported over. I made `SharedSecret` an enum instead of a trait to remove the need to return `Box<dyn SharedSecret>`.