### PR TITLE
Fixes incorrect error code for vendor U2F

### DIFF
--- a/libraries/opensk/src/ctap/ctap1.rs
+++ b/libraries/opensk/src/ctap/ctap1.rs
@@ -233,8 +233,7 @@ impl Ctap1Command {
             // U2F raw message format specification (version 20170411) section 6.3
             U2fCommand::Version => Ok(Vec::<u8>::from(super::U2F_VERSION_STRING)),
 
-            // TODO: should we return an error instead such as SW_INS_NOT_SUPPORTED?
-            U2fCommand::VendorSpecific { .. } => Err(Ctap1StatusCode::SW_SUCCESS),
+            U2fCommand::VendorSpecific { .. } => Err(Ctap1StatusCode::SW_INS_INVALID),
         }
     }
 


### PR DESCRIPTION
The TODO was correct, and we never added any vendor commands.

We could add support for U2F vendor commands into Env like we did for CTAP2. This is a quick fix for now.