### PR TITLE
macos-latest for GitHub workflows

### DIFF
--- a/.github/workflows/boards_build.yml
+++ b/.github/workflows/boards_build.yml
@@ -12,7 +12,7 @@ jobs:
   build_boards:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/opensk_build.yml
+++ b/.github/workflows/opensk_build.yml
@@ -9,7 +9,7 @@ jobs:
   build_ctap2:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/reproducible.yml
+++ b/.github/workflows/reproducible.yml
@@ -9,7 +9,7 @@ jobs:
   check_hashes:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-latest, macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Workflows stopped running since we were on old MacOS versions. Using latest should fix this longer-term.