### PR TITLE
Cryptographic Secret type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,7 @@ dependencies = [
  "serde_json",
  "subtle",
  "untrusted",
+ "zeroize",
 ]
 
 [[package]]
@@ -242,6 +243,7 @@ dependencies = [
  "sk-cbor",
  "subtle",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]
@@ -444,10 +446,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "untrusted"
@@ -561,3 +581,24 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "zeroize"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]

--- a/examples/crypto_bench.rs
+++ b/examples/crypto_bench.rs
@@ -113,7 +113,8 @@ fn main() {
             || {
                 let mut sha = sha256::Sha256::new();
                 sha.update(&contents);
-                sha.finalize();
+                let mut dummy_hash = [0; 32];
+                sha.finalize(&mut dummy_hash);
             },
         );
     }

--- a/libraries/crypto/Cargo.toml
+++ b/libraries/crypto/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "=1.0.69", optional = true }
 regex = { version = "1", optional = true }
 rand_core = "0.6.4"
+zeroize = { version = "1.5.7", features = ["derive"] }
 
 [features]
 std = ["hex", "ring", "untrusted", "serde", "serde_json", "regex", "rand_core/getrandom"]

--- a/libraries/crypto/src/aes256.rs
+++ b/libraries/crypto/src/aes256.rs
@@ -12,21 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! A portable and naive textbook implementation of AES-256
+
 use super::util::{xor_block_16, Block16};
 use arrayref::{array_mut_ref, array_ref};
 use zeroize::Zeroize;
 
-/** A portable and naive textbook implementation of AES-256 **/
 type Word = [u8; 4];
 
-/** This structure caches the round keys, to avoid re-computing the key schedule for each block. **/
+/// Encryption key for AES256.
+///
+/// Never call zeroize explicitly, to not invalidate any invariants.
 #[derive(Zeroize)]
 pub struct EncryptionKey {
+    // This structure caches the round keys, to avoid re-computing the key schedule for each block.
     enc_round_keys: [Block16; 15],
 }
 
+/// Decryption key for AES256.
+///
+/// Never call zeroize explicitly, to not invalidate any invariants.
 #[derive(Zeroize)]
 pub struct DecryptionKey {
+    // This structure caches the round keys, to avoid re-computing the key schedule for each block.
     dec_round_keys: [Block16; 15],
 }
 

--- a/libraries/crypto/src/aes256.rs
+++ b/libraries/crypto/src/aes256.rs
@@ -14,15 +14,18 @@
 
 use super::util::{xor_block_16, Block16};
 use arrayref::{array_mut_ref, array_ref};
+use zeroize::Zeroize;
 
 /** A portable and naive textbook implementation of AES-256 **/
 type Word = [u8; 4];
 
 /** This structure caches the round keys, to avoid re-computing the key schedule for each block. **/
+#[derive(Zeroize)]
 pub struct EncryptionKey {
     enc_round_keys: [Block16; 15],
 }
 
+#[derive(Zeroize)]
 pub struct DecryptionKey {
     dec_round_keys: [Block16; 15],
 }

--- a/libraries/crypto/src/ec/exponent256.rs
+++ b/libraries/crypto/src/ec/exponent256.rs
@@ -16,9 +16,10 @@ use super::int256::{Digit, Int256};
 use core::ops::Mul;
 use rand_core::RngCore;
 use subtle::{self, Choice, ConditionallySelectable, CtOption};
+use zeroize::Zeroize;
 
 // An exponent on the elliptic curve, that is an element modulo the curve order N.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Zeroize)]
 // TODO: remove this Default once https://github.com/dalek-cryptography/subtle/issues/63 is
 // resolved.
 #[derive(Default)]
@@ -91,7 +92,7 @@ impl Mul for &ExponentP256 {
 }
 
 // A non-zero exponent on the elliptic curve.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Zeroize)]
 // TODO: remove this Default once https://github.com/dalek-cryptography/subtle/issues/63 is
 // resolved.
 #[derive(Default)]

--- a/libraries/crypto/src/ec/exponent256.rs
+++ b/libraries/crypto/src/ec/exponent256.rs
@@ -18,7 +18,9 @@ use rand_core::RngCore;
 use subtle::{self, Choice, ConditionallySelectable, CtOption};
 use zeroize::Zeroize;
 
-// An exponent on the elliptic curve, that is an element modulo the curve order N.
+/// An exponent on the elliptic curve, that is an element modulo the curve order N.
+///
+/// Never call zeroize explicitly, to not invalidate any invariants.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Zeroize)]
 // TODO: remove this Default once https://github.com/dalek-cryptography/subtle/issues/63 is
 // resolved.
@@ -91,7 +93,9 @@ impl Mul for &ExponentP256 {
     }
 }
 
-// A non-zero exponent on the elliptic curve.
+/// A non-zero exponent on the elliptic curve.
+///
+/// Never call zeroize explicitly, to not invalidate any invariants.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Zeroize)]
 // TODO: remove this Default once https://github.com/dalek-cryptography/subtle/issues/63 is
 // resolved.

