### PR TITLE
Hardware failure state for user presence API

### DIFF
--- a/libraries/opensk/src/api/user_presence.rs
+++ b/libraries/opensk/src/api/user_presence.rs
@@ -20,6 +20,8 @@ pub enum UserPresenceError {
     Canceled,
     /// User presence check timed out.
     Timeout,
+    /// Unexpected (e.g., hardware) failures
+    Fail,
 }
 
 pub type UserPresenceResult = Result<(), UserPresenceError>;

--- a/libraries/opensk/src/ctap/status_code.rs
+++ b/libraries/opensk/src/ctap/status_code.rs
@@ -91,6 +91,7 @@ impl From<UserPresenceError> for Ctap2StatusCode {
             UserPresenceError::Timeout => Self::CTAP2_ERR_USER_ACTION_TIMEOUT,
             UserPresenceError::Declined => Self::CTAP2_ERR_OPERATION_DENIED,
             UserPresenceError::Canceled => Self::CTAP2_ERR_KEEPALIVE_CANCEL,
+            UserPresenceError::Fail => Self::CTAP2_ERR_VENDOR_HARDWARE_FAILURE,
         }
     }
 }


### PR DESCRIPTION
Introduced in #580

The conversion to libtock's ErrorCode has to happen outside of the library.