### PR TITLE
New key wrapping API

### DIFF
--- a/libraries/opensk/src/api/key_store.rs
+++ b/libraries/opensk/src/api/key_store.rs
@@ -29,14 +29,13 @@ use rand_core::RngCore;
 use sk_cbor as cbor;
 use sk_cbor::{cbor_map_options, destructure_cbor_map};
 
-const LEGACY_CREDENTIAL_ID_SIZE: usize = 112;
 // CBOR credential IDs consist of
 // - 1   byte : version number
 // - 16  bytes: initialization vector for AES-256,
 // - 192 bytes: encrypted block of the key handle cbor,
 // - 32  bytes: HMAC-SHA256 over everything else.
 pub const CBOR_CREDENTIAL_ID_SIZE: usize = 241;
-const MIN_CREDENTIAL_ID_SIZE: usize = LEGACY_CREDENTIAL_ID_SIZE;
+const MIN_CREDENTIAL_ID_SIZE: usize = CBOR_CREDENTIAL_ID_SIZE;
 pub(crate) const MAX_CREDENTIAL_ID_SIZE: usize = CBOR_CREDENTIAL_ID_SIZE;
 
 pub const CBOR_CREDENTIAL_ID_VERSION: u8 = 0x01;
@@ -182,12 +181,6 @@ impl<T: Helper> KeyStore for T {
     /// Returns None if
     /// - the format does not match any known versions, or
     /// - the HMAC test fails.
-    ///
-    /// For v0 (legacy U2F) the credential ID consists of:
-    /// - 16 bytes: initialization vector for AES-256,
-    /// - 32 bytes: encrypted ECDSA private key for the credential,
-    /// - 32 bytes: encrypted relying party ID hashed with SHA256,
-    /// - 32 bytes: HMAC-SHA256 over everything else.
     ///
     /// For v1 (CBOR) the credential ID consists of:
     /// -   1 byte : version number,

--- a/libraries/opensk/src/api/private_key.rs
+++ b/libraries/opensk/src/api/private_key.rs
@@ -69,7 +69,7 @@ impl PrivateKey {
     }
 
     /// Helper function that creates a private key of type ECDSA.
-    fn new_ecdsa_from_bytes(bytes: &[u8]) -> Option<Self> {
+    pub fn new_ecdsa_from_bytes(bytes: &[u8]) -> Option<Self> {
         if bytes.len() != 32 {
             return None;
         }
@@ -80,7 +80,7 @@ impl PrivateKey {
 
     /// Helper function that creates a private key of type Ed25519.
     #[cfg(feature = "ed25519")]
-    fn new_ed25519_from_bytes(bytes: &[u8]) -> Option<Self> {
+    pub fn new_ed25519_from_bytes(bytes: &[u8]) -> Option<Self> {
         if bytes.len() != 32 {
             return None;
         }

--- a/libraries/opensk/src/api/private_key.rs
+++ b/libraries/opensk/src/api/private_key.rs
@@ -69,9 +69,7 @@ impl PrivateKey {
     }
 
     /// Helper function that creates a private key of type ECDSA.
-    ///
-    /// This function is public for legacy credential source parsing only.
-    pub fn new_ecdsa_from_bytes(bytes: &[u8]) -> Option<Self> {
+    fn new_ecdsa_from_bytes(bytes: &[u8]) -> Option<Self> {
         if bytes.len() != 32 {
             return None;
         }
@@ -80,8 +78,9 @@ impl PrivateKey {
         Some(PrivateKey::Ecdsa(seed))
     }
 
+    /// Helper function that creates a private key of type Ed25519.
     #[cfg(feature = "ed25519")]
-    pub fn new_ed25519_from_bytes(bytes: &[u8]) -> Option<Self> {
+    fn new_ed25519_from_bytes(bytes: &[u8]) -> Option<Self> {
         if bytes.len() != 32 {
             return None;
         }

--- a/libraries/opensk/src/api/private_key.rs
+++ b/libraries/opensk/src/api/private_key.rs
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 use crate::api::crypto::ecdsa::{SecretKey as _, Signature};
-use crate::api::key_store::KeyStore;
+use crate::ctap::crypto_wrapper::{aes256_cbc_decrypt, aes256_cbc_encrypt};
 use crate::ctap::data_formats::{extract_array, extract_byte_string, CoseKey, SignatureAlgorithm};
 use crate::ctap::secret::Secret;
 use crate::ctap::status_code::Ctap2StatusCode;
-use crate::env::{EcdsaSk, Env};
+use crate::env::{AesKey, EcdsaSk, Env};
 use alloc::vec;
 use alloc::vec::Vec;
 use core::convert::TryFrom;
@@ -34,8 +34,7 @@ use sk_cbor::{cbor_array, cbor_bytes, cbor_int};
 // We shouldn't compare private keys in prod without constant-time operations.
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub enum PrivateKey {
-    // We store the seed instead of the key since we can't get the seed back from the key. We could
-    // store both if we believe deriving the key is done more than once and costly.
+    // We store the key bytes instead of the env type. They can be converted into each other.
     Ecdsa(Secret<[u8; 32]>),
     #[cfg(feature = "ed25519")]
     Ed25519(ed25519_compact::SecretKey),
@@ -47,10 +46,12 @@ impl PrivateKey {
     /// # Panics
     ///
     /// Panics if the algorithm is [`SignatureAlgorithm::Unknown`].
-    pub fn new(env: &mut impl Env, alg: SignatureAlgorithm) -> Self {
+    pub fn new<E: Env>(env: &mut E, alg: SignatureAlgorithm) -> Self {
         match alg {
             SignatureAlgorithm::Es256 => {
-                PrivateKey::Ecdsa(env.key_store().generate_ecdsa_seed().unwrap())
+                let mut bytes: Secret<[u8; 32]> = Secret::default();
+                EcdsaSk::<E>::random(env.rng()).to_slice(&mut bytes);
+                PrivateKey::Ecdsa(bytes)
             }
             #[cfg(feature = "ed25519")]
             SignatureAlgorithm::Eddsa => {
@@ -89,19 +90,19 @@ impl PrivateKey {
     }
 
     /// Returns the ECDSA private key.
-    pub fn ecdsa_key<E: Env>(&self, env: &mut E) -> Result<EcdsaSk<E>, Ctap2StatusCode> {
+    pub fn ecdsa_key<E: Env>(&self) -> Result<EcdsaSk<E>, Ctap2StatusCode> {
         match self {
-            PrivateKey::Ecdsa(seed) => ecdsa_key_from_seed(env, seed),
+            PrivateKey::Ecdsa(bytes) => ecdsa_key_from_bytes::<E>(bytes),
             #[allow(unreachable_patterns)]
             _ => Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR),
         }
     }
 
     /// Returns the corresponding public key.
-    pub fn get_pub_key(&self, env: &mut impl Env) -> Result<CoseKey, Ctap2StatusCode> {
+    pub fn get_pub_key<E: Env>(&self) -> Result<CoseKey, Ctap2StatusCode> {
         Ok(match self {
-            PrivateKey::Ecdsa(ecdsa_seed) => {
-                CoseKey::from_ecdsa_public_key(ecdsa_key_from_seed(env, ecdsa_seed)?.public_key())
+            PrivateKey::Ecdsa(bytes) => {
+                CoseKey::from_ecdsa_public_key(ecdsa_key_from_bytes::<E>(bytes)?.public_key())
             }
             #[cfg(feature = "ed25519")]
             PrivateKey::Ed25519(ed25519_key) => CoseKey::from(ed25519_key.public_key()),
@@ -109,15 +110,9 @@ impl PrivateKey {
     }
 
     /// Returns the encoded signature for a given message.
-    pub(crate) fn sign_and_encode(
-        &self,
-        env: &mut impl Env,
-        message: &[u8],
-    ) -> Result<Vec<u8>, Ctap2StatusCode> {
+    pub fn sign_and_encode<E: Env>(&self, message: &[u8]) -> Result<Vec<u8>, Ctap2StatusCode> {
         Ok(match self {
-            PrivateKey::Ecdsa(ecdsa_seed) => {
-                ecdsa_key_from_seed(env, ecdsa_seed)?.sign(message).to_der()
-            }
+            PrivateKey::Ecdsa(bytes) => ecdsa_key_from_bytes::<E>(bytes)?.sign(message).to_der(),
             #[cfg(feature = "ed25519")]
             PrivateKey::Ed25519(ed25519_key) => ed25519_key.sign(message, None).to_vec(),
         })
@@ -136,57 +131,55 @@ impl PrivateKey {
     pub fn to_bytes(&self) -> Secret<[u8]> {
         let mut bytes = Secret::new(32);
         match self {
-            PrivateKey::Ecdsa(ecdsa_seed) => bytes.copy_from_slice(ecdsa_seed.deref()),
+            PrivateKey::Ecdsa(key_bytes) => bytes.copy_from_slice(key_bytes.deref()),
             #[cfg(feature = "ed25519")]
             PrivateKey::Ed25519(ed25519_key) => bytes.copy_from_slice(ed25519_key.seed().deref()),
         }
         bytes
     }
-}
 
-fn ecdsa_key_from_seed<E: Env>(
-    env: &mut E,
-    seed: &[u8; 32],
-) -> Result<EcdsaSk<E>, Ctap2StatusCode> {
-    let ecdsa_bytes = env.key_store().derive_ecdsa(seed)?;
-    Ok(EcdsaSk::<E>::from_slice(&ecdsa_bytes).unwrap())
-}
-
-impl From<&PrivateKey> for cbor::Value {
-    /// Writes a private key into CBOR format. This exposes the cryptographic secret.
-    // TODO needs zeroization if seed is secret
-    // called in wrap_credential and PublicKeyCredentialSource
-    fn from(private_key: &PrivateKey) -> Self {
-        cbor_array![
-            cbor_int!(private_key.signature_algorithm() as i64),
-            cbor_bytes!(private_key.to_bytes().expose_secret_to_vec()),
-        ]
+    pub fn to_cbor<E: Env>(
+        &self,
+        rng: &mut E::Rng,
+        wrap_key: &AesKey<E>,
+    ) -> Result<cbor::Value, Ctap2StatusCode> {
+        let bytes = self.to_bytes();
+        let wrapped_bytes = aes256_cbc_encrypt::<E>(rng, wrap_key, &bytes, true)?;
+        Ok(cbor_array![
+            cbor_int!(self.signature_algorithm() as i64),
+            cbor_bytes!(wrapped_bytes),
+        ])
     }
-}
 
-impl TryFrom<cbor::Value> for PrivateKey {
-    type Error = Ctap2StatusCode;
-
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    pub fn from_cbor<E: Env>(
+        wrap_key: &AesKey<E>,
+        cbor_value: cbor::Value,
+    ) -> Result<Self, Ctap2StatusCode> {
         let mut array = extract_array(cbor_value)?;
         if array.len() != 2 {
             return Err(Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR);
         }
-        let key_bytes = extract_byte_string(array.pop().unwrap())?;
+        let wrapped_bytes = extract_byte_string(array.pop().unwrap())?;
+        let key_bytes = aes256_cbc_decrypt::<E>(wrap_key, &wrapped_bytes, true)?;
         match SignatureAlgorithm::try_from(array.pop().unwrap())? {
-            SignatureAlgorithm::Es256 => PrivateKey::new_ecdsa_from_bytes(&key_bytes)
+            SignatureAlgorithm::Es256 => PrivateKey::new_ecdsa_from_bytes(&*key_bytes)
                 .ok_or(Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR),
             #[cfg(feature = "ed25519")]
-            SignatureAlgorithm::Eddsa => PrivateKey::new_ed25519_from_bytes(&key_bytes)
+            SignatureAlgorithm::Eddsa => PrivateKey::new_ed25519_from_bytes(&*key_bytes)
                 .ok_or(Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR),
             _ => Err(Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR),
         }
     }
 }
 
+fn ecdsa_key_from_bytes<E: Env>(bytes: &[u8; 32]) -> Result<EcdsaSk<E>, Ctap2StatusCode> {
+    EcdsaSk::<E>::from_slice(bytes).ok_or(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::api::key_store::KeyStore;
     use crate::env::test::TestEnv;
 
     #[test]
@@ -233,10 +226,10 @@ mod test {
     fn test_private_key_get_pub_key() {
         let mut env = TestEnv::default();
         let private_key = PrivateKey::new_ecdsa(&mut env);
-        let ecdsa_key = private_key.ecdsa_key(&mut env).unwrap();
+        let ecdsa_key = private_key.ecdsa_key::<TestEnv>().unwrap();
         let public_key = ecdsa_key.public_key();
         assert_eq!(
-            private_key.get_pub_key(&mut env),
+            private_key.get_pub_key::<TestEnv>(),
             Ok(CoseKey::from_ecdsa_public_key(public_key))
         );
     }
@@ -246,10 +239,10 @@ mod test {
         let mut env = TestEnv::default();
         let message = [0x5A; 32];
         let private_key = PrivateKey::new_ecdsa(&mut env);
-        let ecdsa_key = private_key.ecdsa_key(&mut env).unwrap();
+        let ecdsa_key = private_key.ecdsa_key::<TestEnv>().unwrap();
         let signature = ecdsa_key.sign(&message).to_der();
         assert_eq!(
-            private_key.sign_and_encode(&mut env, &message),
+            private_key.sign_and_encode::<TestEnv>(&message),
             Ok(signature)
         );
     }
@@ -273,9 +266,15 @@ mod test {
 
     fn test_private_key_from_to_cbor(signature_algorithm: SignatureAlgorithm) {
         let mut env = TestEnv::default();
+        let wrap_key = env.key_store().wrap_key::<TestEnv>().unwrap();
         let private_key = PrivateKey::new(&mut env, signature_algorithm);
-        let cbor = cbor::Value::from(&private_key);
-        assert_eq!(PrivateKey::try_from(cbor), Ok(private_key),);
+        let cbor = private_key
+            .to_cbor::<TestEnv>(env.rng(), &wrap_key)
+            .unwrap();
+        assert_eq!(
+            PrivateKey::from_cbor::<TestEnv>(&wrap_key, cbor),
+            Ok(private_key)
+        );
     }
 
     #[test]
@@ -290,6 +289,8 @@ mod test {
     }
 
     fn test_private_key_from_bad_cbor(signature_algorithm: SignatureAlgorithm) {
+        let mut env = TestEnv::default();
+        let wrap_key = env.key_store().wrap_key::<TestEnv>().unwrap();
         let cbor = cbor_array![
             cbor_int!(signature_algorithm as i64),
             cbor_bytes!(vec![0x88; 32]),
@@ -297,7 +298,7 @@ mod test {
             cbor_int!(0),
         ];
         assert_eq!(
-            PrivateKey::try_from(cbor),
+            PrivateKey::from_cbor::<TestEnv>(&wrap_key, cbor),
             Err(Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR),
         );
     }
@@ -315,13 +316,15 @@ mod test {
 
     #[test]
     fn test_private_key_from_bad_cbor_unsupported_algo() {
+        let mut env = TestEnv::default();
+        let wrap_key = env.key_store().wrap_key::<TestEnv>().unwrap();
         let cbor = cbor_array![
             // This algorithms doesn't exist.
             cbor_int!(-1),
             cbor_bytes!(vec![0x88; 32]),
         ];
         assert_eq!(
-            PrivateKey::try_from(cbor),
+            PrivateKey::from_cbor::<TestEnv>(&wrap_key, cbor),
             Err(Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR),
         );
     }

--- a/libraries/opensk/src/ctap/credential_management.rs
+++ b/libraries/opensk/src/ctap/credential_management.rs
@@ -61,8 +61,7 @@ fn enumerate_rps_response<E: Env>(
 }
 
 /// Generates the response for subcommands enumerating credentials.
-fn enumerate_credentials_response(
-    env: &mut impl Env,
+fn enumerate_credentials_response<E: Env>(
     credential: PublicKeyCredentialSource,
     total_credentials: Option<u64>,
 ) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
@@ -91,7 +90,7 @@ fn enumerate_credentials_response(
         key_id: credential_id,
         transports: None, // You can set USB as a hint here.
     };
-    let public_key = private_key.get_pub_key(env)?;
+    let public_key = private_key.get_pub_key::<E>()?;
     Ok(AuthenticatorCredentialManagementResponse {
         user: Some(user),
         credential_id: Some(credential_id),
@@ -202,7 +201,7 @@ fn process_enumerate_credentials_begin<E: Env>(
             channel,
         );
     }
-    enumerate_credentials_response(env, credential, Some(total_credentials as u64))
+    enumerate_credentials_response::<E>(credential, Some(total_credentials as u64))
 }
 
 /// Processes the subcommand enumerateCredentialsGetNextCredential for CredentialManagement.
@@ -212,7 +211,7 @@ fn process_enumerate_credentials_get_next_credential<E: Env>(
 ) -> Result<AuthenticatorCredentialManagementResponse, Ctap2StatusCode> {
     let credential_key = stateful_command_permission.next_enumerate_credential(env)?;
     let credential = storage::get_credential(env, credential_key)?;
-    enumerate_credentials_response(env, credential, None)
+    enumerate_credentials_response::<E>(credential, None)
 }
 
 /// Processes the subcommand deleteCredential for CredentialManagement.

--- a/libraries/opensk/src/ctap/ctap1.rs
+++ b/libraries/opensk/src/ctap/ctap1.rs
@@ -333,10 +333,6 @@ impl Ctap1Command {
             .map_err(|_| Ctap1StatusCode::SW_WRONG_DATA)?;
         let credential_source = filter_listed_credential(credential_source, false)
             .ok_or(Ctap1StatusCode::SW_WRONG_DATA)?;
-        let ecdsa_key = credential_source
-            .private_key
-            .ecdsa_key::<E>()
-            .map_err(|_| Ctap1StatusCode::SW_WRONG_DATA)?;
         if flags == Ctap1Flags::CheckOnly {
             return Err(Ctap1StatusCode::SW_COND_USE_NOT_SATISFIED);
         }
@@ -351,10 +347,13 @@ impl Ctap1Command {
             )
             .map_err(|_| Ctap1StatusCode::SW_WRONG_DATA)?;
         signature_data.extend(&challenge);
-        let signature = ecdsa_key.sign(&signature_data);
+        let signature = credential_source
+            .private_key
+            .sign_and_encode::<E>(&signature_data)
+            .map_err(|_| Ctap1StatusCode::SW_INTERNAL_EXCEPTION)?;
 
         let mut response = signature_data[application.len()..application.len() + 5].to_vec();
-        response.extend(signature.to_der());
+        response.extend(&signature);
         Ok(response)
     }
 }

--- a/libraries/opensk/src/ctap/ctap1.rs
+++ b/libraries/opensk/src/ctap/ctap1.rs
@@ -256,7 +256,7 @@ impl Ctap1Command {
     ) -> Result<Vec<u8>, Ctap1StatusCode> {
         let private_key = PrivateKey::new_ecdsa(env);
         let sk = private_key
-            .ecdsa_key(env)
+            .ecdsa_key::<E>()
             .map_err(|_| Ctap1StatusCode::SW_INTERNAL_EXCEPTION)?;
         let pk = sk.public_key();
         let credential_source = CredentialSource {
@@ -335,7 +335,7 @@ impl Ctap1Command {
             .ok_or(Ctap1StatusCode::SW_WRONG_DATA)?;
         let ecdsa_key = credential_source
             .private_key
-            .ecdsa_key(env)
+            .ecdsa_key::<E>()
             .map_err(|_| Ctap1StatusCode::SW_WRONG_DATA)?;
         if flags == Ctap1Flags::CheckOnly {
             return Err(Ctap1StatusCode::SW_COND_USE_NOT_SATISFIED);

--- a/libraries/opensk/src/ctap/mod.rs
+++ b/libraries/opensk/src/ctap/mod.rs
@@ -917,7 +917,7 @@ impl<E: Env> CtapState<E> {
         }
         auth_data.extend(vec![0x00, credential_id.len() as u8]);
         auth_data.extend(&credential_id);
-        let public_cose_key = private_key.get_pub_key(env)?;
+        let public_cose_key = private_key.get_pub_key::<E>()?;
         cbor_write(cbor::Value::from(public_cose_key), &mut auth_data)?;
         if has_extension_output {
             let hmac_secret_output = if extensions.hmac_secret {
@@ -965,7 +965,7 @@ impl<E: Env> CtapState<E> {
                     Some(vec![certificate]),
                 )
             }
-            None => (private_key.sign_and_encode(env, &signature_data)?, None),
+            None => (private_key.sign_and_encode::<E>(&signature_data)?, None),
         };
         let attestation_statement = PackedAttestationStatement {
             alg: SignatureAlgorithm::Es256 as i64,
@@ -1051,7 +1051,7 @@ impl<E: Env> CtapState<E> {
         signature_data.extend(client_data_hash);
         let signature = credential
             .private_key
-            .sign_and_encode(env, &signature_data)?;
+            .sign_and_encode::<E>(&signature_data)?;
 
         let cred_desc = PublicKeyCredentialDescriptor {
             key_type: PublicKeyCredentialType::PublicKey,

--- a/libraries/opensk/src/ctap/pin_protocol.rs
+++ b/libraries/opensk/src/ctap/pin_protocol.rs
@@ -225,7 +225,7 @@ impl<E: Env> SharedSecretV1<E> {
     }
 
     fn encrypt(&self, env: &mut E, plaintext: &[u8]) -> Result<Vec<u8>, Ctap2StatusCode> {
-        aes256_cbc_encrypt(env, &self.aes_key, plaintext, false)
+        aes256_cbc_encrypt::<E>(env.rng(), &self.aes_key, plaintext, false)
     }
 
     fn decrypt(&self, ciphertext: &[u8]) -> Result<Secret<[u8]>, Ctap2StatusCode> {
@@ -263,7 +263,7 @@ impl<E: Env> SharedSecretV2<E> {
     }
 
     fn encrypt(&self, env: &mut E, plaintext: &[u8]) -> Result<Vec<u8>, Ctap2StatusCode> {
-        aes256_cbc_encrypt(env, &self.aes_key, plaintext, true)
+        aes256_cbc_encrypt::<E>(env.rng(), &self.aes_key, plaintext, true)
     }
 
     fn decrypt(&self, ciphertext: &[u8]) -> Result<Secret<[u8]>, Ctap2StatusCode> {


### PR DESCRIPTION
Allows key wrapping to be different between persistent and server-side storage.

To accomplish this, the PrivateKey now always stores the fully reconstructed key, and has different methods to serialize it for the respective use case.