--- a/libraries/crypto/src/ec/gfp256.rs
+++ b/libraries/crypto/src/ec/gfp256.rs
@@ -17,10 +17,14 @@ use core::ops::Mul;
 use subtle::Choice;
 use zeroize::Zeroize;
 
-// A field element on the elliptic curve, that is an element modulo the prime P.
-// This is the format used to serialize coordinates of points on the curve.
-// This implements enough methods to validate points and to convert them to/from the Montgomery
-// form, which is more convenient to operate on.
+/// A field element on the elliptic curve, that is an element modulo the prime P.
+///
+/// This is the format used to serialize coordinates of points on the curve.
+/// This implements enough methods to validate points and to convert them to/from the Montgomery
+/// form, which is more convenient to operate on.
+///
+/// Never call zeroize explicitly, to not invalidate any invariants.
+
 #[derive(Clone, Copy, PartialEq, Eq, Zeroize)]
 pub struct GFP256 {
     int: Int256,

--- a/libraries/crypto/src/ec/gfp256.rs
+++ b/libraries/crypto/src/ec/gfp256.rs
@@ -24,7 +24,6 @@ use zeroize::Zeroize;
 /// form, which is more convenient to operate on.
 ///
 /// Never call zeroize explicitly, to not invalidate any invariants.
-
 #[derive(Clone, Copy, PartialEq, Eq, Zeroize)]
 pub struct GFP256 {
     int: Int256,

--- a/libraries/crypto/src/ec/gfp256.rs
+++ b/libraries/crypto/src/ec/gfp256.rs
@@ -15,12 +15,13 @@
 use super::int256::{Digit, Int256};
 use core::ops::Mul;
 use subtle::Choice;
+use zeroize::Zeroize;
 
 // A field element on the elliptic curve, that is an element modulo the prime P.
 // This is the format used to serialize coordinates of points on the curve.
 // This implements enough methods to validate points and to convert them to/from the Montgomery
 // form, which is more convenient to operate on.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Zeroize)]
 pub struct GFP256 {
     int: Int256,
 }

--- a/libraries/crypto/src/ec/int256.rs
+++ b/libraries/crypto/src/ec/int256.rs
@@ -30,6 +30,9 @@ pub type Digit = u32;
 type DoubleDigit = u64;
 type SignedDoubleDigit = i64;
 
+/// Big integer implementation with 256 bits.
+///
+/// Never call zeroize explicitly, to not invalidate any invariants.
 #[derive(Clone, Copy, PartialEq, Eq, Zeroize)]
 // TODO: remove this Default once https://github.com/dalek-cryptography/subtle/issues/63 is
 // resolved.

--- a/libraries/crypto/src/ec/int256.rs
+++ b/libraries/crypto/src/ec/int256.rs
@@ -19,6 +19,7 @@ use byteorder::{BigEndian, ByteOrder};
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 use rand_core::RngCore;
 use subtle::{self, Choice, ConditionallySelectable, ConstantTimeEq};
+use zeroize::Zeroize;
 
 const BITS_PER_DIGIT: usize = 32;
 const BYTES_PER_DIGIT: usize = BITS_PER_DIGIT >> 3;
@@ -29,7 +30,7 @@ pub type Digit = u32;
 type DoubleDigit = u64;
 type SignedDoubleDigit = i64;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Zeroize)]
 // TODO: remove this Default once https://github.com/dalek-cryptography/subtle/issues/63 is
 // resolved.
 #[derive(Default)]

--- a/libraries/crypto/src/ec/montgomery.rs
+++ b/libraries/crypto/src/ec/montgomery.rs
@@ -23,7 +23,9 @@ pub const NLIMBS: usize = 9;
 pub const BOTTOM_28_BITS: u32 = 0x0fff_ffff;
 pub const BOTTOM_29_BITS: u32 = 0x1fff_ffff;
 
