### PR TITLE
TODO cleanup

### DIFF
--- a/libraries/opensk/src/ctap/credential_management.rs
+++ b/libraries/opensk/src/ctap/credential_management.rs
@@ -138,16 +138,14 @@ fn process_enumerate_rps_begin<E: Env>(
     stateful_command_permission: &mut StatefulPermission<E>,
     channel: Channel,
 ) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
-    let rp_set = get_stored_rp_ids(env)?;
+    let mut rp_set = get_stored_rp_ids(env)?;
     let total_rps = rp_set.len();
 
     if total_rps > 1 {
         stateful_command_permission.set_command(env, StatefulCommand::EnumerateRps(1), channel);
     }
-    // TODO https://github.com/rust-lang/rust/issues/62924 replace with pop_first()
     let rp_id = rp_set
-        .into_iter()
-        .next()
+        .pop_first()
         .ok_or(Ctap2StatusCode::CTAP2_ERR_NO_CREDENTIALS)?;
     enumerate_rps_response::<E>(rp_id, Some(total_rps as u64))
 }

--- a/libraries/opensk/src/ctap/mod.rs
+++ b/libraries/opensk/src/ctap/mod.rs
@@ -97,7 +97,6 @@ const MAX_CBOR_NESTING_DEPTH: i8 = 4;
 
 pub const KEEPALIVE_DELAY_MS: usize = 100;
 pub const TOUCH_TIMEOUT_MS: usize = 30000;
-// TODO(kaczmarczyck) 2.1 allows Reset after Reset and 15 seconds?
 const RESET_TIMEOUT_DURATION_MS: usize = 10000;
 const STATEFUL_COMMAND_TIMEOUT_DURATION_MS: usize = 30000;
 


### PR DESCRIPTION
These cleanups were unlocked by a clear specification and a new compiler version.