### PR TITLE
Adds AES256 to the Crypto trait

### DIFF
--- a/libraries/opensk/Cargo.toml
+++ b/libraries/opensk/Cargo.toml
@@ -27,6 +27,8 @@ rand_core = { version = "0.6.4", optional = true }
 sha2 = { version = "0.10.6", optional = true }
 hmac = { version = "0.12.1", optional = true }
 hkdf = { version = "0.12.3", optional = true }
+aes = { version = "0.8.2", optional = true }
+cbc = { version = "0.1.2", optional = true }
 
 [features]
 debug_ctap = []
@@ -35,7 +37,7 @@ with_ctap1 = ["crypto/with_ctap1"]
 vendor_hid = []
 fuzz = ["arbitrary", "std"]
 ed25519 = ["ed25519-compact"]
-rust_crypto = ["p256", "rand_core", "sha2", "hmac", "hkdf"]
+rust_crypto = ["p256", "rand_core", "sha2", "hmac", "hkdf", "aes", "cbc"]
 
 [dev-dependencies]
 enum-iterator = "0.6.0"

--- a/libraries/opensk/src/api/crypto/aes256.rs
+++ b/libraries/opensk/src/api/crypto/aes256.rs
@@ -1,0 +1,41 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{AES_BLOCK_SIZE, AES_KEY_SIZE};
+
+/// Encrypts and decrypts data using AES256.
+pub trait Aes256 {
+    /// Creates a new key from its bytes.
+    fn new(key: &[u8; AES_KEY_SIZE]) -> Self;
+
+    /// Encrypts a block in place.
+    fn encrypt_block(&self, block: &mut [u8; AES_BLOCK_SIZE]);
+
+    /// Decrypts a block in place.
+    fn decrypt_block(&self, block: &mut [u8; AES_BLOCK_SIZE]);
+
+    /// Encrypts a message in place using CBC mode.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the plaintext is not a multiple of the block size.
+    fn encrypt_cbc(&self, iv: &[u8; AES_BLOCK_SIZE], plaintext: &mut [u8]);
+
+    /// Decrypts a message in place using CBC mode.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the ciphertext is not a multiple of the block size.
+    fn decrypt_cbc(&self, iv: &[u8; AES_BLOCK_SIZE], ciphertext: &mut [u8]);
+}

--- a/libraries/opensk/src/api/crypto/mod.rs
+++ b/libraries/opensk/src/api/crypto/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod aes256;
 pub mod ecdh;
 pub mod ecdsa;
 #[cfg(feature = "rust_crypto")]
@@ -24,11 +25,18 @@ pub mod hkdf256;
 pub mod hmac256;
 pub mod sha256;
 
+use self::aes256::Aes256;
 use self::ecdh::Ecdh;
 use self::ecdsa::Ecdsa;
 use self::hkdf256::Hkdf256;
 use self::hmac256::Hmac256;
 use self::sha256::Sha256;
+
+/// The size of a serialized ECDSA signature.
+pub const AES_BLOCK_SIZE: usize = 16;
+
+/// The size of field elements in the elliptic curve P256.
+pub const AES_KEY_SIZE: usize = 32;
 
 /// The size of field elements in the elliptic curve P256.
 pub const EC_FIELD_SIZE: usize = 32;
