### PR TITLE
Fix clippy lints

### DIFF
--- a/libraries/opensk/src/ctap/mod.rs
+++ b/libraries/opensk/src/ctap/mod.rs
@@ -1110,7 +1110,7 @@ impl<E: Env> CtapState<E> {
             }
             let credential = filter_listed_credential(
                 env.key_store()
-                    .unwrap_credential(&allowed_credential.key_id, &rp_id_hash)?,
+                    .unwrap_credential(&allowed_credential.key_id, rp_id_hash)?,
                 has_uv,
             );
             if credential.is_some() {


### PR DESCRIPTION
Applies all suggested lints, then `cargo fmt`.