### PR TITLE
Fix USB enumeration on OS X

### DIFF
--- a/boards/nordic/nrf52840_dongle_opensk/src/main.rs
+++ b/boards/nordic/nrf52840_dongle_opensk/src/main.rs
@@ -55,6 +55,10 @@ static STRINGS: &'static [&'static str] = &[
     "OpenSK",
     // Serial number
     "v1.0",
+    // Interface description + main HID string
+    "FIDO2",
+    // vendor HID string
+    "Vendor HID",
 ];
 
 // State for loading and holding applications.

--- a/boards/nordic/nrf52840_mdk_dfu/src/main.rs
+++ b/boards/nordic/nrf52840_mdk_dfu/src/main.rs
@@ -48,6 +48,10 @@ static STRINGS: &'static [&'static str] = &[
     "OpenSK",
     // Serial number
     "v1.0",
+    // Interface description + main HID string
+    "FIDO2",
+    // vendor HID string
+    "Vendor HID",
 ];
 
 // State for loading and holding applications.

--- a/boards/nordic/nrf52840dk_opensk/src/main.rs
+++ b/boards/nordic/nrf52840dk_opensk/src/main.rs
@@ -119,6 +119,10 @@ static STRINGS: &'static [&'static str] = &[
     "OpenSK",
     // Serial number
     "v1.0",
+    // Interface description + main HID string
+    "FIDO2",
+    // vendor HID string
+    "Vendor HID",
 ];
 
 // State for loading and holding applications.

--- a/patches/tock/03-add-ctap-modules.patch
+++ b/patches/tock/03-add-ctap-modules.patch
@@ -180,6 +180,21 @@ index 000000000..f2e248bc9
 +        self.side == Some(side)
 +    }
 +}
+diff --git a/capsules/src/usb/descriptors.rs b/capsules/src/usb/descriptors.rs
+index 67f708239..9c5bc9cd1 100644
+--- a/capsules/src/usb/descriptors.rs
++++ b/capsules/src/usb/descriptors.rs
+@@ -568,8 +568,8 @@ impl Default for ConfigurationDescriptor {
+             num_interfaces: 1,
+             configuration_value: 1,
+             string_index: 0,
+-            attributes: ConfigurationAttributes::new(true, false),
+-            max_power: 0, // in 2mA units
++            attributes: ConfigurationAttributes::new(false, false),
++            max_power: 50, // in 2mA units
+             related_descriptor_length: 0,
+         }
+     }
 diff --git a/capsules/src/usb/mod.rs b/capsules/src/usb/mod.rs
 index 767f5de83..cb5e0af97 100644
 --- a/capsules/src/usb/mod.rs
@@ -544,10 +559,10 @@ index 000000000..30cac1323
 +}
 diff --git a/capsules/src/usb/usbc_ctap_hid.rs b/capsules/src/usb/usbc_ctap_hid.rs
 new file mode 100644
-index 000000000..e074eb7a6
+index 000000000..5ad2c44b3
 --- /dev/null
 +++ b/capsules/src/usb/usbc_ctap_hid.rs
-@@ -0,0 +1,552 @@
+@@ -0,0 +1,554 @@
 +//! A USB HID client of the USB hardware interface
 +
 +use super::app::App;
@@ -652,14 +667,14 @@ index 000000000..e074eb7a6
 +    }];
 +
 +static HID: HIDDescriptor<'static> = HIDDescriptor {
-+    hid_class: 0x0110,
++    hid_class: 0x0111,
 +    country_code: HIDCountryCode::NotSupported,
 +    sub_descriptors: HID_SUB_DESCRIPTORS,
 +};
 +
 +#[cfg(feature = "vendor_hid")]
 +static VENDOR_HID: HIDDescriptor<'static> = HIDDescriptor {
-+    hid_class: 0x0110,
++    hid_class: 0x0111,
 +    country_code: HIDCountryCode::NotSupported,
 +    sub_descriptors: VENDOR_HID_SUB_DESCRIPTORS,
 +};
@@ -719,6 +734,7 @@ index 000000000..e074eb7a6
 +                interface_class: 0x03,    // HID
 +                interface_subclass: 0x00, // no subcall
 +                interface_protocol: 0x00, // no protocol
++                string_index: 4,
 +                ..InterfaceDescriptor::default()
 +            },
 +            // Vendor HID interface.
@@ -728,6 +744,7 @@ index 000000000..e074eb7a6
 +                interface_class: 0x03, // HID
 +                interface_subclass: 0x00,
 +                interface_protocol: 0x00,
++                string_index: 5,
 +                ..InterfaceDescriptor::default()
 +            },
 +        ];
@@ -786,7 +803,7 @@ index 000000000..e074eb7a6
 +                    manufacturer_string: 1,
 +                    product_string: 2,
 +                    serial_number_string: 3,
-+                    class: 0x03, // HID class for all interfaces
++                    class: 0x00, // Class is specified at the interface level
 +                    max_packet_size_ep0: max_ctrl_packet_size,
 +                    ..descriptors::DeviceDescriptor::default()
 +                },

--- a/patches/tock/04-vendor-hid.patch
+++ b/patches/tock/04-vendor-hid.patch
@@ -10,7 +10,7 @@ index 65301bcf1..dc70e98b1 100644
 +[features]
 +vendor_hid = []
 diff --git a/capsules/src/usb/descriptors.rs b/capsules/src/usb/descriptors.rs
-index 67f708239..c2556d3a2 100644
+index 9c5bc9cd1..c3ed71c44 100644
 --- a/capsules/src/usb/descriptors.rs
 +++ b/capsules/src/usb/descriptors.rs
 @@ -415,13 +415,14 @@ impl DescriptorBuffer {

--- a/patches/tock/06-persistent-storage.patch
+++ b/patches/tock/06-persistent-storage.patch
@@ -1,5 +1,5 @@
 diff --git a/chips/nrf52/src/nvmc.rs b/chips/nrf52/src/nvmc.rs
-index 61e94260e..b7c3be3f6 100644
+index 61e94260e..e115e1851 100644
 --- a/chips/nrf52/src/nvmc.rs
 +++ b/chips/nrf52/src/nvmc.rs
 @@ -5,7 +5,14 @@
@@ -393,7 +393,7 @@ index 028f30220..8880bc000 100644
  pub use crate::process::ProcessId;
  pub use crate::scheduler::Scheduler;
 diff --git a/kernel/src/memop.rs b/kernel/src/memop.rs
-index 51d89f37c..45ab3856b 100644
+index 51d89f37c..c4f7cef92 100644
 --- a/kernel/src/memop.rs
 +++ b/kernel/src/memop.rs
 @@ -107,6 +107,37 @@ pub(crate) fn memop(process: &dyn Process, op_type: usize, r1: usize) -> Syscall


### PR DESCRIPTION
Hopefully without breaking the others.

Summary of the changes:
- Device descriptor reports the device is bus powered and requires 100mA max.
- HID descriptor version bumped to 1.11 (was 1.10)
- Added string index for Interface and HID descriptors (which seems to make OS X happy)

Fixes #348


- [x] Tests pass
- [x] Appropriate changes to README are included in PR