### PR TITLE
Small fixes for consistency

### DIFF
--- a/libraries/opensk/fuzz/fuzz_helper/src/lib.rs
+++ b/libraries/opensk/fuzz/fuzz_helper/src/lib.rs
@@ -31,7 +31,7 @@ use opensk::{test_helpers, Ctap, Transport};
 
 const CHANNEL_BROADCAST: ChannelID = [0xFF, 0xFF, 0xFF, 0xFF];
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum InputType {
     CborMakeCredentialParameter,
     CborGetAssertionParameter,

--- a/libraries/opensk/src/ctap/status_code.rs
+++ b/libraries/opensk/src/ctap/status_code.rs
@@ -21,7 +21,7 @@ pub type CtapResult<T> = Result<T, Ctap2StatusCode>;
 // For now, only the CTAP2 codes are here, the CTAP1 are not included.
 #[allow(non_camel_case_types)]
 #[allow(dead_code)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Ctap2StatusCode {
     CTAP2_OK = 0x00,
     CTAP1_ERR_INVALID_COMMAND = 0x01,

--- a/libraries/opensk/src/env/test/mod.rs
+++ b/libraries/opensk/src/env/test/mod.rs
@@ -43,7 +43,7 @@ pub type TestRng = StdRng;
 
 impl Rng for TestRng {}
 
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct TestTimer {
     end_ms: usize,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,6 @@ extern crate byteorder;
 extern crate core;
 extern crate lang_items;
 
-use core::convert::TryFrom;
 #[cfg(feature = "debug_ctap")]
 use core::fmt::Write;
 #[cfg(feature = "with_ctap1")]
@@ -151,7 +150,7 @@ fn main() {
         #[cfg(feature = "with_ctap1")]
         let num_buttons = Buttons::<SyscallImplementation>::count().ok().unwrap();
 
-        // Variable for use in both the send_and_maybe_recv and recv cases.
+        // Variable for use in both the send and recv cases.
         let mut usb_endpoint: Option<UsbEndpoint> = None;
         let mut pkt_request = [0; 64];
 
@@ -189,7 +188,7 @@ fn main() {
                         ctap.env().clock().timestamp_us(),
                         &mut writer,
                     );
-                    UsbEndpoint::try_from(endpoint as usize).ok()
+                    Some(endpoint)
                 }
                 Err(_) => panic!("Error on USB recv"),
             };


### PR DESCRIPTION
- Adds `Eq` to types that already derive `PartialEq`.
- Fixes a comment to match the latest USB changes.
- Removes a back-and-forth conversion.