-/** Field element on the secp256r1 curve, represented in Montgomery form **/
+/// Field element on the secp256r1 curve, represented in Montgomery form.
+///
+/// Never call zeroize explicitly, to not invalidate any invariants.
 #[derive(Clone, Copy, Zeroize)]
 pub struct Montgomery {
     // The 9 limbs use 28 or 29 bits, alternatively: even limbs use 29 bits, odd limbs use 28 bits.

--- a/libraries/crypto/src/ec/montgomery.rs
+++ b/libraries/crypto/src/ec/montgomery.rs
@@ -17,13 +17,14 @@ use super::int256::Int256;
 use super::precomputed;
 use core::ops::{Add, Mul, Sub};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
+use zeroize::Zeroize;
 
 pub const NLIMBS: usize = 9;
 pub const BOTTOM_28_BITS: u32 = 0x0fff_ffff;
 pub const BOTTOM_29_BITS: u32 = 0x1fff_ffff;
 
 /** Field element on the secp256r1 curve, represented in Montgomery form **/
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Zeroize)]
 pub struct Montgomery {
     // The 9 limbs use 28 or 29 bits, alternatively: even limbs use 29 bits, odd limbs use 28 bits.
     // The Montgomery form stores a field element x as (x * 2^257) mod P.

--- a/libraries/crypto/src/ec/point.rs
+++ b/libraries/crypto/src/ec/point.rs
@@ -21,11 +21,12 @@ use arrayref::array_mut_ref;
 use arrayref::array_ref;
 use core::ops::Add;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
+use zeroize::Zeroize;
 
 // A point on the elliptic curve is represented by two field elements.
 // The "direct" representation with GFP256 (integer modulo p) is used for serialization of public
 // keys.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Zeroize)]
 pub struct PointP256 {
     x: GFP256,
     y: GFP256,
@@ -133,7 +134,7 @@ impl PointP256 {
 // This is in projective coordinates, i.e. it represents the point { x: x / z, y: y / z }.
 // This representation is more convenient to implement complete formulas for elliptic curve
 // arithmetic.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Zeroize)]
 pub struct PointProjective {
     x: Montgomery,
     y: Montgomery,
@@ -151,7 +152,7 @@ impl ConditionallySelectable for PointProjective {
 }
 
 // Equivalent to PointProjective { x, y, z: 1 }
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Zeroize)]
 pub struct PointAffine {
     x: Montgomery,
     y: Montgomery,

--- a/libraries/crypto/src/ec/point.rs
+++ b/libraries/crypto/src/ec/point.rs
@@ -23,9 +23,12 @@ use core::ops::Add;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 use zeroize::Zeroize;
 
-// A point on the elliptic curve is represented by two field elements.
-// The "direct" representation with GFP256 (integer modulo p) is used for serialization of public
-// keys.
+/// A point on the elliptic curve, represented by two field elements.
+///
+/// The "direct" representation with GFP256 (integer modulo p) is used for serialization of public
+/// keys.
+///
+/// Never call zeroize explicitly, to not invalidate any invariants.
 #[derive(Clone, Copy, Zeroize)]
 pub struct PointP256 {
     x: GFP256,
@@ -129,11 +132,14 @@ impl PointP256 {
     }
 }
 
-// A point on the elliptic curve in projective form.
-// This uses Montgomery representation for field elements.
-// This is in projective coordinates, i.e. it represents the point { x: x / z, y: y / z }.
-// This representation is more convenient to implement complete formulas for elliptic curve
-// arithmetic.
+/// A point on the elliptic curve in projective form.
+///
+/// This uses Montgomery representation for field elements.
+/// This is in projective coordinates, i.e. it represents the point { x: x / z, y: y / z }.
+/// This representation is more convenient to implement complete formulas for elliptic curve
+/// arithmetic.
+///
+/// Never call zeroize explicitly, to not invalidate any invariants.
 #[derive(Clone, Copy, Zeroize)]
 pub struct PointProjective {
     x: Montgomery,
@@ -151,7 +157,9 @@ impl ConditionallySelectable for PointProjective {
     }
 }
 
-// Equivalent to PointProjective { x, y, z: 1 }
+/// Equivalent to PointProjective { x, y, z: 1 }
+///
+/// Never call zeroize explicitly, to not invalidate any invariants.
 #[derive(Clone, Copy, Zeroize)]
 pub struct PointAffine {
     x: Montgomery,

--- a/libraries/crypto/src/ecdh.rs
+++ b/libraries/crypto/src/ecdh.rs
@@ -21,11 +21,17 @@ use zeroize::Zeroize;
 
 pub const NBYTES: usize = int256::NBYTES;
 
+/// A private key for ECDH.
+///
+/// Never call zeroize explicitly, to not invalidate any invariants.
 #[derive(Zeroize)]
 pub struct SecKey {
     a: NonZeroExponentP256,
 }
 
+/// A public key for ECDH.
+///
+/// Never call zeroize explicitly, to not invalidate any invariants.
 #[derive(Clone, Debug, PartialEq, Zeroize)]
 pub struct PubKey {
     p: PointP256,

--- a/libraries/crypto/src/ecdh.rs
+++ b/libraries/crypto/src/ecdh.rs
@@ -17,14 +17,16 @@ use super::ec::int256;
 use super::ec::int256::Int256;
 use super::ec::point::PointP256;
 use rand_core::RngCore;
+use zeroize::Zeroize;
 
 pub const NBYTES: usize = int256::NBYTES;
 
+#[derive(Zeroize)]
 pub struct SecKey {
     a: NonZeroExponentP256,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Zeroize)]
 pub struct PubKey {
     p: PointP256,
 }

--- a/libraries/crypto/src/ecdsa.rs
+++ b/libraries/crypto/src/ecdsa.rs
@@ -28,17 +28,26 @@ use zeroize::Zeroize;
 
 pub const NBYTES: usize = int256::NBYTES;
 
+/// A private key for ECDSA.
+///
+/// Never call zeroize explicitly, to not invalidate any invariants.
 #[derive(Clone, Debug, PartialEq, Eq, Zeroize)]
 pub struct SecKey {
     k: NonZeroExponentP256,
 }
 
+/// An ECDSA signature.
+///
+/// Never call zeroize explicitly, to not invalidate any invariants.
 #[derive(Zeroize)]
 pub struct Signature {
     r: NonZeroExponentP256,
     s: NonZeroExponentP256,
 }
 
+/// A public key for ECDSA.
+///
+/// Never call zeroize explicitly, to not invalidate any invariants.
 #[derive(Clone, Zeroize)]
 pub struct PubKey {
     p: PointP256,

--- a/libraries/crypto/src/lib.rs
+++ b/libraries/crypto/src/lib.rs
@@ -27,19 +27,18 @@ pub mod hmac;
 pub mod sha256;
 pub mod util;
 
-// Trait for hash functions that returns a 256-bit hash.
-// The type must be Sized (size known at compile time) so that we can instanciate one on the stack
-// in the hash() method.
+/// Trait for hash functions that returns a 256-bit hash.
+///
+/// When you implement this trait, make sure to implement `hash_mut` and `hmac_mut` first, because
+/// the default implementations of `hash` and `hmac` rely on it.
 pub trait Hash256: Sized {
     fn new() -> Self;
     fn update(&mut self, contents: &[u8]);
     fn finalize(self, output: &mut [u8; 32]);
 
     fn hash(contents: &[u8]) -> [u8; 32] {
-        let mut h = Self::new();
-        h.update(contents);
         let mut output = [0; 32];
-        h.finalize(&mut output);
+        Self::hash_mut(contents, &mut output);
         output
     }
 
@@ -51,7 +50,7 @@ pub trait Hash256: Sized {
 
     fn hmac(key: &[u8; 32], contents: &[u8]) -> [u8; 32] {
         let mut output = [0; 32];
-        hmac::software_hmac_256::<Self>(key, contents, &mut output);
+        Self::hmac_mut(key, contents, &mut output);
         output
     }
 
@@ -60,7 +59,7 @@ pub trait Hash256: Sized {
     }
 }
 
-// Trait for hash functions that operate on 64-byte input blocks.
+/// Trait for hash functions that operate on 64-byte input blocks.
 pub trait HashBlockSize64Bytes {
     type State;
 

--- a/libraries/crypto/src/lib.rs
+++ b/libraries/crypto/src/lib.rs
@@ -33,16 +33,30 @@ pub mod util;
 pub trait Hash256: Sized {
     fn new() -> Self;
     fn update(&mut self, contents: &[u8]);
-    fn finalize(self) -> [u8; 32];
+    fn finalize(self, output: &mut [u8; 32]);
 
     fn hash(contents: &[u8]) -> [u8; 32] {
         let mut h = Self::new();
         h.update(contents);
-        h.finalize()
+        let mut output = [0; 32];
+        h.finalize(&mut output);
+        output
+    }
+
+    fn hash_mut(contents: &[u8], output: &mut [u8; 32]) {
+        let mut h = Self::new();
+        h.update(contents);
+        h.finalize(output)
     }
 
     fn hmac(key: &[u8; 32], contents: &[u8]) -> [u8; 32] {
-        hmac::software_hmac_256::<Self>(key, contents)
+        let mut output = [0; 32];
+        hmac::software_hmac_256::<Self>(key, contents, &mut output);
+        output
+    }
+
+    fn hmac_mut(key: &[u8; 32], contents: &[u8], output: &mut [u8; 32]) {
+        hmac::software_hmac_256::<Self>(key, contents, output);
     }
 }
 

--- a/libraries/opensk/Cargo.toml
+++ b/libraries/opensk/Cargo.toml
@@ -28,6 +28,7 @@ hmac = { version = "0.12.1", optional = true }
 hkdf = { version = "0.12.3", optional = true }
 aes = { version = "0.8.2", optional = true }
 cbc = { version = "0.1.2", optional = true }
+zeroize = { version = "1.5.7", features = ["derive"] }
 
 [features]
 debug_ctap = []

--- a/libraries/opensk/src/api/attestation_store.rs
+++ b/libraries/opensk/src/api/attestation_store.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::api::crypto::EC_FIELD_SIZE;
+use crate::ctap::secret::Secret;
 use crate::env::Env;
 use alloc::vec::Vec;
 use persistent_store::{StoreError, StoreUpdate};
@@ -27,7 +28,7 @@ pub enum Id {
 #[cfg_attr(feature = "std", derive(Debug, PartialEq, Eq))]
 pub struct Attestation {
     /// ECDSA private key (big-endian).
-    pub private_key: [u8; EC_FIELD_SIZE],
+    pub private_key: Secret<[u8; EC_FIELD_SIZE]>,
     pub certificate: Vec<u8>,
 }
 
@@ -69,7 +70,7 @@ pub fn helper_get(env: &mut impl Env) -> Result<Option<Attestation>, Error> {
         return Err(Error::Internal);
     }
     Ok(Some(Attestation {
-        private_key: *array_ref![private_key, 0, EC_FIELD_SIZE],
+        private_key: Secret::from_exposed_secret(*array_ref![private_key, 0, EC_FIELD_SIZE]),
         certificate,
     }))
 }

--- a/libraries/opensk/src/api/crypto/ecdh.rs
+++ b/libraries/opensk/src/api/crypto/ecdh.rs
@@ -49,5 +49,5 @@ pub trait PublicKey: Sized {
 /// ECDH shared secret.
 pub trait SharedSecret {
     /// Exports the x component of the point computed by Diffie–Hellman.
-    fn raw_secret_bytes(&self) -> [u8; EC_FIELD_SIZE];
+    fn raw_secret_bytes(&self, secret: &mut [u8; EC_FIELD_SIZE]);
 }

--- a/libraries/opensk/src/api/crypto/hkdf256.rs
+++ b/libraries/opensk/src/api/crypto/hkdf256.rs
@@ -26,7 +26,7 @@ pub trait Hkdf256 {
     ///
     /// This implementation is equivalent to a standard HKD, with `salt` fixed at a length of
     /// 32 byte and the output length l as 32.
-    fn hkdf_256(ikm: &[u8], salt: &[u8; HASH_SIZE], info: &[u8]) -> [u8; HASH_SIZE];
+    fn hkdf_256(ikm: &[u8], salt: &[u8; HASH_SIZE], info: &[u8], okm: &mut [u8; HASH_SIZE]);
 
     /// Computes the HKDF with empty salt and 256 bit (one block) output.
     ///
@@ -37,7 +37,7 @@ pub trait Hkdf256 {
     ///
     /// This implementation is equivalent to a standard HKDF, with `salt` set to the
     /// default block of zeros and the output length l as 32.
-    fn hkdf_empty_salt_256(ikm: &[u8], info: &[u8]) -> [u8; HASH_SIZE] {
-        Self::hkdf_256(ikm, &[0; HASH_SIZE], info)
+    fn hkdf_empty_salt_256(ikm: &[u8], info: &[u8], okm: &mut [u8; HASH_SIZE]) {
+        Self::hkdf_256(ikm, &[0; HASH_SIZE], info, okm)
     }
 }

--- a/libraries/opensk/src/api/crypto/hmac256.rs
+++ b/libraries/opensk/src/api/crypto/hmac256.rs
@@ -17,7 +17,7 @@ use super::{HASH_SIZE, HMAC_KEY_SIZE, TRUNCATED_HMAC_SIZE};
 /// For a given hash function, computes and verifies the HMAC.
 pub trait Hmac256 {
     /// Computes the HMAC.
-    fn mac(key: &[u8; HMAC_KEY_SIZE], data: &[u8]) -> [u8; HASH_SIZE];
+    fn mac(key: &[u8; HMAC_KEY_SIZE], data: &[u8], output: &mut [u8; HASH_SIZE]);
 
     /// Verifies the HMAC.
     ///

--- a/libraries/opensk/src/api/crypto/sha256.rs
+++ b/libraries/opensk/src/api/crypto/sha256.rs
@@ -15,16 +15,17 @@
 use super::HASH_SIZE;
 
 /// Hashes data using SHA256.
+///
+/// When you implement this trait, make sure to implement `digest_mut` first, because the default
+/// implementations of `digest` relies on it.
 pub trait Sha256: Sized {
     /// Computes the hash of a given message as an array.
     ///
     /// This function does not let you control the memory allocation. It should therefore not be
     /// used for secrets that need zeroization.
     fn digest(data: &[u8]) -> [u8; HASH_SIZE] {
-        let mut hasher = Self::new();
-        hasher.update(data);
         let mut output = [0; HASH_SIZE];
-        hasher.finalize(&mut output);
+        Self::digest_mut(data, &mut output);
         output
     }
 

--- a/libraries/opensk/src/api/crypto/sha256.rs
+++ b/libraries/opensk/src/api/crypto/sha256.rs
@@ -16,11 +16,23 @@ use super::HASH_SIZE;
 
 /// Hashes data using SHA256.
 pub trait Sha256: Sized {
-    /// Computes the hash of a given message directly.
+    /// Computes the hash of a given message as an array.
+    ///
+    /// This function does not let you control the memory allocation. It should therefore not be
+    /// used for secrets that need zeroization.
     fn digest(data: &[u8]) -> [u8; HASH_SIZE] {
         let mut hasher = Self::new();
         hasher.update(data);
-        hasher.finalize()
+        let mut output = [0; HASH_SIZE];
+        hasher.finalize(&mut output);
+        output
+    }
+
+    /// Computes the hash of a given message directly.
+    fn digest_mut(data: &[u8], output: &mut [u8; HASH_SIZE]) {
+        let mut hasher = Self::new();
+        hasher.update(data);
+        hasher.finalize(output)
     }
 
     /// Create a new object that can be incrementally updated for digesting.
@@ -30,5 +42,5 @@ pub trait Sha256: Sized {
     fn update(&mut self, data: &[u8]);
 
     /// Finalizes the hashing process, returns the hash value.
-    fn finalize(self) -> [u8; HASH_SIZE];
+    fn finalize(self, output: &mut [u8; HASH_SIZE]);
 }

--- a/libraries/opensk/src/api/key_store.rs
+++ b/libraries/opensk/src/api/key_store.rs
@@ -13,28 +13,29 @@
 // limitations under the License.
 
 use crate::api::crypto::ecdsa::SecretKey as _;
-use crate::api::rng::Rng;
+use crate::ctap::secret::Secret;
 use crate::env::{EcdsaSk, Env};
-use alloc::vec::Vec;
+use alloc::vec;
 use persistent_store::StoreError;
+use rand_core::RngCore;
 
 /// Provides storage for secret keys.
 ///
 /// Implementations may use the environment store: [`STORAGE_KEY`] is reserved for this usage.
 pub trait KeyStore {
     /// Returns the AES key for key handles encryption.
-    fn key_handle_encryption(&mut self) -> Result<[u8; 32], Error>;
+    fn key_handle_encryption(&mut self) -> Result<Secret<[u8; 32]>, Error>;
 
     /// Returns the key for key handles authentication.
-    fn key_handle_authentication(&mut self) -> Result<[u8; 32], Error>;
+    fn key_handle_authentication(&mut self) -> Result<Secret<[u8; 32]>, Error>;
 
     /// Derives an ECDSA private key from a seed.
     ///
     /// The result is big-endian.
-    fn derive_ecdsa(&mut self, seed: &[u8; 32]) -> Result<[u8; 32], Error>;
+    fn derive_ecdsa(&mut self, seed: &[u8; 32]) -> Result<Secret<[u8; 32]>, Error>;
 
     /// Generates a seed to derive an ECDSA private key.
-    fn generate_ecdsa_seed(&mut self) -> Result<[u8; 32], Error>;
+    fn generate_ecdsa_seed(&mut self) -> Result<Secret<[u8; 32]>, Error>;
 
     /// Resets the key store.
     fn reset(&mut self) -> Result<(), Error>;
@@ -53,23 +54,27 @@ pub const STORAGE_KEY: usize = 2046;
 pub trait Helper: Env {}
 
 impl<T: Helper> KeyStore for T {
-    fn key_handle_encryption(&mut self) -> Result<[u8; 32], Error> {
-        Ok(get_master_keys(self)?.encryption)
+    fn key_handle_encryption(&mut self) -> Result<Secret<[u8; 32]>, Error> {
+        Ok(get_master_keys(self)?.encryption.clone())
     }
 
-    fn key_handle_authentication(&mut self) -> Result<[u8; 32], Error> {
-        Ok(get_master_keys(self)?.authentication)
+    fn key_handle_authentication(&mut self) -> Result<Secret<[u8; 32]>, Error> {
+        Ok(get_master_keys(self)?.authentication.clone())
     }
 
-    fn derive_ecdsa(&mut self, seed: &[u8; 32]) -> Result<[u8; 32], Error> {
+    fn derive_ecdsa(&mut self, seed: &[u8; 32]) -> Result<Secret<[u8; 32]>, Error> {
         match EcdsaSk::<T>::from_slice(seed) {
             None => Err(Error),
-            Some(_) => Ok(*seed),
+            Some(_) => {
+                let mut derived: Secret<[u8; 32]> = Secret::default();
+                derived.copy_from_slice(seed);
+                Ok(derived)
+            }
         }
     }
 
-    fn generate_ecdsa_seed(&mut self) -> Result<[u8; 32], Error> {
-        let mut seed = [0; 32];
+    fn generate_ecdsa_seed(&mut self) -> Result<Secret<[u8; 32]>, Error> {
+        let mut seed = Secret::default();
         EcdsaSk::<T>::random(self.rng()).to_slice(&mut seed);
         Ok(seed)
     }
@@ -82,31 +87,30 @@ impl<T: Helper> KeyStore for T {
 /// Wrapper for master keys.
 struct MasterKeys {
     /// Master encryption key.
-    encryption: [u8; 32],
+    encryption: Secret<[u8; 32]>,
 
     /// Master authentication key.
-    authentication: [u8; 32],
+    authentication: Secret<[u8; 32]>,
 }
 
 fn get_master_keys(env: &mut impl Env) -> Result<MasterKeys, Error> {
     let master_keys = match env.store().find(STORAGE_KEY)? {
-        Some(x) => x,
+        Some(x) if x.len() == 64 => x,
+        Some(_) => return Err(Error),
         None => {
-            let master_encryption_key = env.rng().gen_uniform_u8x32();
-            let master_authentication_key = env.rng().gen_uniform_u8x32();
-            let mut master_keys = Vec::with_capacity(64);
-            master_keys.extend_from_slice(&master_encryption_key);
-            master_keys.extend_from_slice(&master_authentication_key);
+            let mut master_keys = vec![0; 64];
+            env.rng().fill_bytes(&mut master_keys);
             env.store().insert(STORAGE_KEY, &master_keys)?;
             master_keys
         }
     };
-    if master_keys.len() != 64 {
-        return Err(Error);
-    }
+    let mut encryption: Secret<[u8; 32]> = Secret::default();
+    encryption.copy_from_slice(array_ref![master_keys, 0, 32]);
+    let mut authentication: Secret<[u8; 32]> = Secret::default();
+    authentication.copy_from_slice(array_ref![master_keys, 32, 32]);
     Ok(MasterKeys {
-        encryption: *array_ref![master_keys, 0, 32],
-        authentication: *array_ref![master_keys, 32, 32],
+        encryption,
+        authentication,
     })
 }
 
@@ -119,19 +123,20 @@ impl From<StoreError> for Error {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::env::test::TestEnv;
 
     #[test]
     fn test_key_store() {
-        let mut env = crate::env::test::TestEnv::default();
+        let mut env = TestEnv::default();
         let key_store = env.key_store();
 
         // Master keys are well-defined and stable.
         let encryption_key = key_store.key_handle_encryption().unwrap();
         let authentication_key = key_store.key_handle_authentication().unwrap();
-        assert_eq!(key_store.key_handle_encryption(), Ok(encryption_key));
+        assert_eq!(&key_store.key_handle_encryption().unwrap(), &encryption_key);
         assert_eq!(
-            key_store.key_handle_authentication(),
-            Ok(authentication_key)
+            &key_store.key_handle_authentication().unwrap(),
+            &authentication_key
         );
 
         // ECDSA seeds are well-defined and stable.
@@ -142,7 +147,10 @@ mod test {
         // Master keys change after reset. We don't require this for ECDSA seeds because it's not
         // the case, but it might be better.
         key_store.reset().unwrap();
-        assert!(key_store.key_handle_encryption().unwrap() != encryption_key);
-        assert!(key_store.key_handle_authentication().unwrap() != authentication_key);
+        assert_ne!(key_store.key_handle_encryption().unwrap(), encryption_key);
+        assert_ne!(
+            key_store.key_handle_authentication().unwrap(),
+            authentication_key
+        );
     }
 }

--- a/libraries/opensk/src/ctap/ctap1.rs
+++ b/libraries/opensk/src/ctap/ctap1.rs
@@ -359,6 +359,7 @@ mod test {
     use super::*;
     use crate::api::crypto::sha256::Sha256;
     use crate::api::customization::Customization;
+    use crate::ctap::secret::Secret;
     use crate::ctap::storage;
     use crate::env::test::TestEnv;
     use crate::env::Sha;
@@ -432,7 +433,7 @@ mod test {
         assert_eq!(response, Err(Ctap1StatusCode::SW_INTERNAL_EXCEPTION));
 
         let attestation = Attestation {
-            private_key: [0x41; 32],
+            private_key: Secret::from_exposed_secret([0x41; 32]),
             certificate: vec![0x99; 100],
         };
         env.attestation_store()

--- a/libraries/opensk/src/ctap/secret.rs
+++ b/libraries/opensk/src/ctap/secret.rs
@@ -1,0 +1,89 @@
+// Copyright 2022-2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides secret handling support.
+//!
+//! This module provides the `Secret<T>` type to store secrets of type `T` while minimizing the
+//! amount of time the secret is present in RAM. This type ensures that:
+//! - The secret only lives in one place. It is not implicitly copied (or equivalently moved).
+//! - The secret is zeroed out (using the `zeroize` crate) after usage.
+//!
+//! It is possible to escape those principles:
+//! - By using functions containing the sequence of words "expose secret" in their name.
+//! - By explicitly cloning or copying the secret.
+//!
+//! We don't use the secrecy crate because the SecretBox is incorrect and it doesn't provide a
+//! mutable version of ExposeSecret.
+//!
+//! Also note that eventually, we may use some Randomize trait instead of Zeroize, to prevent
+//! side-channels.
+
+use alloc::boxed::Box;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::ops::{Deref, DerefMut};
+use zeroize::Zeroize;
+
+/// Defines a secret that is zeroized on Drop.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Secret<T: Zeroize + ?Sized>(Box<T>);
+
+impl<T: Zeroize> Secret<T> {
+    /// Imports an already exposed secret.
+    ///
+    /// This is provided for convenience and should be avoided when possible. The expected usage is
+    /// to create a default secret, then write its content in place.
+    pub fn from_exposed_secret(secret: T) -> Self {
+        Self(Box::new(secret))
+    }
+}
+
+impl Secret<[u8]> {
+    pub fn new(len: usize) -> Self {
+        Self(vec![0; len].into_boxed_slice())
+    }
+
+    /// Extracts the secret as a Vec.
+    ///
+    /// This means that the secret won't be zeroed-out on Drop.
+    pub fn expose_secret_to_vec(mut self) -> Vec<u8> {
+        core::mem::take(&mut self.0).into()
+    }
+}
+
+impl<T: Default + Zeroize> Default for Secret<T> {
+    fn default() -> Self {
+        Secret(Box::default())
+    }
+}
+
+impl<T: Zeroize + ?Sized> Drop for Secret<T> {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl<T: Zeroize + ?Sized> Deref for Secret<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl<T: Zeroize + ?Sized> DerefMut for Secret<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.deref_mut()
+    }
+}

--- a/libraries/opensk/src/ctap/storage.rs
+++ b/libraries/opensk/src/ctap/storage.rs
@@ -624,6 +624,7 @@ mod test {
     use crate::ctap::data_formats::{
         CredentialProtectionPolicy, PublicKeyCredentialSource, PublicKeyCredentialType,
     };
+    use crate::ctap::secret::Secret;
     use crate::env::test::TestEnv;
 
     fn create_credential_source(
@@ -936,7 +937,7 @@ mod test {
 
         // Make sure the persistent keys are initialized to dummy values.
         let dummy_attestation = Attestation {
-            private_key: [0x41; 32],
+            private_key: Secret::from_exposed_secret([0x41; 32]),
             certificate: vec![0xdd; 20],
         };
         env.attestation_store()
@@ -1083,7 +1084,7 @@ mod test {
         let mut env = TestEnv::default();
 
         let dummy_attestation = Attestation {
-            private_key: [0x41; 32],
+            private_key: Secret::from_exposed_secret([0x41; 32]),
             certificate: vec![0xdd; 20],
         };
         env.attestation_store()

--- a/libraries/opensk/src/test_helpers/mod.rs
+++ b/libraries/opensk/src/test_helpers/mod.rs
@@ -15,6 +15,7 @@
 use crate::api::attestation_store::{self, AttestationStore};
 use crate::ctap::command::{AuthenticatorConfigParameters, Command};
 use crate::ctap::data_formats::ConfigSubCommand;
+use crate::ctap::secret::Secret;
 use crate::ctap::status_code::Ctap2StatusCode;
 use crate::ctap::{Channel, CtapState};
 use crate::env::Env;
@@ -28,7 +29,7 @@ pub fn enable_enterprise_attestation<E: Env>(
     env: &mut E,
 ) -> Result<attestation_store::Attestation, Ctap2StatusCode> {
     let attestation = attestation_store::Attestation {
-        private_key: [0x41; 32],
+        private_key: Secret::from_exposed_secret([0x41; 32]),
         certificate: vec![0xdd; 20],
     };
     env.attestation_store()

--- a/src/env/tock/commands.rs
+++ b/src/env/tock/commands.rs
@@ -27,6 +27,7 @@ use opensk::ctap::check_user_presence;
 use opensk::ctap::data_formats::{
     extract_bool, extract_byte_string, extract_map, extract_unsigned, ok_or_missing,
 };
+use opensk::ctap::secret::Secret;
 use opensk::ctap::status_code::Ctap2StatusCode;
 use opensk::ctap::{cbor_read, cbor_write, Channel};
 use opensk::env::{Env, Sha};
@@ -110,7 +111,7 @@ fn process_vendor_configure(
             // to not leak information.
             if current_attestation.is_none() {
                 let attestation = Attestation {
-                    private_key: data.private_key,
+                    private_key: Secret::from_exposed_secret(data.private_key),
                     certificate: data.certificate,
                 };
                 env.attestation_store()
@@ -491,7 +492,7 @@ mod test {
         assert_eq!(
             env.attestation_store().get(&attestation_store::Id::Batch),
             Ok(Some(Attestation {
-                private_key: dummy_key,
+                private_key: Secret::from_exposed_secret(dummy_key),
                 certificate: dummy_cert.to_vec(),
             }))
         );
@@ -519,7 +520,7 @@ mod test {
         assert_eq!(
             env.attestation_store().get(&attestation_store::Id::Batch),
             Ok(Some(Attestation {
-                private_key: dummy_key,
+                private_key: Secret::from_exposed_secret(dummy_key),
                 certificate: dummy_cert.to_vec(),
             }))
         );

--- a/src/env/tock/storage.rs
+++ b/src/env/tock/storage.rs
@@ -343,7 +343,8 @@ impl TockUpgradeStorage {
             // The hash implementation handles this in chunks, so no memory issues.
             hasher.update(partition_slice);
         }
-        let computed_hash = hasher.finalize();
+        let mut computed_hash = [0; 32];
+        hasher.finalize(&mut computed_hash);
         if &computed_hash != parse_metadata_hash(metadata) {
             return Err(StorageError::CustomError);
         }


### PR DESCRIPTION
This PR allows other `Env`s to fully zeroize its secret. For `TockEnv`, it is a best-effort implementation:

- `api/crypto` now writes into mutable slices to return secrets, with SHA256 offering both, as it is often used on non-secrets.
- `libraries/crypto` is adapted to that API change, and now zeroizes its public-facing types, as a first low-effort measure. For full zeroization, we could invest more into the implementation details if we want to use the library in the future.

Limitations:

- Storage is not encrypted, as we don't have a good way to generate an encryption key that does not live in the storage itself. Therefore, whatever we read from storage is not zeroized, as it is readable there anyway.
- The CBOR library is not zeroized, this affects `PrivateKey` in `encrypt_to_credential_id` and `PublicKeyCredentialSource`.

A different `Env` that has a means to derive keys from stored seeds would not be affected by these 2 limitations. It would have to implement a new `AttestationStore` and `KeyStore`.

With this PR, the crypto API shouldn't change too much anymore. The exception is the `ed25519` support behind a compile flag that should move into the API eventually.