### PR TITLE
CI fix for breaking Python lint

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -215,6 +215,7 @@ class RemoveConstAction(argparse.Action):
   def __init__(self,
                option_strings,
                dest,
+               *,
                const,
                default=None,
                required=False,


### PR DESCRIPTION
Fixes pylint by forcing keyword arguments.