### PR TITLE
Ignores pylint warning to fix CI

### DIFF
--- a/.github/workflows/reproducible.yml
+++ b/.github/workflows/reproducible.yml
@@ -30,7 +30,7 @@ jobs:
         run: ./maintainers/reproduce_hashes.sh
 
       - name: Upload reproduced binaries
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: reproduced-${{ matrix.os }}
           path: reproducible/reproduced.tar

--- a/deploy.py
+++ b/deploy.py
@@ -205,6 +205,7 @@ def assert_python_library(module: str):
 class RemoveConstAction(argparse.Action):
 
   # pylint: disable=redefined-builtin
+  # pylint: disable=too-many-positional-arguments
   def __init__(self,
                option_strings,
                dest,


### PR DESCRIPTION
To keep this branch mostly untouched, I simply ignore the warning.