@@ -49,9 +57,140 @@ pub const TRUNCATED_HMAC_SIZE: usize = 16;
 
 /// Necessary cryptographic primitives for CTAP.
 pub trait Crypto {
+    type Aes256: Aes256;
     type Ecdh: Ecdh;
     type Ecdsa: Ecdsa;
     type Sha256: Sha256;
     type Hmac256: Hmac256;
     type Hkdf256: Hkdf256;
+}
+
+#[cfg(test)]
+mod test {
+    use super::software_crypto::*;
+    use super::*;
+    use crate::api::crypto::ecdh::{PublicKey as _, SecretKey as _, SharedSecret};
+    use crate::api::crypto::ecdsa::{PublicKey as _, SecretKey as _};
+    use crate::env::test::TestEnv;
+    use core::convert::TryFrom;
+
+    #[test]
+    fn test_shared_secret_symmetric() {
+        let mut env = TestEnv::default();
+        let private1 = SoftwareEcdhSecretKey::random(env.rng());
+        let private2 = SoftwareEcdhSecretKey::random(env.rng());
+        let pub1 = private1.public_key();
+        let pub2 = private2.public_key();
+        let shared1 = private1.diffie_hellman(&pub2);
+        let shared2 = private2.diffie_hellman(&pub1);
+        assert_eq!(shared1.raw_secret_bytes(), shared2.raw_secret_bytes());
+    }
+
+    #[test]
+    fn test_ecdh_public_key_from_to_bytes() {
+        let mut env = TestEnv::default();
+        let first_key = SoftwareEcdhSecretKey::random(env.rng());
+        let first_public = first_key.public_key();
+        let mut x = [0; EC_FIELD_SIZE];
+        let mut y = [0; EC_FIELD_SIZE];
+        first_public.to_coordinates(&mut x, &mut y);
+        let new_public = SoftwareEcdhPublicKey::from_coordinates(&x, &y).unwrap();
+        let mut new_x = [0; EC_FIELD_SIZE];
+        let mut new_y = [0; EC_FIELD_SIZE];
+        new_public.to_coordinates(&mut new_x, &mut new_y);
+        assert_eq!(x, new_x);
+        assert_eq!(y, new_y);
+    }
+
+    #[test]
+    fn test_sign_verify() {
+        let mut env = TestEnv::default();
+        let private_key = SoftwareEcdsaSecretKey::random(env.rng());
+        let public_key = private_key.public_key();
+        let message = [0x12, 0x34, 0x56, 0x78];
+        let signature = private_key.sign(&message);
+        assert!(public_key.verify(&message, &signature));
+    }
+
+    #[test]
+    fn test_ecdsa_secret_key_from_to_bytes() {
+        let mut env = TestEnv::default();
+        let first_key = SoftwareEcdsaSecretKey::random(env.rng());
+        let mut key_bytes = [0; EC_FIELD_SIZE];
+        first_key.to_slice(&mut key_bytes);
+        let second_key = SoftwareEcdsaSecretKey::from_slice(&key_bytes).unwrap();
+        let mut new_bytes = [0; EC_FIELD_SIZE];
+        second_key.to_slice(&mut new_bytes);
+        assert_eq!(key_bytes, new_bytes);
+    }
+
+    #[test]
+    fn test_sha256_hash_matches() {
+        let data = [0x55; 16];
+        let mut hasher = SoftwareSha256::new();
+        hasher.update(&data);
+        assert_eq!(SoftwareSha256::digest(&data), hasher.finalize());
+    }
+
+    #[test]
+    fn test_hmac256_verifies() {
+        let key = [0xAA; HMAC_KEY_SIZE];
+        let data = [0x55; 16];
+        let mac = SoftwareHmac256::mac(&key, &data);
+        assert!(SoftwareHmac256::verify(&key, &data, &mac));
+        let truncated_mac =
+            <&[u8; TRUNCATED_HMAC_SIZE]>::try_from(&mac[..TRUNCATED_HMAC_SIZE]).unwrap();
+        assert!(SoftwareHmac256::verify_truncated_left(
+            &key,
+            &data,
+            &truncated_mac
+        ));
+    }
+
+    #[test]
+    fn test_hkdf_empty_salt_256_vector() {
+        let okm = [
+            0xf9, 0xbe, 0x72, 0x11, 0x6c, 0xb9, 0x7f, 0x41, 0x82, 0x82, 0x10, 0x28, 0x9c, 0xaa,
+            0xfe, 0xab, 0xde, 0x1f, 0x3d, 0xfb, 0x97, 0x23, 0xbf, 0x43, 0x53, 0x8a, 0xb1, 0x8f,
+            0x36, 0x66, 0x78, 0x3a,
+        ];
+        assert_eq!(&SoftwareHkdf256::hkdf_empty_salt_256(b"0", &[0]), &okm);
+    }
+
+    #[test]
+    fn test_aes_encrypt_decrypt_block() {
+        let mut block = [0x55; AES_BLOCK_SIZE];
+        let aes = SoftwareAes256::new(&[0xAA; AES_KEY_SIZE]);
+        aes.encrypt_block(&mut block);
+        aes.decrypt_block(&mut block);
+        assert_eq!(block, [0x55; AES_BLOCK_SIZE]);
+    }
+
+    #[test]
+    fn test_aes_encrypt_decrypt_cbc() {
+        let mut message = [0x55; 2 * AES_BLOCK_SIZE];
+        let iv = [0x11; AES_BLOCK_SIZE];
+        let aes = SoftwareAes256::new(&[0xAA; AES_KEY_SIZE]);
+        aes.encrypt_cbc(&iv, &mut message);
+        aes.decrypt_cbc(&iv, &mut message);
+        assert_eq!(message, [0x55; 2 * AES_BLOCK_SIZE]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_aes_encrypt_panics() {
+        let mut message = [0x55; AES_BLOCK_SIZE + 1];
+        let iv = [0x11; AES_BLOCK_SIZE];
+        let aes = SoftwareAes256::new(&[0xAA; AES_KEY_SIZE]);
+        aes.encrypt_cbc(&iv, &mut message);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_aes_decrypt_panics() {
+        let mut message = [0x55; AES_BLOCK_SIZE + 1];
+        let iv = [0x11; AES_BLOCK_SIZE];
+        let aes = SoftwareAes256::new(&[0xAA; AES_KEY_SIZE]);
+        aes.decrypt_cbc(&iv, &mut message);
+    }
 }

--- a/libraries/opensk/src/api/crypto/software_crypto.rs
+++ b/libraries/opensk/src/api/crypto/software_crypto.rs
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::api::crypto::aes256::Aes256;
 use crate::api::crypto::hkdf256::Hkdf256;
 use crate::api::crypto::hmac256::Hmac256;
 use crate::api::crypto::sha256::Sha256;
 use crate::api::crypto::{
-    ecdh, ecdsa, Crypto, EC_FIELD_SIZE, EC_SIGNATURE_SIZE, HASH_SIZE, HMAC_KEY_SIZE,
-    TRUNCATED_HMAC_SIZE,
+    ecdh, ecdsa, Crypto, AES_BLOCK_SIZE, AES_KEY_SIZE, EC_FIELD_SIZE, EC_SIGNATURE_SIZE, HASH_SIZE,
+    HMAC_KEY_SIZE, TRUNCATED_HMAC_SIZE,
 };
 use alloc::vec::Vec;
 use crypto::Hash256;
@@ -28,6 +29,7 @@ pub struct SoftwareEcdh;
 pub struct SoftwareEcdsa;
 
 impl Crypto for SoftwareCrypto {
+    type Aes256 = SoftwareAes256;
     type Ecdh = SoftwareEcdh;
     type Ecdsa = SoftwareEcdsa;
     type Sha256 = SoftwareSha256;
@@ -211,96 +213,31 @@ impl Hkdf256 for SoftwareHkdf256 {
     }
 }
 
-#[cfg(test)]
-mod test {
-    use super::*;
-    use crate::api::crypto::ecdh::{
-        PublicKey as EcdhPublicKey, SecretKey as EcdhSecretKey, SharedSecret,
-    };
-    use crate::api::crypto::ecdsa::{PublicKey as EcdsaPublicKey, SecretKey as EcdsaSecretKey};
-    use crate::env::test::TestEnv;
-    use core::convert::TryFrom;
+pub struct SoftwareAes256 {
+    enc_key: crypto::aes256::EncryptionKey,
+}
 
-    #[test]
-    fn test_shared_secret_symmetric() {
-        let mut env = TestEnv::default();
-        let private1 = SoftwareEcdhSecretKey::random(env.rng());
-        let private2 = SoftwareEcdhSecretKey::random(env.rng());
-        let pub1 = private1.public_key();
-        let pub2 = private2.public_key();
-        let shared1 = private1.diffie_hellman(&pub2);
-        let shared2 = private2.diffie_hellman(&pub1);
-        assert_eq!(shared1.raw_secret_bytes(), shared2.raw_secret_bytes());
+impl Aes256 for SoftwareAes256 {
+    fn new(key: &[u8; AES_KEY_SIZE]) -> Self {
+        let enc_key = crypto::aes256::EncryptionKey::new(key);
+        SoftwareAes256 { enc_key }
     }
 
-    #[test]
-    fn test_ecdh_public_key_from_to_bytes() {
-        let mut env = TestEnv::default();
-        let first_key = SoftwareEcdhSecretKey::random(env.rng());
-        let first_public = first_key.public_key();
-        let mut x = [0; EC_FIELD_SIZE];
-        let mut y = [0; EC_FIELD_SIZE];
-        first_public.to_coordinates(&mut x, &mut y);
-        let new_public = SoftwareEcdhPublicKey::from_coordinates(&x, &y).unwrap();
-        let mut new_x = [0; EC_FIELD_SIZE];
-        let mut new_y = [0; EC_FIELD_SIZE];
-        new_public.to_coordinates(&mut new_x, &mut new_y);
-        assert_eq!(x, new_x);
-        assert_eq!(y, new_y);
+    fn encrypt_block(&self, block: &mut [u8; AES_BLOCK_SIZE]) {
+        self.enc_key.encrypt_block(block);
     }
 
-    #[test]
-    fn test_sign_verify() {
-        let mut env = TestEnv::default();
-        let private_key = SoftwareEcdsaSecretKey::random(env.rng());
-        let public_key = private_key.public_key();
-        let message = [0x12, 0x34, 0x56, 0x78];
-        let signature = private_key.sign(&message);
-        assert!(public_key.verify(&message, &signature));
+    fn decrypt_block(&self, block: &mut [u8; AES_BLOCK_SIZE]) {
+        let dec_key = crypto::aes256::DecryptionKey::new(&self.enc_key);
+        dec_key.decrypt_block(block);
     }
 
-    #[test]
-    fn test_ecdsa_secret_key_from_to_bytes() {
-        let mut env = TestEnv::default();
-        let first_key = SoftwareEcdsaSecretKey::random(env.rng());
-        let mut key_bytes = [0; EC_FIELD_SIZE];
-        first_key.to_slice(&mut key_bytes);
-        let second_key = SoftwareEcdsaSecretKey::from_slice(&key_bytes).unwrap();
-        let mut new_bytes = [0; EC_FIELD_SIZE];
-        second_key.to_slice(&mut new_bytes);
-        assert_eq!(key_bytes, new_bytes);
+    fn encrypt_cbc(&self, iv: &[u8; AES_BLOCK_SIZE], plaintext: &mut [u8]) {
+        crypto::cbc::cbc_encrypt(&self.enc_key, *iv, plaintext);
     }
 
-    #[test]
-    fn test_sha256_hash_matches() {
-        let data = [0x55; 16];
-        let mut hasher = SoftwareSha256::new();
-        hasher.update(&data);
-        assert_eq!(SoftwareSha256::digest(&data), hasher.finalize());
-    }
-
-    #[test]
-    fn test_hmac256_verifies() {
-        let key = [0xAA; HMAC_KEY_SIZE];
-        let data = [0x55; 16];
-        let mac = SoftwareHmac256::mac(&key, &data);
-        assert!(SoftwareHmac256::verify(&key, &data, &mac));
-        let truncated_mac =
-            <&[u8; TRUNCATED_HMAC_SIZE]>::try_from(&mac[..TRUNCATED_HMAC_SIZE]).unwrap();
-        assert!(SoftwareHmac256::verify_truncated_left(
-            &key,
-            &data,
-            truncated_mac
-        ));
-    }
-
-    #[test]
-    fn test_hkdf_empty_salt_256_vector() {
-        let okm = [
-            0xf9, 0xbe, 0x72, 0x11, 0x6c, 0xb9, 0x7f, 0x41, 0x82, 0x82, 0x10, 0x28, 0x9c, 0xaa,
-            0xfe, 0xab, 0xde, 0x1f, 0x3d, 0xfb, 0x97, 0x23, 0xbf, 0x43, 0x53, 0x8a, 0xb1, 0x8f,
-            0x36, 0x66, 0x78, 0x3a,
-        ];
-        assert_eq!(&SoftwareHkdf256::hkdf_empty_salt_256(b"0", &[0]), &okm);
+    fn decrypt_cbc(&self, iv: &[u8; AES_BLOCK_SIZE], ciphertext: &mut [u8]) {
+        let dec_key = crypto::aes256::DecryptionKey::new(&self.enc_key);
+        crypto::cbc::cbc_decrypt(&dec_key, *iv, ciphertext);
     }
 }

--- a/libraries/opensk/src/env/mod.rs
+++ b/libraries/opensk/src/env/mod.rs
@@ -29,6 +29,7 @@ use rng256::Rng256;
 #[cfg(feature = "std")]
 pub mod test;
 
+pub type AesKey<E> = <<E as Env>::Crypto as Crypto>::Aes256;
 pub type EcdhSk<E> = <<<E as Env>::Crypto as Crypto>::Ecdh as Ecdh>::SecretKey;
 pub type EcdhPk<E> = <<<E as Env>::Crypto as Crypto>::Ecdh as Ecdh>::PublicKey;
 pub type EcdsaSk<E> = <<<E as Env>::Crypto as Crypto>::Ecdsa as Ecdsa>::SecretKey;


### PR DESCRIPTION
Continues porting Crypto into Env. Next is RNG.

I decided to keep `encrypt_block` and `decrypt_block` in the interface, for all future use cases of people needing the primitive, even though it is currently unused.
Another decision is to only have an `AesKey`, not specific keys for encryption and decryption. In our CTAP code, we only passed around encryption keys anyway, and derived the decryption key when necessary. So having just one type made sense to me.

I moved the tests as discussed in #610 .