### PR TITLE
Remove duplicated alarm syscall.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,7 @@ dependencies = [
  "ed25519-compact",
  "enum-iterator",
  "lang_items",
+ "libtock_alarm",
  "libtock_buttons",
  "libtock_console",
  "libtock_drivers",
@@ -374,6 +375,7 @@ dependencies = [
 name = "lang_items"
 version = "0.1.0"
 dependencies = [
+ "libtock_alarm",
  "libtock_console",
  "libtock_drivers",
  "libtock_leds",
@@ -388,6 +390,13 @@ name = "libc"
 version = "0.2.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+
+[[package]]
+name = "libtock_alarm"
+version = "0.1.0"
+dependencies = [
+ "libtock_platform",
+]
 
 [[package]]
 name = "libtock_buttons"
@@ -407,6 +416,7 @@ dependencies = [
 name = "libtock_drivers"
 version = "0.1.0"
 dependencies = [
+ "libtock_alarm",
  "libtock_console",
  "libtock_platform",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ features = ["no_auto_layout", "no_debug_memop"]
 libtock_buttons = { path = "third_party/libtock-rs/apis/buttons" }
 libtock_platform = { path = "third_party/libtock-rs/platform" }
 libtock_drivers = { path = "third_party/libtock-drivers" }
+libtock_alarm = { path = "third_party/libtock-rs/apis/alarm" }
 libtock_console = { path = "third_party/libtock-rs/apis/console" }
 libtock_leds = { path = "third_party/libtock-rs/apis/leds" }
 lang_items = { path = "third_party/lang-items" }

--- a/third_party/lang-items/Cargo.toml
+++ b/third_party/lang-items/Cargo.toml
@@ -18,6 +18,7 @@ libtock_drivers = { path = "../libtock-drivers" }
 libtock_platform = { path = "../../third_party/libtock-rs/platform" }
 libtock_low_level_debug = { path = "../../third_party/libtock-rs/apis/low_level_debug" }
 libtock_leds = { path = "../../third_party/libtock-rs/apis/leds" }
+libtock_alarm = { path = "../../third_party/libtock-rs/apis/alarm" }
 libtock_console = { path = "../../third_party/libtock-rs/apis/console" }
 
 [dependencies.linked_list_allocator]

--- a/third_party/lang-items/src/util.rs
+++ b/third_party/lang-items/src/util.rs
@@ -1,4 +1,4 @@
-use libtock_drivers::timer;
+use libtock_alarm::{Alarm, Milliseconds};
 use libtock_leds::Leds;
 use libtock_low_level_debug::{AlertCode, LowLevelDebug};
 use libtock_platform as platform;
@@ -28,13 +28,13 @@ impl<S: Syscalls, C: platform::subscribe::Config> Util<S, C> {
                     let _ = Leds::<S>::on(led);
                 }
             }
-            let _ = timer::Alarm::<S, C>::sleep_for(timer::Milliseconds(100));
+            let _ = Alarm::<S, C>::sleep_for(Milliseconds(100));
             if let Ok(led_count) = Leds::<S>::count() {
                 for led in 0..led_count {
                     let _ = Leds::<S>::off(led);
                 }
             }
-            let _ = timer::Alarm::<S, C>::sleep_for(timer::Milliseconds(100));
+            let _ = Alarm::<S, C>::sleep_for(Milliseconds(100));
         }
     }
 
@@ -47,7 +47,7 @@ impl<S: Syscalls, C: platform::subscribe::Config> Util<S, C> {
             if let Ok(leds) = Leds::<S>::count() {
                 for led in 0..leds {
                     let _ = Leds::<S>::on(led);
-                    let _ = timer::Alarm::<S, C>::sleep_for(timer::Milliseconds(100));
+                    let _ = Alarm::<S, C>::sleep_for(Milliseconds(100));
                     let _ = Leds::<S>::off(led);
                 }
             }

--- a/third_party/libtock-drivers/Cargo.toml
+++ b/third_party/libtock-drivers/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
+libtock_alarm = { path = "../../third_party/libtock-rs/apis/alarm" }
 libtock_console = { path = "../../third_party/libtock-rs/apis/console" }
 libtock_platform = { path = "../../third_party/libtock-rs/platform" }
 


### PR DESCRIPTION
The alarm syscall is implemented in libtock-rs, but was duplicated here. This removes the duplicated code and changes the references to point to libtock-rs directly.