### PR TITLE
Update nrf52840_dongle.md

### DIFF
--- a/docs/boards/nrf52840_dongle.md
+++ b/docs/boards/nrf52840_dongle.md
@@ -64,7 +64,7 @@ Follow these steps:
 Run our script for compiling/flashing Tock OS on your device:
 
 ```shell
-$ ./deploy.py --board=nrf52840_dongle --programmer=jlink
+$ ./deploy.py --board=nrf52840_dongle_opensk --opensk --programmer=jlink
 ```
 
 #### OpenOCD
@@ -96,7 +96,7 @@ $ ./deploy.py --board=nrf52840_dongle --programmer=jlink
 1.  Run the deploy script with the appropriate options, i.e.:
 
     ```shell
-    ./deploy.py --board=nrf52840_dongle --opensk --programmer=openocd
+    ./deploy.py --board=nrf52840_dongle_opensk --opensk --programmer=openocd
     ```
 
 


### PR DESCRIPTION
Updated terminal commands for flashing nrf52840_dongle to match new ./deploy.py API

