### PR TITLE
Moves CTAP secrets to the key store

### DIFF
--- a/libraries/opensk/src/ctap/mod.rs
+++ b/libraries/opensk/src/ctap/mod.rs
@@ -70,6 +70,7 @@ use crate::api::crypto::hkdf256::Hkdf256;
 use crate::api::crypto::sha256::Sha256;
 use crate::api::crypto::HASH_SIZE;
 use crate::api::customization::Customization;
+use crate::api::key_store::KeyStore;
 use crate::api::rng::Rng;
 use crate::api::user_presence::{UserPresence, UserPresenceError};
 use crate::env::{EcdsaSk, Env, Hkdf, Sha};
@@ -956,9 +957,9 @@ impl<E: Env> CtapState<E> {
     ) -> Result<Secret<[u8; HASH_SIZE]>, Ctap2StatusCode> {
         let private_key_bytes = private_key.to_bytes();
         let salt = array_ref!(private_key_bytes, 0, 32);
-        let key = storage::cred_random_secret(env, has_uv)?;
+        let key = env.key_store().cred_random(has_uv)?;
         let mut output = Secret::default();
-        Hkdf::<E>::hkdf_256(&key, salt, b"credRandom", &mut output);
+        Hkdf::<E>::hkdf_256(&*key, salt, b"credRandom", &mut output);
         Ok(output)
     }
 

--- a/libraries/opensk/src/ctap/storage/key.rs
+++ b/libraries/opensk/src/ctap/storage/key.rs
@@ -101,7 +101,7 @@ make_partition! {
     FORCE_PIN_CHANGE = 2040;
 
     /// The secret of the CredRandom feature.
-    CRED_RANDOM_SECRET = 2041;
+    _CRED_RANDOM_SECRET = 2041;
 
     /// List of RP IDs allowed to read the minimum PIN length.
     MIN_PIN_LENGTH_RP_IDS = 2042;


### PR DESCRIPTION
The PIN hash can be encrypted and decrypted, and CredRandom is part of the master secrets.

This PR doesn't change the behavior, but it allows other `Env` to be more sophisticated.