### PR TITLE
Warns users when deploying with --debug

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -771,6 +771,10 @@ class OpenSKInstaller:
     if self.args.clear_storage:
       self.clear_storage()
 
+    if "debug_ctap" in self.args.features:
+      error("The debug feature does not work correctly on this branch. "
+            "For development and debugging, please use the develop branch.")
+
     # Flashing
     if self.args.programmer in ("jlink", "openocd"):
       # We rely on Tockloader to do the job


### PR DESCRIPTION
Problems with the `debug` feature were reported in #714 . Since all new development is happening in the `develop` branch, I added an error that redirects people to the other branch.