### PR TITLE
Add more transparency into some EC structures.

### DIFF
--- a/libraries/crypto/src/ecdh.rs
+++ b/libraries/crypto/src/ecdh.rs
@@ -78,6 +78,17 @@ impl SecKey {
         p.getx().to_int().to_bin(&mut x);
         x
     }
+
+    /// Creates a private key from the exponent's bytes, or None if checks fail.
+    pub fn from_bytes(bytes: &[u8; 32]) -> Option<SecKey> {
+        let a = NonZeroExponentP256::from_int_checked(Int256::from_bin(bytes));
+        // The branching here is fine because all this reveals is whether the key was invalid.
+        if bool::from(a.is_none()) {
+            return None;
+        }
+        let a = a.unwrap();
+        Some(SecKey { a })
+    }
 }
 
 impl PubKey {

--- a/libraries/crypto/src/ecdsa.rs
+++ b/libraries/crypto/src/ecdsa.rs
@@ -19,9 +19,7 @@ use super::ec::point::PointP256;
 use super::Hash256;
 use alloc::vec;
 use alloc::vec::Vec;
-#[cfg(feature = "std")]
-use arrayref::array_mut_ref;
-use arrayref::{array_ref, mut_array_refs};
+use arrayref::{array_mut_ref, array_ref, mut_array_refs};
 use core::marker::PhantomData;
 use rand_core::RngCore;
 use zeroize::Zeroize;
@@ -220,7 +218,6 @@ impl Signature {
         Some(Signature { r, s })
     }
 
-    #[cfg(feature = "std")]
     pub fn to_bytes(&self, bytes: &mut [u8; Signature::BYTES_LENGTH]) {
         self.r
             .to_int()

--- a/libraries/opensk/src/api/crypto/ecdsa.rs
+++ b/libraries/opensk/src/api/crypto/ecdsa.rs
@@ -73,7 +73,6 @@ pub trait Signature: Sized {
     fn from_slice(bytes: &[u8; EC_SIGNATURE_SIZE]) -> Option<Self>;
 
     /// Writes the signature bytes into the passed in parameter.
-    #[cfg(feature = "std")]
     fn to_slice(&self, bytes: &mut [u8; EC_SIGNATURE_SIZE]);
 
     /// Encodes the signatures as ASN1 DER.

--- a/libraries/opensk/src/api/crypto/software_crypto.rs
+++ b/libraries/opensk/src/api/crypto/software_crypto.rs
@@ -169,7 +169,6 @@ impl ecdsa::Signature for SoftwareEcdsaSignature {
         crypto::ecdsa::Signature::from_bytes(bytes).map(|s| SoftwareEcdsaSignature { signature: s })
     }
 
-    #[cfg(feature = "std")]
     fn to_slice(&self, bytes: &mut [u8; EC_SIGNATURE_SIZE]) {
         self.signature.to_bytes(bytes);
     }


### PR DESCRIPTION
This adds the ability to create ECDH keys from raw bytes and export signatures as raw bytes.