### PR TITLE
Uses CtapResult instead of explicit Result

### DIFF
--- a/libraries/opensk/src/ctap/command.rs
+++ b/libraries/opensk/src/ctap/command.rs
@@ -24,6 +24,7 @@ use super::data_formats::{
 #[cfg(feature = "config_command")]
 use super::data_formats::{ConfigSubCommand, ConfigSubCommandParams, SetMinPinLengthParams};
 use super::status_code::Ctap2StatusCode;
+use crate::ctap::status_code::CtapResult;
 use alloc::string::String;
 use alloc::vec::Vec;
 #[cfg(feature = "fuzz")]
@@ -70,7 +71,7 @@ impl Command {
     const AUTHENTICATOR_VENDOR_CREDENTIAL_MANAGEMENT: u8 = 0x41;
     const _AUTHENTICATOR_VENDOR_LAST: u8 = 0xBF;
 
-    pub fn deserialize(bytes: &[u8]) -> Result<Command, Ctap2StatusCode> {
+    pub fn deserialize(bytes: &[u8]) -> CtapResult<Command> {
         if bytes.is_empty() {
             // The error to return is not specified, missing parameter seems to fit best.
             return Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER);
@@ -157,7 +158,7 @@ pub struct AuthenticatorMakeCredentialParameters {
 impl TryFrom<cbor::Value> for AuthenticatorMakeCredentialParameters {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         destructure_cbor_map! {
             let {
                 0x01 => client_data_hash,
@@ -181,7 +182,7 @@ impl TryFrom<cbor::Value> for AuthenticatorMakeCredentialParameters {
         let pub_key_cred_params = cred_param_vec
             .into_iter()
             .map(PublicKeyCredentialParameter::try_from)
-            .collect::<Result<Vec<PublicKeyCredentialParameter>, Ctap2StatusCode>>()?;
+            .collect::<CtapResult<Vec<PublicKeyCredentialParameter>>>()?;
 
         let exclude_list = match exclude_list {
             Some(entry) => {
@@ -189,7 +190,7 @@ impl TryFrom<cbor::Value> for AuthenticatorMakeCredentialParameters {
                 let exclude_list = exclude_list_vec
                     .into_iter()
                     .map(PublicKeyCredentialDescriptor::try_from)
-                    .collect::<Result<Vec<PublicKeyCredentialDescriptor>, Ctap2StatusCode>>()?;
+                    .collect::<CtapResult<Vec<PublicKeyCredentialDescriptor>>>()?;
                 Some(exclude_list)
             }
             None => None,
@@ -244,7 +245,7 @@ pub struct AuthenticatorGetAssertionParameters {
 impl TryFrom<cbor::Value> for AuthenticatorGetAssertionParameters {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         destructure_cbor_map! {
             let {
                 0x01 => rp_id,
@@ -266,7 +267,7 @@ impl TryFrom<cbor::Value> for AuthenticatorGetAssertionParameters {
                 let allow_list = allow_list_vec
                     .into_iter()
                     .map(PublicKeyCredentialDescriptor::try_from)
-                    .collect::<Result<Vec<PublicKeyCredentialDescriptor>, Ctap2StatusCode>>()?;
+                    .collect::<CtapResult<Vec<PublicKeyCredentialDescriptor>>>()?;
                 Some(allow_list)
             }
             None => None,
@@ -315,7 +316,7 @@ pub struct AuthenticatorClientPinParameters {
 impl TryFrom<cbor::Value> for AuthenticatorClientPinParameters {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         destructure_cbor_map! {
             let {
                 0x01 => pin_uv_auth_protocol,
@@ -370,7 +371,7 @@ pub struct AuthenticatorLargeBlobsParameters {
 impl TryFrom<cbor::Value> for AuthenticatorLargeBlobsParameters {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         destructure_cbor_map! {
             let {
                 0x01 => get,
@@ -432,7 +433,7 @@ pub struct AuthenticatorConfigParameters {
 impl TryFrom<cbor::Value> for AuthenticatorConfigParameters {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         destructure_cbor_map! {
             let {
                 0x01 => sub_command,
@@ -474,7 +475,7 @@ pub struct AuthenticatorCredentialManagementParameters {
 impl TryFrom<cbor::Value> for AuthenticatorCredentialManagementParameters {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         destructure_cbor_map! {
             let {
                 0x01 => sub_command,

--- a/libraries/opensk/src/ctap/config_command.rs
+++ b/libraries/opensk/src/ctap/config_command.rs
@@ -19,14 +19,13 @@ use super::response::ResponseData;
 use super::status_code::Ctap2StatusCode;
 use crate::api::customization::Customization;
 use crate::api::persist::Persist;
+use crate::ctap::status_code::CtapResult;
 use crate::ctap::storage;
 use crate::env::Env;
 use alloc::vec;
 
 /// Processes the subcommand enableEnterpriseAttestation for AuthenticatorConfig.
-fn process_enable_enterprise_attestation(
-    env: &mut impl Env,
-) -> Result<ResponseData, Ctap2StatusCode> {
+fn process_enable_enterprise_attestation(env: &mut impl Env) -> CtapResult<ResponseData> {
     if env.customization().enterprise_attestation_mode().is_some() {
         storage::enable_enterprise_attestation(env)?;
         Ok(ResponseData::AuthenticatorConfig)
@@ -36,7 +35,7 @@ fn process_enable_enterprise_attestation(
 }
 
 /// Processes the subcommand toggleAlwaysUv for AuthenticatorConfig.
-fn process_toggle_always_uv(env: &mut impl Env) -> Result<ResponseData, Ctap2StatusCode> {
+fn process_toggle_always_uv(env: &mut impl Env) -> CtapResult<ResponseData> {
     storage::toggle_always_uv(env)?;
     Ok(ResponseData::AuthenticatorConfig)
 }
@@ -45,7 +44,7 @@ fn process_toggle_always_uv(env: &mut impl Env) -> Result<ResponseData, Ctap2Sta
 fn process_set_min_pin_length(
     env: &mut impl Env,
     params: SetMinPinLengthParams,
-) -> Result<ResponseData, Ctap2StatusCode> {
+) -> CtapResult<ResponseData> {
     let SetMinPinLengthParams {
         new_min_pin_length,
         min_pin_length_rp_ids,
@@ -78,7 +77,7 @@ pub fn process_config<E: Env>(
     env: &mut E,
     client_pin: &mut ClientPin<E>,
     params: AuthenticatorConfigParameters,
-) -> Result<ResponseData, Ctap2StatusCode> {
+) -> CtapResult<ResponseData> {
     let AuthenticatorConfigParameters {
         sub_command,
         sub_command_params,

--- a/libraries/opensk/src/ctap/crypto_wrapper.rs
+++ b/libraries/opensk/src/ctap/crypto_wrapper.rs
@@ -14,7 +14,7 @@
 
 use crate::api::crypto::aes256::Aes256;
 use crate::ctap::secret::Secret;
-use crate::ctap::status_code::Ctap2StatusCode;
+use crate::ctap::status_code::{Ctap2StatusCode, CtapResult};
 use crate::env::{AesKey, Env};
 use alloc::vec::Vec;
 use rand_core::RngCore;
@@ -25,7 +25,7 @@ pub fn aes256_cbc_encrypt<E: Env>(
     aes_key: &AesKey<E>,
     plaintext: &[u8],
     embeds_iv: bool,
-) -> Result<Vec<u8>, Ctap2StatusCode> {
+) -> CtapResult<Vec<u8>> {
     if plaintext.len() % 16 != 0 {
         return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
     }
@@ -48,7 +48,7 @@ pub fn aes256_cbc_decrypt<E: Env>(
     aes_key: &AesKey<E>,
     ciphertext: &[u8],
     embeds_iv: bool,
-) -> Result<Secret<[u8]>, Ctap2StatusCode> {
+) -> CtapResult<Secret<[u8]>> {
     if ciphertext.len() % 16 != 0 || (embeds_iv && ciphertext.is_empty()) {
         return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
     }

--- a/libraries/opensk/src/ctap/data_formats.rs
+++ b/libraries/opensk/src/ctap/data_formats.rs
@@ -15,6 +15,7 @@
 use super::status_code::Ctap2StatusCode;
 use crate::api::crypto::{ecdh, ecdsa, EC_FIELD_SIZE};
 use crate::api::private_key::PrivateKey;
+use crate::ctap::status_code::CtapResult;
 use crate::env::{AesKey, Env};
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -44,7 +45,7 @@ pub struct PublicKeyCredentialRpEntity {
 impl TryFrom<cbor::Value> for PublicKeyCredentialRpEntity {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         destructure_cbor_map! {
             let {
                 "id" => rp_id,
@@ -88,7 +89,7 @@ pub struct PublicKeyCredentialUserEntity {
 impl TryFrom<cbor::Value> for PublicKeyCredentialUserEntity {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         destructure_cbor_map! {
             let {
                 "id" => user_id,
@@ -147,7 +148,7 @@ impl From<PublicKeyCredentialType> for cbor::Value {
 impl TryFrom<cbor::Value> for PublicKeyCredentialType {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         let cred_type_string = extract_text_string(cbor_value)?;
         match &cred_type_string[..] {
             "public-key" => Ok(PublicKeyCredentialType::PublicKey),
@@ -167,7 +168,7 @@ pub struct PublicKeyCredentialParameter {
 impl TryFrom<cbor::Value> for PublicKeyCredentialParameter {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         destructure_cbor_map! {
             let {
                 "alg" => alg,
@@ -216,7 +217,7 @@ impl From<AuthenticatorTransport> for cbor::Value {
 impl TryFrom<cbor::Value> for AuthenticatorTransport {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         let transport_string = extract_text_string(cbor_value)?;
         match &transport_string[..] {
             "usb" => Ok(AuthenticatorTransport::Usb),
@@ -240,7 +241,7 @@ pub struct PublicKeyCredentialDescriptor {
 impl TryFrom<cbor::Value> for PublicKeyCredentialDescriptor {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         destructure_cbor_map! {
             let {
                 "id" => key_id,
@@ -257,7 +258,7 @@ impl TryFrom<cbor::Value> for PublicKeyCredentialDescriptor {
                 let transports = transport_vec
                     .into_iter()
                     .map(AuthenticatorTransport::try_from)
-                    .collect::<Result<Vec<AuthenticatorTransport>, Ctap2StatusCode>>()?;
+                    .collect::<CtapResult<Vec<AuthenticatorTransport>>>()?;
                 Some(transports)
             }
             None => None,
@@ -294,7 +295,7 @@ pub struct MakeCredentialExtensions {
 impl TryFrom<cbor::Value> for MakeCredentialExtensions {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         destructure_cbor_map! {
             let {
                 "credBlob" => cred_blob,
@@ -338,7 +339,7 @@ pub struct GetAssertionExtensions {
 impl TryFrom<cbor::Value> for GetAssertionExtensions {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         destructure_cbor_map! {
             let {
                 "credBlob" => cred_blob,
@@ -377,7 +378,7 @@ pub struct GetAssertionHmacSecretInput {
 impl TryFrom<cbor::Value> for GetAssertionHmacSecretInput {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         destructure_cbor_map! {
             let {
                 1 => key_agreement,
@@ -412,7 +413,7 @@ pub struct MakeCredentialOptions {
 impl TryFrom<cbor::Value> for MakeCredentialOptions {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         destructure_cbor_map! {
             let {
                 "rk" => rk,
@@ -458,7 +459,7 @@ impl Default for GetAssertionOptions {
 impl TryFrom<cbor::Value> for GetAssertionOptions {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         destructure_cbor_map! {
             let {
                 "rk" => rk,
@@ -536,7 +537,7 @@ impl From<i64> for SignatureAlgorithm {
 impl TryFrom<cbor::Value> for SignatureAlgorithm {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         extract_integer(cbor_value).map(SignatureAlgorithm::from)
     }
 }
@@ -567,7 +568,7 @@ impl From<CredentialProtectionPolicy> for cbor::Value {
 impl TryFrom<cbor::Value> for CredentialProtectionPolicy {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         match extract_integer(cbor_value)? {
             0x01 => Ok(CredentialProtectionPolicy::UserVerificationOptional),
             0x02 => Ok(CredentialProtectionPolicy::UserVerificationOptionalWithCredentialIdList),
@@ -637,7 +638,7 @@ impl PublicKeyCredentialSource {
         self,
         rng: &mut E::Rng,
         wrap_key: &AesKey<E>,
-    ) -> Result<cbor::Value, Ctap2StatusCode> {
+    ) -> CtapResult<cbor::Value> {
         Ok(cbor_map_options! {
             PublicKeyCredentialSourceField::CredentialId => Some(self.credential_id),
             PublicKeyCredentialSourceField::RpId => Some(self.rp_id),
@@ -653,10 +654,7 @@ impl PublicKeyCredentialSource {
         })
     }
 
-    pub fn from_cbor<E: Env>(
-        wrap_key: &AesKey<E>,
-        cbor_value: cbor::Value,
-    ) -> Result<Self, Ctap2StatusCode> {
+    pub fn from_cbor<E: Env>(wrap_key: &AesKey<E>, cbor_value: cbor::Value) -> CtapResult<Self> {
         destructure_cbor_map! {
             let {
                 PublicKeyCredentialSourceField::CredentialId => credential_id,
@@ -816,7 +814,7 @@ impl CoseKey {
 impl TryFrom<cbor::Value> for CoseKey {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         destructure_cbor_map! {
             let {
                 // This is sorted correctly, negative encoding is bigger.
@@ -902,7 +900,7 @@ pub enum PinUvAuthProtocol {
 impl TryFrom<cbor::Value> for PinUvAuthProtocol {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         match extract_unsigned(cbor_value)? {
             1 => Ok(PinUvAuthProtocol::V1),
             2 => Ok(PinUvAuthProtocol::V2),
@@ -934,7 +932,7 @@ impl From<ClientPinSubCommand> for cbor::Value {
 impl TryFrom<cbor::Value> for ClientPinSubCommand {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         let subcommand_int = extract_unsigned(cbor_value)?;
         match subcommand_int {
             0x01 => Ok(ClientPinSubCommand::GetPinRetries),
@@ -968,7 +966,7 @@ impl From<ConfigSubCommand> for cbor::Value {
 impl TryFrom<cbor::Value> for ConfigSubCommand {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         let subcommand_int = extract_unsigned(cbor_value)?;
         match subcommand_int {
             0x01 => Ok(ConfigSubCommand::EnableEnterpriseAttestation),
@@ -1005,7 +1003,7 @@ pub struct SetMinPinLengthParams {
 impl TryFrom<cbor::Value> for SetMinPinLengthParams {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         destructure_cbor_map! {
             let {
                 0x01 => new_min_pin_length,
@@ -1025,7 +1023,7 @@ impl TryFrom<cbor::Value> for SetMinPinLengthParams {
                 extract_array(entry)?
                     .into_iter()
                     .map(extract_text_string)
-                    .collect::<Result<Vec<String>, Ctap2StatusCode>>()?,
+                    .collect::<CtapResult<Vec<String>>>()?,
             ),
             None => None,
         };
@@ -1064,7 +1062,7 @@ pub enum EnterpriseAttestationMode {
 impl TryFrom<u64> for EnterpriseAttestationMode {
     type Error = Ctap2StatusCode;
 
-    fn try_from(value: u64) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(value: u64) -> CtapResult<Self> {
         match value {
             1 => Ok(EnterpriseAttestationMode::VendorFacilitated),
             2 => Ok(EnterpriseAttestationMode::PlatformManaged),
@@ -1094,7 +1092,7 @@ impl From<CredentialManagementSubCommand> for cbor::Value {
 impl TryFrom<cbor::Value> for CredentialManagementSubCommand {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         let subcommand_int = extract_unsigned(cbor_value)?;
         match subcommand_int {
             0x01 => Ok(CredentialManagementSubCommand::GetCredsMetadata),
@@ -1119,7 +1117,7 @@ pub struct CredentialManagementSubCommandParameters {
 impl TryFrom<cbor::Value> for CredentialManagementSubCommandParameters {
     type Error = Ctap2StatusCode;
 
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Ctap2StatusCode> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         destructure_cbor_map! {
             let {
                 0x01 => rp_id_hash,
@@ -1153,27 +1151,27 @@ impl From<CredentialManagementSubCommandParameters> for cbor::Value {
     }
 }
 
-fn ok_or_cbor_type<T>(value_option: Option<T>) -> Result<T, Ctap2StatusCode> {
+fn ok_or_cbor_type<T>(value_option: Option<T>) -> CtapResult<T> {
     value_option.ok_or(Ctap2StatusCode::CTAP2_ERR_CBOR_UNEXPECTED_TYPE)
 }
 
-pub fn extract_unsigned(cbor_value: cbor::Value) -> Result<u64, Ctap2StatusCode> {
+pub fn extract_unsigned(cbor_value: cbor::Value) -> CtapResult<u64> {
     ok_or_cbor_type(cbor_value.extract_unsigned())
 }
 
-pub fn extract_integer(cbor_value: cbor::Value) -> Result<i64, Ctap2StatusCode> {
+pub fn extract_integer(cbor_value: cbor::Value) -> CtapResult<i64> {
     ok_or_cbor_type(cbor_value.extract_integer())
 }
 
-pub fn extract_byte_string(cbor_value: cbor::Value) -> Result<Vec<u8>, Ctap2StatusCode> {
+pub fn extract_byte_string(cbor_value: cbor::Value) -> CtapResult<Vec<u8>> {
     ok_or_cbor_type(cbor_value.extract_byte_string())
 }
 
-pub fn extract_text_string(cbor_value: cbor::Value) -> Result<String, Ctap2StatusCode> {
+pub fn extract_text_string(cbor_value: cbor::Value) -> CtapResult<String> {
     ok_or_cbor_type(cbor_value.extract_text_string())
 }
 
-pub fn extract_array(cbor_value: cbor::Value) -> Result<Vec<cbor::Value>, Ctap2StatusCode> {
+pub fn extract_array(cbor_value: cbor::Value) -> CtapResult<Vec<cbor::Value>> {
     ok_or_cbor_type(cbor_value.extract_array())
 }
 
@@ -1183,11 +1181,11 @@ pub fn extract_map(
     ok_or_cbor_type(cbor_value.extract_map())
 }
 
-pub fn extract_bool(cbor_value: cbor::Value) -> Result<bool, Ctap2StatusCode> {
+pub fn extract_bool(cbor_value: cbor::Value) -> CtapResult<bool> {
     ok_or_cbor_type(cbor_value.extract_bool())
 }
 
-pub fn ok_or_missing<T>(value_option: Option<T>) -> Result<T, Ctap2StatusCode> {
+pub fn ok_or_missing<T>(value_option: Option<T>) -> CtapResult<T> {
     value_option.ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)
 }
 

--- a/libraries/opensk/src/ctap/token_state.rs
+++ b/libraries/opensk/src/ctap/token_state.rs
@@ -15,7 +15,7 @@
 use crate::api::clock::Clock;
 use crate::api::crypto::sha256::Sha256;
 use crate::ctap::client_pin::PinPermission;
-use crate::ctap::status_code::Ctap2StatusCode;
+use crate::ctap::status_code::{Ctap2StatusCode, CtapResult};
 use crate::env::{Env, Sha};
 use alloc::string::String;
 
@@ -59,7 +59,7 @@ impl<E: Env> PinUvAuthTokenState<E> {
     }
 
     /// Checks if the permission is granted.
-    pub fn has_permission(&self, permission: PinPermission) -> Result<(), Ctap2StatusCode> {
+    pub fn has_permission(&self, permission: PinPermission) -> CtapResult<()> {
         if permission as u8 & self.permissions_set != 0 {
             Ok(())
         } else {
@@ -68,7 +68,7 @@ impl<E: Env> PinUvAuthTokenState<E> {
     }
 
     /// Checks if there is no associated permissions RPID.
-    pub fn has_no_permissions_rp_id(&self) -> Result<(), Ctap2StatusCode> {
+    pub fn has_no_permissions_rp_id(&self) -> CtapResult<()> {
         if self.permissions_rp_id.is_some() {
             return Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID);
         }
@@ -76,7 +76,7 @@ impl<E: Env> PinUvAuthTokenState<E> {
     }
 
     /// Checks if the permissions RPID is associated.
-    pub fn has_permissions_rp_id(&self, rp_id: &str) -> Result<(), Ctap2StatusCode> {
+    pub fn has_permissions_rp_id(&self, rp_id: &str) -> CtapResult<()> {
         match &self.permissions_rp_id {
             Some(p) if rp_id == p => Ok(()),
             _ => Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID),
@@ -84,7 +84,7 @@ impl<E: Env> PinUvAuthTokenState<E> {
     }
 
     /// Checks if the permissions RPID's association matches the hash.
-    pub fn has_permissions_rp_id_hash(&self, rp_id_hash: &[u8]) -> Result<(), Ctap2StatusCode> {
+    pub fn has_permissions_rp_id_hash(&self, rp_id_hash: &[u8]) -> CtapResult<()> {
         match &self.permissions_rp_id {
             Some(p) if rp_id_hash == Sha::<E>::digest(p.as_bytes()) => Ok(()),
             _ => Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID),

--- a/libraries/opensk/src/test_helpers/mod.rs
+++ b/libraries/opensk/src/test_helpers/mod.rs
@@ -16,7 +16,7 @@ use crate::api::persist::{Attestation, AttestationId, Persist};
 use crate::ctap::command::{AuthenticatorConfigParameters, Command};
 use crate::ctap::data_formats::ConfigSubCommand;
 use crate::ctap::secret::Secret;
-use crate::ctap::status_code::Ctap2StatusCode;
+use crate::ctap::status_code::CtapResult;
 use crate::ctap::{Channel, CtapState};
 use crate::env::Env;
 
@@ -27,7 +27,7 @@ const DUMMY_CHANNEL: Channel = Channel::MainHid([0x12, 0x34, 0x56, 0x78]);
 pub fn enable_enterprise_attestation<E: Env>(
     state: &mut CtapState<E>,
     env: &mut E,
-) -> Result<Attestation, Ctap2StatusCode> {
+) -> CtapResult<Attestation> {
     let attestation = Attestation {
         private_key: Secret::from_exposed_secret([0x41; 32]),
         certificate: vec![0xdd; 20],


### PR DESCRIPTION
Generated with

```
find . -type f -name "*.rs" -exec sed -i 's/Result<\([^,]*\), Ctap2StatusCode>/CtapResult<\1>/g' {} \;
cd libraries/opensk
find . -type f -name "*.rs" -exec grep -q 'CtapResult' {} \; -exec sed -i '15 i\
use crate::ctap::status_code::CtapResult;
' {} +
```

Then we fix the last few compiler errors and run `cargo fmt`.

Next step is to move away from custom error types in the API to only use CtapResult everywhere.
