### PR TITLE
Adds Bibtex for our paper to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 ![Cargo format](https://github.com/google/OpenSK/workflows/Cargo%20format/badge.svg?branch=stable)
 [![Coverage Status](https://coveralls.io/repos/github/google/OpenSK/badge.svg?branch=stable)](https://coveralls.io/github/google/OpenSK?branch=stable)
 
-*News:* [PQC paper published!](#Research)
+*News:*
+
+- 2023-08-24: [PQC paper reference](#Research)
 
 ## OpenSK
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 ![Cargo format](https://github.com/google/OpenSK/workflows/Cargo%20format/badge.svg?branch=stable)
 [![Coverage Status](https://coveralls.io/repos/github/google/OpenSK/badge.svg?branch=stable)](https://coveralls.io/github/google/OpenSK?branch=stable)
 
+*News:* [PQC paper published!](#Research)
+
 ## OpenSK
 
 This repository contains a Rust implementation of a
@@ -76,8 +78,22 @@ else you can do with your OpenSK, see [Customization](docs/customization.md).
 
 We implemented post-quantum cryptography on OpenSK. The code is released under
 the [hybrid-pqc tag](https://github.com/google/OpenSK/releases/tag/hybrid-pqc).
-Our [paper](https://research.google/pubs/pub51659/) was published in the ACNS
-Secure Cryptographic Implementation workshop 2023.
+Our [paper](https://eprint.iacr.org/2022/1225) was published in the ACNS
+Secure Cryptographic Implementation workshop 2023 and won the best paper award.
+
+<details>
+<summary>Bibtex reference</summary>
+
+```
+@misc{51659,
+title  = {Hybrid Post-Quantum Signatures in Hardware Security Keys},
+author = {Diana Ghinea and Fabian Kaczmarczyck and Jennifer Pullman and Julien Cretin and Rafael Misoczki and Stefan Kölbl and Luca Invernizzi and Elie Bursztein and Jean-Michel Picod},
+year   = {2022},
+URL    = {https://eprint.iacr.org/2022/1225}
+}
+```
+
+</details>
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -85,11 +85,12 @@ Secure Cryptographic Implementation workshop 2023 and won the best paper award.
 <summary>Bibtex reference</summary>
 
 ```
-@misc{51659,
-title  = {Hybrid Post-Quantum Signatures in Hardware Security Keys},
-author = {Diana Ghinea and Fabian Kaczmarczyck and Jennifer Pullman and Julien Cretin and Rafael Misoczki and Stefan Kölbl and Luca Invernizzi and Elie Bursztein and Jean-Michel Picod},
-year   = {2022},
-URL    = {https://eprint.iacr.org/2022/1225}
+@InProceedings{Ghinea2023hybrid,
+	author= {Diana Ghinea and Fabian Kaczmarczyck and Jennifer Pullman and Julien Cretin and Rafael Misoczki and Stefan Kölbl and Luca Invernizzi and Elie Bursztein and Jean-Michel Picod},
+	title=	{{Hybrid Post-Quantum Signatures in Hardware Security Keys}},
+	booktitle=	{{4th ACNS Workshop on Secure Cryptographic Implementation, Kyoto, Japan}},
+	month=	{June},
+	year=	{2023},
 }
 ```
 


### PR DESCRIPTION
The bibtex is now pointing to ACNS even though it isn't published yet (as of 2023-08-23, see https://link.springer.com/book/9783031411809).