### PR TITLE
Add Support for User Verification (UV) and BioEnrollment

### DIFF
--- a/libraries/opensk/src/api/customization.rs
+++ b/libraries/opensk/src/api/customization.rs
@@ -252,6 +252,31 @@ pub trait Customization {
     /// With P=20 and K=150, we have I=2M which is enough for 500 increments per day
     /// for 10 years.
     fn max_supported_resident_keys(&self) -> usize;
+
+    /// This specifies the preferred number of invocations of the
+    /// `getPinUvAuthTokenUsingUvWithPermissions` subCommand the platform may
+    /// attempt before falling back to the
+    /// `getPinUvAuthTokenUsingPinWithPermissions` subCommand or displaying an
+    /// error.
+    ///
+    /// MUST be greater than zero. If the value is 1 then all uvRetries are
+    /// internal and the platform MUST only invoke the
+    /// getPinUvAuthTokenUsingUvWithPermissions subCommand a single time. If the
+    /// value is > 1 the authenticator MUST only decrement uvRetries by 1 for
+    /// each iteration.
+    fn preferred_platform_uv_attempts(&self) -> usize;
+
+    /// Sets the number of consecutive failed User Verification attempts before
+    /// blocking built-in UV.
+    ///
+    /// # Invariant
+    ///
+    /// - CTAP2.1: Maximum PIN retries must be 25 at most.
+    fn max_uv_retries(&self) -> u8;
+
+    /// The maximum number of times the authenticator will retry internally when
+    /// internalRetry is true as part of the performBuiltInUv() algorithm.
+    fn max_uv_attempts_for_internal_retries(&self) -> u8;
 }
 
 #[derive(Clone)]
@@ -273,15 +298,18 @@ pub struct CustomizationImpl {
     pub max_large_blob_array_size: usize,
     pub max_rp_ids_length: usize,
     pub max_supported_resident_keys: usize,
+    pub preferred_platform_uv_attempts: usize,
+    pub max_uv_retries: u8,
+    pub max_uv_attempts_for_internal_retries: u8,
 }
 
 pub const DEFAULT_CUSTOMIZATION: CustomizationImpl = CustomizationImpl {
     aaguid: &[0; AAGUID_LENGTH],
     allows_pin_protocol_v1: true,
-    default_cred_protect: None,
+    default_cred_protect: Some(CredentialProtectionPolicy::UserVerificationOptional),
     default_min_pin_length: 4,
     default_min_pin_length_rp_ids: &[],
-    enforce_always_uv: false,
+    enforce_always_uv: true,
     enterprise_attestation_mode: None,
     enterprise_rp_id_list: &[],
     max_msg_size: 7609,
@@ -293,6 +321,9 @@ pub const DEFAULT_CUSTOMIZATION: CustomizationImpl = CustomizationImpl {
     max_large_blob_array_size: 2048,
     max_rp_ids_length: 8,
     max_supported_resident_keys: 150,
+    preferred_platform_uv_attempts: 5,
+    max_uv_retries: 8,
+    max_uv_attempts_for_internal_retries: 8,
 };
 
 impl Customization for CustomizationImpl {
@@ -373,6 +404,18 @@ impl Customization for CustomizationImpl {
 
     fn max_supported_resident_keys(&self) -> usize {
         self.max_supported_resident_keys
+    }
+
+    fn preferred_platform_uv_attempts(&self) -> usize {
+        self.preferred_platform_uv_attempts
+    }
+
+    fn max_uv_retries(&self) -> u8 {
+        self.max_uv_retries
+    }
+
+    fn max_uv_attempts_for_internal_retries(&self) -> u8 {
+        self.max_uv_attempts_for_internal_retries
     }
 }
 

--- a/libraries/opensk/src/api/fingerprint.rs
+++ b/libraries/opensk/src/api/fingerprint.rs
@@ -1,0 +1,81 @@
+#[derive(Debug)]
+pub enum FingerprintCaptureError {
+    NoTouch,
+    ImageBad,
+    ImagePartial,
+    TooFast,
+    Other,
+}
+
+#[derive(Debug)]
+pub enum FingerprintCheckError {
+    NoMatch,
+    Timeout,
+    Other,
+}
+
+pub trait Fingerprint {
+    /// Get the maximum number of fingerprint enrollments the sensor can
+    /// support.
+    fn get_enrollment_count_maximum(&self) -> u8;
+
+    /// Get the number of fingerprints currently enrolled.
+    fn get_enrollment_count(&self) -> u8;
+
+    /// Start an enrollment session for the fingerprint at the given index.
+    ///
+    /// `index` should be from 0 to `get_enrollment_count_maximum()-1`.
+    fn prepare_enrollment(&self, index: u8);
+
+    /// Capture a fingerprint image.
+    ///
+    /// `prepare_enrollment()` must be called first.
+    ///
+    /// Waits for a fingerprint image or returns if `timeout_ms` happens without
+    /// a touch.
+    ///
+    /// ## Return
+    ///
+    /// `Ok(())` on success and `Err(())` on any failure.
+    fn capture_sample(&self, timeout_ms: usize) -> Result<(), FingerprintCaptureError>;
+
+    /// Store a fingerprint enrollment.
+    ///
+    /// ## Return
+    ///
+    /// `Ok(())` on success and `Err(())` on any failure.
+    fn commit_enrollment(&self) -> Result<(), ()>;
+
+    /// Cancel a fingerprint enrollment.
+    fn cancel_enrollment(&self);
+
+    /// Check all enrollments to see if they are enrolled.
+    fn get_enrollments(&self, fingerlist: &mut [u8; 5]);
+
+    /// Called before [`check_fingerprint()`].
+    ///
+    /// Useful for starting any operation that needs to happen before
+    /// potentially repeated fingerprint checks, such as blinking LEDs.
+    fn check_fingerprint_init(&mut self);
+
+    /// Require the user to touch the sensor and verify the fingerprint is
+    /// valid.
+    ///
+    /// Waits for a fingerprint image or returns if `timeout_ms` happens without
+    /// a touch.
+    ///
+    /// Returns:
+    /// - `Ok(index)`: If fingerprint is valid, returns the index of the matched
+    ///   fingerprint.
+    /// - `Err(e)`: Error if fingerprint is not valid.
+    fn check_fingerprint(&self, timeout_ms: usize) -> Result<u8, FingerprintCheckError>;
+
+    /// Called after checking fingerprints has finished.
+    fn check_fingerprint_complete(&mut self);
+
+    /// Delete the fingerprint enrolled at the given index.
+    fn delete_enrollment(&self, index: u8);
+
+    fn setloglevel(&self, level: u8);
+
+}

--- a/libraries/opensk/src/api/mod.rs
+++ b/libraries/opensk/src/api/mod.rs
@@ -21,6 +21,7 @@ pub mod clock;
 pub mod connection;
 pub mod crypto;
 pub mod customization;
+pub mod fingerprint;
 pub mod firmware_protection;
 pub mod key_store;
 pub mod persist;

--- a/libraries/opensk/src/api/persist.rs
+++ b/libraries/opensk/src/api/persist.rs
@@ -20,6 +20,7 @@ use crate::ctap::status_code::{Ctap2StatusCode, CtapResult};
 use crate::ctap::PIN_AUTH_LENGTH;
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
+use alloc::string::String;
 use alloc::vec::Vec;
 use core::cmp;
 use core::convert::TryFrom;
@@ -204,6 +205,27 @@ pub trait Persist {
         self.remove(keys::PIN_RETRIES)
     }
 
+    /// Returns the number of failed UV attempts.
+    fn uv_fails(&self) -> CtapResult<u8> {
+        match self.find(keys::UV_RETRIES)? {
+            None => Ok(0),
+            Some(value) if value.len() == 1 => Ok(value[0]),
+            _ => Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR),
+        }
+    }
+
+    /// Decrements the number of remaining UV retries.
+    fn incr_uv_fails(&mut self) -> CtapResult<()> {
+        let old_value = self.uv_fails()?;
+        let new_value = old_value.saturating_add(1);
+        self.insert(keys::UV_RETRIES, &[new_value])
+    }
+
+    /// Resets the number of remaining UV retries.
+    fn reset_uv_retries(&mut self) -> CtapResult<()> {
+        self.remove(keys::UV_RETRIES)
+    }
+
     /// Returns the minimum PIN length, if stored.
     fn min_pin_length(&self) -> CtapResult<Option<u8>> {
         match self.find(keys::MIN_PIN_LENGTH)? {
@@ -383,6 +405,23 @@ pub trait Persist {
             Ok(self.remove(keys::ALWAYS_UV)?)
         } else {
             Ok(self.insert(keys::ALWAYS_UV, &[])?)
+        }
+    }
+
+    /// Store a Bio Enrollment friendly name for a given template_id.
+    fn store_friendly_name(&mut self, template_id: u8, friendly_name: &str) -> CtapResult<()> {
+        let key = keys::FRIENDLY_NAMES.start + template_id as usize;
+        self.insert(key, friendly_name.as_bytes())?;
+        Ok(())
+    }
+
+    /// Retrieve the Bio Enrollment friendly name for a given template_id.
+    fn get_friendly_name(&mut self, template_id: u8) -> CtapResult<String> {
+        let key = keys::FRIENDLY_NAMES.start + template_id as usize;
+
+        match self.find(key)? {
+            None => Err(Ctap2StatusCode::CTAP1_ERR_OTHER),
+            Some(value) => Ok(String::from_utf8(value).unwrap_or(String::from(""))),
         }
     }
 

--- a/libraries/opensk/src/api/persist/keys.rs
+++ b/libraries/opensk/src/api/persist/keys.rs
@@ -142,6 +142,12 @@ make_partition! {
     ///
     /// If the entry is absent, the counter is 0.
     GLOBAL_SIGNATURE_COUNTER = 2047;
+
+    /// Stored counter  UV retries.
+    UV_RETRIES = 2048;
+
+    /// Stored friendly names for enrolled fingerprints.
+    FRIENDLY_NAMES = 2100..2105;
 }
 
 #[cfg(test)]

--- a/libraries/opensk/src/ctap/client_pin.rs
+++ b/libraries/opensk/src/ctap/client_pin.rs
@@ -21,11 +21,13 @@ use super::response::{AuthenticatorClientPinResponse, ResponseData};
 use super::secret::Secret;
 use super::status_code::Ctap2StatusCode;
 use super::token_state::PinUvAuthTokenState;
+use super::Channel;
 #[cfg(test)]
 use crate::api::crypto::ecdh::SecretKey as _;
 use crate::api::crypto::hmac256::Hmac256;
 use crate::api::crypto::sha256::Sha256;
 use crate::api::customization::Customization;
+use crate::api::fingerprint::{Fingerprint, FingerprintCheckError};
 use crate::api::key_store::KeyStore;
 use crate::api::persist::Persist;
 use crate::ctap::status_code::CtapResult;
@@ -224,6 +226,7 @@ impl<E: Env> ClientPin<E> {
             pin_uv_auth_token: None,
             retries: Some(storage::pin_retries(env)? as u64),
             power_cycle_state: Some(self.consecutive_pin_mismatches >= 3),
+            uv_retries: None,
         })
     }
 
@@ -240,6 +243,7 @@ impl<E: Env> ClientPin<E> {
             pin_uv_auth_token: None,
             retries: None,
             power_cycle_state: None,
+            uv_retries: None,
         })
     }
 
@@ -342,27 +346,218 @@ impl<E: Env> ClientPin<E> {
                 .get_pin_uv_auth_token(),
         )?;
 
+        // Because using a PIN succeeded, we can clear the UV retry counter.
+        let _ = storage::reset_uv_retries(env);
+
         Ok(AuthenticatorClientPinResponse {
             key_agreement: None,
             pin_uv_auth_token: Some(pin_uv_auth_token),
             retries: None,
             power_cycle_state: None,
+            uv_retries: None,
         })
     }
 
     fn process_get_pin_uv_auth_token_using_uv_with_permissions(
-        &self,
-        // If you want to support local user verification, implement this function.
-        // Lacking a fingerprint reader, this subcommand is currently unsupported.
-        _client_pin_params: AuthenticatorClientPinParameters,
+        &mut self,
+        env: &mut E,
+        client_pin_params: AuthenticatorClientPinParameters,
+        channel: Channel,
     ) -> CtapResult<AuthenticatorClientPinResponse> {
-        // User verification is only supported through PIN currently.
-        Err(Ctap2StatusCode::CTAP2_ERR_INVALID_SUBCOMMAND)
+        let AuthenticatorClientPinParameters {
+            pin_uv_auth_protocol,
+            key_agreement,
+            permissions,
+            permissions_rp_id,
+            ..
+        } = client_pin_params;
+        let key_agreement = ok_or_missing(key_agreement)?;
+
+        // If the authenticator does not receive mandatory parameters for this
+        // command, it returns CTAP2_ERR_MISSING_PARAMETER error.
+        if permissions.is_none() {
+            debug_ctap!(env, "CP: getPinUvAuthUv no  permissions",);
+        }
+        let permissions_bitfield =
+            permissions.ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?;
+
+        // If the authenticator receives a permissions parameter with value 0,
+        // return CTAP1_ERR_INVALID_PARAMETER.
+        if permissions_bitfield == 0 {
+            return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
+        }
+
+        // For each pinUvAuthToken permission present in the permissions
+        // parameter, if the statement corresponding to the permission is
+        // currently true, terminate these steps and return
+        // CTAP2_ERR_UNAUTHORIZED_PERMISSION.
+        // - cm: credMgmt is false or absent.
+        // - be: uvBioEnroll is false or absent.
+        // - lbw: largeBlobs is false or absent.
+        // - acfg: uvAcfg is false or absent.
+        //
+        // We set the credMgmt, uvBioEnroll, and largeBlobs options to true, so
+        // we only need to check for acfg.
+        #[cfg(feature = "config_command")]
+        if permissions_bitfield & PinPermission::AuthenticatorConfiguration as u8 > 0 {
+            return Err(Ctap2StatusCode::CTAP2_ERR_UNAUTHORIZED_PERMISSION);
+        }
+
+        let internal_retry = env.customization().preferred_platform_uv_attempts() == 1;
+        self.perform_built_in_uv(env, channel, internal_retry)?;
+
+        let shared_secret = self.get_shared_secret(pin_uv_auth_protocol, key_agreement)?;
+        if env.persist().has_force_pin_change()? {
+            return Err(Ctap2StatusCode::CTAP2_ERR_PIN_INVALID);
+        }
+
+        // Create a new pinUvAuthToken by calling resetPinUvAuthToken() for all
+        // pinUvAuthProtocols supported by this authenticator.
+        self.pin_protocol_v1.reset_pin_uv_auth_token(env);
+        self.pin_protocol_v2.reset_pin_uv_auth_token(env);
+
+        // If the employed built-in user verification method supplied evidence
+        // of user interaction, then call
+        // beginUsingPinUvAuthToken(userIsPresent: true).
+        self.pin_uv_auth_token_state
+            .begin_using_pin_uv_auth_token(env);
+
+        // Assign the requested permissions to the pinUvAuthToken, ignoring any
+        // undefined permissions.
+        self.pin_uv_auth_token_state
+            .set_permissions(permissions_bitfield);
+
+        // If the rpId parameter is present, use its value as the permissions RP
+        // ID and associate it with the pinUvAuthToken.
+        self.pin_uv_auth_token_state
+            .set_permissions_rp_id(permissions_rp_id);
+
+        let pin_uv_auth_token = shared_secret.encrypt(
+            env,
+            self.get_pin_protocol(pin_uv_auth_protocol)
+                .get_pin_uv_auth_token(),
+        )?;
+
+        Ok(AuthenticatorClientPinResponse {
+            key_agreement: None,
+            pin_uv_auth_token: Some(pin_uv_auth_token),
+            retries: None,
+            power_cycle_state: None,
+            uv_retries: None,
+        })
     }
 
-    fn process_get_uv_retries(&self) -> CtapResult<AuthenticatorClientPinResponse> {
-        // User verification is only supported through PIN currently.
-        Err(Ctap2StatusCode::CTAP2_ERR_INVALID_SUBCOMMAND)
+    pub fn perform_built_in_uv(
+        &self,
+        env: &mut E,
+        channel: Channel,
+        internal_retry: bool,
+    ) -> CtapResult<()> {
+        // Create helper function so we can clear LEDs after trying the
+        // fingerprint potentially multiple times.
+        fn check_fingerprint_loop<E: Env>(
+            env: &mut E,
+            channel: Channel,
+            internal_retry: bool,
+        ) -> Result<(), Ctap2StatusCode> {
+            // How long we give the user to touch the device before returning
+            // `CTAP2_ERR_USER_ACTION_TIMEOUT`.
+            const UV_TIMEOUT_MS: usize = 10000;
+            // How long we wait for the fingerprint sensor on each iteration.
+            const FINGERPRINT_TIMEOUT_MS: usize = 500;
+            // How many iterations we need to get the full UV timeout time.
+            const FINGERPRINT_TIMEOUT_LOOPS: usize = UV_TIMEOUT_MS / FINGERPRINT_TIMEOUT_MS;
+
+            // Keep track of the number of times the fingerprint detection timed
+            // out. If this happens too many times we need to return with
+            // `CTAP2_ERR_USER_ACTION_TIMEOUT`.
+            let mut timeouts = 0;
+
+            let mut attempts_before_returning = if internal_retry {
+                env.customization().max_uv_attempts_for_internal_retries()
+            } else {
+                1
+            };
+
+            while attempts_before_returning > 0 {
+                // If uvRetries <= 0 then return error.
+                storage::uv_retries(env).and_then(|retries| {
+                    if retries == 0 {
+                        Err(Ctap2StatusCode::CTAP2_ERR_UV_BLOCKED)
+                    } else {
+                        Ok(())
+                    }
+                })?;
+
+                // Decrement the uvRetries counter by 1.
+                let _ = storage::decr_uv_retries(env);
+
+                // Decrement attemptsBeforeReturning by 1.
+                attempts_before_returning -= 1;
+
+                // We need to give the user time to touch the device during UV.
+                // Also, on Windows, it seems we need to send KEEPALIVEs to
+                // avoid timeouts, so we need to do the check incrementally.
+                //
+                // The total timeout is specified this way in the spec:
+                //
+                // > This refers to a timeout that occurs when the authenticator
+                // > is waiting for direct action from the user, like a touch.
+                // > (I.e. not a command from the platform.) The duration of
+                // > this timeout is chosen by the authenticator but MUST be at
+                // > least 10 seconds. Thirty seconds is a reasonable value.
+                while timeouts < FINGERPRINT_TIMEOUT_LOOPS {
+                    // Perform built-in user verification.
+                    match env.fingerprint().check_fingerprint(FINGERPRINT_TIMEOUT_MS) {
+                        Ok(_finger_index) => {
+                            // set the uvRetries counter to maxUvRetries
+                            let _ = storage::reset_uv_retries(env);
+
+                            return Ok(());
+                        }
+                        Err(e) => {
+                            // Send a KEEPALIVE to avoid timeouts on Windows.
+                            crate::ctap::send_keepalive_packet(env, channel)?;
+
+                            match e {
+                                FingerprintCheckError::NoMatch | FingerprintCheckError::Other => {
+                                    // We got a fingerprint touch, but it was
+                                    // invalid. We break out of the timeouts
+                                    // loop.
+                                    break;
+                                }
+                                FingerprintCheckError::Timeout => {
+                                    timeouts += 1;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if timeouts >= FINGERPRINT_TIMEOUT_LOOPS {
+                    return Err(Ctap2StatusCode::CTAP2_ERR_USER_ACTION_TIMEOUT);
+                }
+            }
+
+            Err(Ctap2StatusCode::CTAP2_ERR_UV_INVALID)
+        }
+
+        env.fingerprint().check_fingerprint_init();
+        let res = check_fingerprint_loop(env, channel, internal_retry);
+        env.fingerprint().check_fingerprint_complete();
+        res
+    }
+
+    fn process_get_uv_retries(&self, env: &mut E) -> CtapResult<AuthenticatorClientPinResponse> {
+        debug_ctap!(env, "CP:  process_get_uv_retries");
+
+        Ok(AuthenticatorClientPinResponse {
+            key_agreement: None,
+            pin_uv_auth_token: None,
+            retries: None,
+            power_cycle_state: None,
+            uv_retries: Some(storage::uv_retries(env)? as u64),
+        })
     }
 
     fn process_get_pin_uv_auth_token_using_pin_with_permissions(
@@ -397,6 +592,7 @@ impl<E: Env> ClientPin<E> {
         &mut self,
         env: &mut E,
         client_pin_params: AuthenticatorClientPinParameters,
+        channel: Channel,
     ) -> CtapResult<ResponseData> {
         if !env.customization().allows_pin_protocol_v1()
             && client_pin_params.pin_uv_auth_protocol == PinUvAuthProtocol::V1
@@ -420,9 +616,13 @@ impl<E: Env> ClientPin<E> {
                 Some(self.process_get_pin_token(env, client_pin_params)?)
             }
             ClientPinSubCommand::GetPinUvAuthTokenUsingUvWithPermissions => Some(
-                self.process_get_pin_uv_auth_token_using_uv_with_permissions(client_pin_params)?,
+                self.process_get_pin_uv_auth_token_using_uv_with_permissions(
+                    env,
+                    client_pin_params,
+                    channel,
+                )?,
             ),
-            ClientPinSubCommand::GetUvRetries => Some(self.process_get_uv_retries()?),
+            ClientPinSubCommand::GetUvRetries => Some(self.process_get_uv_retries(env)?),
             ClientPinSubCommand::GetPinUvAuthTokenUsingPinWithPermissions => Some(
                 self.process_get_pin_uv_auth_token_using_pin_with_permissions(
                     env,

--- a/libraries/opensk/src/ctap/command.rs
+++ b/libraries/opensk/src/ctap/command.rs
@@ -14,8 +14,8 @@
 
 use super::cbor_read;
 use super::data_formats::{
-    extract_array, extract_byte_string, extract_map, extract_text_string, extract_unsigned,
-    ok_or_missing, ClientPinSubCommand, CoseKey, CredentialManagementSubCommand,
+    extract_array, extract_bool, extract_byte_string, extract_map, extract_text_string,
+    extract_unsigned, ok_or_missing, ClientPinSubCommand, CoseKey, CredentialManagementSubCommand,
     CredentialManagementSubCommandParameters, GetAssertionExtensions, GetAssertionOptions,
     MakeCredentialExtensions, MakeCredentialOptions, PinUvAuthProtocol,
     PublicKeyCredentialDescriptor, PublicKeyCredentialParameter, PublicKeyCredentialRpEntity,
@@ -43,6 +43,7 @@ pub enum Command {
     AuthenticatorClientPin(AuthenticatorClientPinParameters),
     AuthenticatorReset,
     AuthenticatorGetNextAssertion,
+    AuthenticatorBioEnrollment(AuthenticatorBioEnrollmentParameters),
     AuthenticatorCredentialManagement(AuthenticatorCredentialManagementParameters),
     AuthenticatorSelection,
     AuthenticatorLargeBlobs(AuthenticatorLargeBlobsParameters),
@@ -58,7 +59,7 @@ impl Command {
     const AUTHENTICATOR_RESET: u8 = 0x07;
     const AUTHENTICATOR_GET_NEXT_ASSERTION: u8 = 0x08;
     // Implement Bio Enrollment when your hardware supports biometrics.
-    const _AUTHENTICATOR_BIO_ENROLLMENT: u8 = 0x09;
+    const AUTHENTICATOR_BIO_ENROLLMENT: u8 = 0x09;
     const AUTHENTICATOR_CREDENTIAL_MANAGEMENT: u8 = 0x0A;
     const AUTHENTICATOR_SELECTION: u8 = 0x0B;
     const AUTHENTICATOR_LARGE_BLOBS: u8 = 0x0C;
@@ -109,6 +110,12 @@ impl Command {
                 // Parameters are ignored.
                 Ok(Command::AuthenticatorGetNextAssertion)
             }
+            Command::AUTHENTICATOR_BIO_ENROLLMENT => {
+                let decoded_cbor = cbor_read(&bytes[1..])?;
+                Ok(Command::AuthenticatorBioEnrollment(
+                    AuthenticatorBioEnrollmentParameters::try_from(decoded_cbor)?,
+                ))
+            }
             Command::AUTHENTICATOR_CREDENTIAL_MANAGEMENT
             | Command::AUTHENTICATOR_VENDOR_CREDENTIAL_MANAGEMENT => {
                 let decoded_cbor = cbor_read(&bytes[1..])?;
@@ -135,6 +142,49 @@ impl Command {
             }
             _ => Err(Ctap2StatusCode::CTAP1_ERR_INVALID_COMMAND),
         }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct AuthenticatorBioEnrollmentParameters {
+    pub modality: Option<u64>,
+    pub sub_command: Option<u64>,
+    pub sub_command_params: Option<cbor::Value>,
+    pub pin_protocol: Option<u64>,
+    pub pin_auth: Option<Vec<u8>>,
+    pub get_modality: Option<bool>,
+}
+
+impl TryFrom<cbor::Value> for AuthenticatorBioEnrollmentParameters {
+    type Error = Ctap2StatusCode;
+
+    fn try_from(cbor_value: cbor::Value) -> Result<Self, Self::Error> {
+        destructure_cbor_map! {
+            let {
+                0x01 => modality,
+                0x02 => sub_command,
+                0x03 => sub_command_params,
+                0x04 => pin_protocol,
+                0x05 => pin_auth,
+                0x06 => get_modality,
+            } = extract_map(cbor_value)?;
+        }
+
+        let modality = modality.map(extract_unsigned).transpose()?;
+        let sub_command = sub_command.map(extract_unsigned).transpose()?;
+        let sub_command_params = sub_command_params;
+        let pin_protocol = pin_protocol.map(extract_unsigned).transpose()?;
+        let pin_auth = pin_auth.map(extract_byte_string).transpose()?;
+        let get_modality = get_modality.map(extract_bool).transpose()?;
+
+        Ok(AuthenticatorBioEnrollmentParameters {
+            modality,
+            sub_command,
+            sub_command_params,
+            pin_protocol,
+            pin_auth,
+            get_modality,
+        })
     }
 }
 

--- a/libraries/opensk/src/ctap/mod.rs
+++ b/libraries/opensk/src/ctap/mod.rs
@@ -39,7 +39,8 @@ pub mod vendor_hid;
 pub use self::client_pin::PIN_AUTH_LENGTH;
 use self::client_pin::{ClientPin, PinPermission};
 use self::command::{
-    AuthenticatorGetAssertionParameters, AuthenticatorMakeCredentialParameters, Command,
+    AuthenticatorBioEnrollmentParameters, AuthenticatorGetAssertionParameters,
+    AuthenticatorMakeCredentialParameters, Command,
 };
 #[cfg(feature = "config_command")]
 use self::config_command::process_config;
@@ -55,8 +56,8 @@ use self::hid::{
 };
 use self::large_blobs::LargeBlobState;
 use self::response::{
-    AuthenticatorGetAssertionResponse, AuthenticatorGetInfoResponse,
-    AuthenticatorMakeCredentialResponse, ResponseData,
+    AuthenticatorBioEnrollmentResponse, AuthenticatorGetAssertionResponse,
+    AuthenticatorGetInfoResponse, AuthenticatorMakeCredentialResponse, ResponseData,
 };
 use self::secret::Secret;
 use self::status_code::{Ctap2StatusCode, CtapResult};
@@ -69,6 +70,7 @@ use crate::api::crypto::hkdf256::Hkdf256;
 use crate::api::crypto::sha256::Sha256;
 use crate::api::crypto::HASH_SIZE;
 use crate::api::customization::Customization;
+use crate::api::fingerprint::{Fingerprint, FingerprintCaptureError};
 use crate::api::key_store::{CredentialSource, KeyStore, MAX_CREDENTIAL_ID_SIZE};
 use crate::api::persist::{Attestation, AttestationId, Persist};
 use crate::api::private_key::PrivateKey;
@@ -106,6 +108,7 @@ pub const FIDO2_VERSION_STRING: &str = "FIDO_2_0";
 #[cfg(feature = "with_ctap1")]
 pub const U2F_VERSION_STRING: &str = "U2F_V2";
 pub const FIDO2_1_VERSION_STRING: &str = "FIDO_2_1";
+pub const FIDO2_1_PRE_VERSION_STRING: &str = "FIDO_2_1_PRE";
 
 // We currently only support one algorithm for signatures: ES256.
 // This algorithm is requested in MakeCredential and advertized in GetInfo.
@@ -125,6 +128,34 @@ const SUPPORTED_CRED_PARAMS: &[PublicKeyCredentialParameter] = &[
     #[cfg(feature = "ed25519")]
     EDDSA_CRED_PARAM,
 ];
+
+#[derive(Debug)]
+pub enum BioEnrollmentSubCommand {
+    EnrollBegin = 1,
+    EnrollCaptureNextSample = 2,
+    CancelCurrentEnrollment = 3,
+    EnumerateEnrollments = 4,
+    SetFriendlyName = 5,
+    RemoveEnrollment = 6,
+    GetFingerSensorInfo = 7,
+}
+
+impl TryFrom<u64> for BioEnrollmentSubCommand {
+    type Error = ();
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(BioEnrollmentSubCommand::EnrollBegin),
+            2 => Ok(BioEnrollmentSubCommand::EnrollCaptureNextSample),
+            3 => Ok(BioEnrollmentSubCommand::CancelCurrentEnrollment),
+            4 => Ok(BioEnrollmentSubCommand::EnumerateEnrollments),
+            5 => Ok(BioEnrollmentSubCommand::SetFriendlyName),
+            6 => Ok(BioEnrollmentSubCommand::RemoveEnrollment),
+            7 => Ok(BioEnrollmentSubCommand::GetFingerSensorInfo),
+            _ => Err(()),
+        }
+    }
+}
 
 fn get_preferred_cred_param(
     params: &[PublicKeyCredentialParameter],
@@ -276,6 +307,17 @@ fn is_cancel(packet: &ProcessedPacket) -> bool {
     }
 }
 
+pub fn send_keepalive_packet<E: Env>(env: &mut E, channel: Channel) -> CtapResult<()> {
+    let (cid, transport) = match channel {
+        Channel::MainHid(cid) => (cid, Transport::MainHid),
+        #[cfg(feature = "vendor_hid")]
+        Channel::VendorHid(cid) => (cid, Transport::VendorHid),
+    };
+    let endpoint = transport.usb_endpoint();
+    let keepalive_msg = CtapHid::<E>::keepalive(cid, KeepaliveStatus::UpNeeded);
+    send_packets(env, endpoint, keepalive_msg)
+}
+
 fn wait_and_respond_busy<E: Env>(env: &mut E, channel: Channel) -> CtapResult<()> {
     let (cid, transport) = match channel {
         Channel::MainHid(cid) => (cid, Transport::MainHid),
@@ -367,6 +409,30 @@ pub enum StatefulCommand {
     EnumerateRps(usize),
     EnumerateCredentials(Vec<usize>),
     LargeBlob(LargeBlobState),
+}
+
+//https://fidoalliance.org/specs/fido2/vendor/BioEnrollmentPrototype.pdf
+#[repr(u64)]
+enum Ctap2EnrollFeedback {
+    FpGood = 0,
+    FpPoorQuality = 7,
+    FpMergeFailure = 10,
+    FpTooFast = 0x5,
+    FpTooHigh = 0x1,
+    NoUserActivity = 0xd,
+}
+
+#[repr(u64)]
+enum BioEnrollmentSubCommandParamFields {
+    TemplateId = 0x01,
+    TemplateFriendlyName = 0x02,
+    TimeoutMilliseconds = 0x03,
+}
+
+#[repr(u64)]
+enum BioEnrollmentSubCommandTemplateInfoFields {
+    TemplateId = 0x01,
+    TemplateFriendlyName = 0x02,
 }
 
 /// Stores the current CTAP command state and when it times out.
@@ -546,6 +612,9 @@ pub struct CtapState<E: Env> {
     pub(crate) u2f_up_state: U2fUserPresenceState<E>,
     // The state initializes to Reset and its timeout, and never goes back to Reset.
     stateful_command_permission: StatefulPermission<E>,
+    // Bio enrollment variables
+    remaining_samples: u64,
+    current_template_id: u8,
 }
 
 impl<E: Env> CtapState<E> {
@@ -562,6 +631,8 @@ impl<E: Env> CtapState<E> {
             #[cfg(feature = "with_ctap1")]
             u2f_up_state: U2fUserPresenceState::new(),
             stateful_command_permission,
+            remaining_samples: 3,
+            current_template_id: 0,
         }
     }
 
@@ -596,6 +667,486 @@ impl<E: Env> CtapState<E> {
     pub fn can_sleep(&mut self, env: &mut E) -> bool {
         !self.client_pin.has_token(env)
             && self.stateful_command_permission.get_command(env).is_err()
+    }
+
+    pub fn process_bio_enrollment(
+        &mut self,
+        env: &mut E,
+        params: AuthenticatorBioEnrollmentParameters,
+        _channel: Channel,
+    ) -> CtapResult<ResponseData> {
+        let sub_command = params
+            .sub_command
+            .map(|cmd| BioEnrollmentSubCommand::try_from(cmd))
+            .transpose()
+            .map_err(|_| Ctap2StatusCode::CTAP2_ERR_INVALID_SUBCOMMAND)?;
+
+        debug_ctap!(
+            env,
+            "CT: Received bio enrollment sub_command {:?}",
+            sub_command
+        );
+
+        match sub_command {
+            Some(BioEnrollmentSubCommand::EnrollBegin) => {
+                // Check which fingerprint slots are open, and use the first
+                // one. If none is open we will eventually return an error.
+                let mut fingerlist = [0u8; 5];
+                env.fingerprint().get_enrollments(&mut fingerlist);
+                debug_ctap!(env, "CT: EnrollBegin fingerlist {:?}", fingerlist);
+                let open_index = fingerlist.iter().position(|&x| x == 0);
+
+                let timeout_ms = params.sub_command_params.map_or(2000, |p| {
+                    p.extract_map().map_or(2000, |m| {
+                        m.iter()
+                            .find_map(|e| {
+                                if e.0.clone().extract_unsigned().unwrap_or(0)
+                                    == BioEnrollmentSubCommandParamFields::TimeoutMilliseconds
+                                        as u64
+                                {
+                                    e.1.clone().extract_unsigned()
+                                } else {
+                                    None
+                                }
+                            })
+                            .unwrap_or(2000) as usize
+                    })
+                });
+
+                match open_index {
+                    Some(index) => {
+                        self.remaining_samples =
+                            env.fingerprint().get_enrollment_count_maximum() as u64;
+                        self.current_template_id = index as u8;
+
+                        debug_ctap!(
+                            env,
+                            "CT: EnrollBegin remaining samples {:?}    enrollment_count {:?}   timeout_ms {:?}",
+                            self.remaining_samples,
+                            self.current_template_id,
+                            timeout_ms,
+                        );
+                        env.fingerprint()
+                            .prepare_enrollment(self.current_template_id);
+                        let sample_ret = env.fingerprint().capture_sample(timeout_ms);
+
+                        let sample_status = match sample_ret {
+                            Ok(()) => {
+                                self.remaining_samples -= 1;
+                                Ctap2EnrollFeedback::FpGood
+                            }
+                            Err(e) => {
+                                debug_ctap!(env, "CT: EnrollBegin capture_sample() - Err\n");
+                                match e {
+                                    FingerprintCaptureError::NoTouch => {
+                                        Ctap2EnrollFeedback::NoUserActivity
+                                    }
+                                    FingerprintCaptureError::ImageBad => {
+                                        Ctap2EnrollFeedback::FpPoorQuality
+                                    }
+                                    FingerprintCaptureError::ImagePartial => {
+                                        Ctap2EnrollFeedback::FpTooHigh
+                                    }
+                                    FingerprintCaptureError::TooFast => {
+                                        Ctap2EnrollFeedback::FpTooFast
+                                    }
+                                    FingerprintCaptureError::Other => {
+                                        Ctap2EnrollFeedback::FpPoorQuality
+                                    }
+                                }
+                            }
+                        };
+
+                        let response = AuthenticatorBioEnrollmentResponse {
+                            modality: Some(1),
+                            fingerprint_kind: None,
+                            max_capture_samples_required_for_enroll: Some(self.remaining_samples),
+                            template_id: Some(vec![self.current_template_id]),
+                            last_enroll_sample_status: Some(sample_status as u64),
+                            remaining_samples: Some(self.remaining_samples),
+                            template_infos: None,
+                            max_template_friendly_name: Some(32),
+                        };
+
+                        Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
+                    }
+                    None => {
+                        debug_ctap!(
+                            env,
+                            "CT: EnrollBegin no space (timeout_ms {:?})",
+                            timeout_ms,
+                        );
+
+                        Err(Ctap2StatusCode::CTAP2_ERR_FP_DATABASE_FULL)
+                    }
+                }
+            }
+            Some(BioEnrollmentSubCommand::EnrollCaptureNextSample) => {
+                //check_user_presence(env, channel)?;
+
+                let timeout_ms = params.sub_command_params.map_or(2000, |p| {
+                    p.extract_map().map_or(2000, |m| {
+                        m.iter()
+                            .find_map(|e| {
+                                if e.0.clone().extract_unsigned().unwrap_or(0)
+                                    == BioEnrollmentSubCommandParamFields::TimeoutMilliseconds
+                                        as u64
+                                {
+                                    e.1.clone().extract_unsigned()
+                                } else {
+                                    None
+                                }
+                            })
+                            .unwrap_or(2000) as usize
+                    })
+                });
+
+                let sample_ret = env.fingerprint().capture_sample(timeout_ms);
+
+                debug_ctap!(
+                    env,
+                    "CT: EnrollCaptureNext capture_sample return {:?} remaining_sample {:?} timeout_ms {:?}",
+                    sample_ret,
+                    self.remaining_samples,
+                    timeout_ms,
+                );
+
+                let sample_status = match sample_ret {
+                    Ok(()) => {
+                        if self.remaining_samples == 1 {
+                            let commit_ret = env.fingerprint().commit_enrollment();
+                            debug_ctap!(
+                                env,
+                                "CT: EnrollCaptureNext return from commit enroll {:?}",
+                                commit_ret
+                            );
+                            match commit_ret {
+                                Ok(()) => {
+                                    // nothing to do
+                                    debug_ctap!(
+                                        env,
+                                        "CT: EnrollCaptureNext commit_enrollment() - OK\n"
+                                    );
+                                    self.remaining_samples -= 1;
+                                    Ctap2EnrollFeedback::FpGood
+                                }
+
+                                Err(()) => {
+                                    debug_ctap!(
+                                        env,
+                                        "CT: EnrollCaptureNext commit_enrollment() - Err\n"
+                                    );
+                                    Ctap2EnrollFeedback::FpMergeFailure
+                                }
+                            }
+                        } else {
+                            self.remaining_samples -= 1;
+                            Ctap2EnrollFeedback::FpGood
+                        }
+                    }
+
+                    Err(e) => {
+                        debug_ctap!(env, "CT: EnrollCaptureNext capture_sample() - Err\n");
+                        match e {
+                            FingerprintCaptureError::NoTouch => Ctap2EnrollFeedback::NoUserActivity,
+                            FingerprintCaptureError::ImageBad => Ctap2EnrollFeedback::FpPoorQuality,
+                            FingerprintCaptureError::ImagePartial => Ctap2EnrollFeedback::FpTooHigh,
+                            FingerprintCaptureError::TooFast => Ctap2EnrollFeedback::FpTooFast,
+                            FingerprintCaptureError::Other => Ctap2EnrollFeedback::FpPoorQuality,
+                        }
+                    }
+                };
+
+                let response = AuthenticatorBioEnrollmentResponse {
+                    modality: Some(1),
+                    fingerprint_kind: None,
+                    max_capture_samples_required_for_enroll: None,
+                    template_id: Some(vec![self.current_template_id]),
+                    last_enroll_sample_status: Some(sample_status as u64),
+                    remaining_samples: Some(self.remaining_samples),
+                    template_infos: None,
+                    max_template_friendly_name: Some(32),
+                };
+                Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
+            }
+
+            Some(BioEnrollmentSubCommand::CancelCurrentEnrollment) => {
+                {
+                    env.fingerprint().cancel_enrollment();
+                }
+
+                let response = AuthenticatorBioEnrollmentResponse {
+                    modality: Some(1),
+                    fingerprint_kind: None,
+                    max_capture_samples_required_for_enroll: None,
+                    template_id: None,
+                    last_enroll_sample_status: None,
+                    remaining_samples: None,
+                    template_infos: None,
+                    max_template_friendly_name: Some(32),
+                };
+                Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
+            }
+
+            Some(BioEnrollmentSubCommand::EnumerateEnrollments) => {
+                let mut fingerlist = [0u8; 5];
+                env.fingerprint().get_enrollments(&mut fingerlist);
+
+                debug_ctap!(env, "CT: EnumerateEnrollment fingerlist {:?}", fingerlist);
+
+                let template_ids: Vec<u8> = fingerlist
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(index, &id)| if id != 0 { Some(index as u8) } else { None })
+                    .collect();
+
+                debug_ctap!(
+                    env,
+                    "CT: EnumerateEnrollment template_ids {:?}",
+                    template_ids
+                );
+
+                // Check if there are no enrolled fingers
+                if template_ids.is_empty() {
+                    debug_ctap!(
+                        env,
+                        "CT: No enrolled fingers found. Returning CTAP2_ERR_INVALID_OPTION."
+                    );
+                    return Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION);
+                }
+
+                let template_infos_array: Vec<cbor::Value> = template_ids
+                    .iter()
+                    .map(|template_id| {
+                        let template_id = *template_id;
+                        let friendly_name =
+                            storage::get_friendly_name(env, template_id).unwrap_or("".to_string());
+                        debug_ctap!(env, "CT: Friendly name for template_id {}:", template_id);
+                        if friendly_name.len() > 0 {
+                            debug_ctap!(env, "'{}'", friendly_name);
+                        }
+                        let entries = vec![
+                            (
+                                cbor::Value::unsigned(
+                                    BioEnrollmentSubCommandTemplateInfoFields::TemplateId as u64,
+                                ),
+                                cbor::Value::byte_string(vec![template_id]),
+                            ),
+                            (
+                                cbor::Value::unsigned(
+                                    BioEnrollmentSubCommandTemplateInfoFields::TemplateFriendlyName
+                                        as u64,
+                                ),
+                                cbor::Value::text_string(friendly_name),
+                            ),
+                        ];
+                        cbor::Value::map(entries)
+                    })
+                    .collect();
+
+                let template_infos = cbor::Value::array(template_infos_array);
+
+                let response = AuthenticatorBioEnrollmentResponse {
+                    modality: Some(1),
+                    fingerprint_kind: None,
+                    max_capture_samples_required_for_enroll: None,
+                    template_id: None,
+                    last_enroll_sample_status: None,
+                    remaining_samples: None,
+                    template_infos: Some(template_infos),
+                    max_template_friendly_name: Some(32),
+                };
+                Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
+            }
+
+            Some(BioEnrollmentSubCommand::RemoveEnrollment) => {
+                debug_ctap!(env, "CT: RemoveEnrollment");
+
+                let template_id = params.sub_command_params.map_or(
+                    Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER),
+                    |p| {
+                        p.extract_map().map_or(
+                            Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER),
+                            |m| {
+                                m.iter()
+                                    .find_map(|e| {
+                                        if e.0.clone().extract_unsigned().unwrap_or(0)
+                                            == BioEnrollmentSubCommandParamFields::TemplateId as u64
+                                        {
+                                            Some(Ok(*e
+                                                .1
+                                                .clone()
+                                                .extract_byte_string()
+                                                .unwrap_or(vec![])
+                                                .get(0)
+                                                .unwrap_or(&0)))
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                    .unwrap_or(Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER))
+                            },
+                        )
+                    },
+                )?;
+
+                debug_ctap!(env, "Remove enrollment tempate_id {:?}", template_id);
+
+                env.fingerprint().delete_enrollment(template_id);
+
+                let response = AuthenticatorBioEnrollmentResponse {
+                    modality: Some(1),
+                    fingerprint_kind: None,
+                    max_capture_samples_required_for_enroll: None,
+                    template_id: None,
+                    last_enroll_sample_status: None,
+                    remaining_samples: None,
+                    template_infos: None,
+                    max_template_friendly_name: Some(32),
+                };
+                Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
+            }
+
+            Some(BioEnrollmentSubCommand::SetFriendlyName) => {
+                debug_ctap!(env, "CT: SetFriendlyName");
+
+                // placeholder:  Check token permission for "be"
+
+                let template_id = params.sub_command_params.clone().map_or(
+                    Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER),
+                    |p| {
+                        p.extract_map().map_or(
+                            Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER),
+                            |m| {
+                                m.iter()
+                                    .find_map(|e| {
+                                        if e.0.clone().extract_unsigned().unwrap_or(0)
+                                            == BioEnrollmentSubCommandParamFields::TemplateId as u64
+                                        {
+                                            Some(Ok(*e
+                                                .1
+                                                .clone()
+                                                .extract_byte_string()
+                                                .unwrap_or(vec![])
+                                                .get(0)
+                                                .unwrap_or(&0)))
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                    .unwrap_or(Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER))
+                            },
+                        )
+                    },
+                )?;
+
+                let friendly_name = params.sub_command_params.clone().map_or(
+                    Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER),
+                    |p| {
+                        p.extract_map().map_or(
+                            Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER),
+                            |m| {
+                                m.iter()
+                                    .find_map(|e| {
+                                        if e.0.clone().extract_unsigned().unwrap_or(0)
+                                            == BioEnrollmentSubCommandParamFields::TemplateFriendlyName as u64
+                                        {
+                                            Some(Ok(e
+                                                .1
+                                                .clone()
+                                                .extract_text_string()
+                                                .unwrap_or("".to_string())
+                                                ))
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                    .unwrap_or(Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER))
+                            },
+                        )
+                    },
+                )?;
+
+                debug_ctap!(env, "CT: SetFriendlyName {} {}", template_id, friendly_name);
+
+                // Check if the friendly name length exceeds the maximum allowed
+                const MAX_TEMPLATE_FRIENDLY_NAME: usize = 32; // set it to 32 for now
+                if friendly_name.len() > MAX_TEMPLATE_FRIENDLY_NAME {
+                    return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_LENGTH);
+                }
+
+                // Check if there's an existing enrollment for the given template_id
+                let mut fingerlist = [0u8; 5];
+                env.fingerprint().get_enrollments(&mut fingerlist);
+                if !fingerlist.contains(&template_id) {
+                    return Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION);
+                }
+
+                storage::store_friendly_name(env, template_id, &friendly_name)?;
+
+                // Create a template_info map with the new friendly name
+                let template_info = cbor::Value::map(vec![
+                    (
+                        cbor::Value::unsigned(
+                            BioEnrollmentSubCommandTemplateInfoFields::TemplateId as u64,
+                        ),
+                        cbor::Value::byte_string(vec![template_id]),
+                    ),
+                    (
+                        cbor::Value::unsigned(
+                            BioEnrollmentSubCommandTemplateInfoFields::TemplateFriendlyName as u64,
+                        ),
+                        cbor::Value::text_string(friendly_name.clone()),
+                    ),
+                ]);
+
+                // Create the template_infos array with the single template_info
+                let template_infos = cbor::Value::array(vec![template_info]);
+
+                let response = AuthenticatorBioEnrollmentResponse {
+                    modality: Some(1),
+                    fingerprint_kind: None,
+                    max_capture_samples_required_for_enroll: None,
+                    template_id: None,
+                    last_enroll_sample_status: None,
+                    remaining_samples: None,
+                    template_infos: Some(template_infos),
+                    max_template_friendly_name: Some(32),
+                };
+                Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
+            }
+
+            Some(BioEnrollmentSubCommand::GetFingerSensorInfo) => {
+                // Finger sensor information
+                debug_ctap!(env, "CT: GetFingerSensorInfo");
+
+                let response = AuthenticatorBioEnrollmentResponse {
+                    modality: Some(1),
+                    fingerprint_kind: Some(1),
+                    max_capture_samples_required_for_enroll: Some(6), // change to 6 to match RT
+                    max_template_friendly_name: Some(32),
+                    template_id: None,
+                    last_enroll_sample_status: None,
+                    remaining_samples: None,
+                    template_infos: None,
+                };
+                Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
+            }
+
+            _ => {
+                let response = AuthenticatorBioEnrollmentResponse {
+                    modality: Some(1),
+                    fingerprint_kind: Some(1),
+                    max_capture_samples_required_for_enroll: Some(5),
+                    max_template_friendly_name: Some(32),
+                    template_id: None,
+                    last_enroll_sample_status: None,
+                    remaining_samples: None,
+                    template_infos: None,
+                };
+                Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
+            }
+        }
     }
 
     pub fn process_command(
@@ -647,6 +1198,7 @@ impl<E: Env> CtapState<E> {
             (Command::AuthenticatorGetNextAssertion, Ok(StatefulCommand::GetAssertion(_)))
             | (Command::AuthenticatorLargeBlobs(_), Ok(StatefulCommand::LargeBlob(_)))
             | (Command::AuthenticatorReset, Ok(StatefulCommand::Reset))
+            | (Command::AuthenticatorBioEnrollment(_), Ok(StatefulCommand::Reset))
             // AuthenticatorGetInfo still allows Reset.
             | (Command::AuthenticatorGetInfo, Ok(StatefulCommand::Reset))
             // AuthenticatorSelection still allows Reset.
@@ -685,8 +1237,13 @@ impl<E: Env> CtapState<E> {
                 self.process_get_assertion(env, params, channel)
             }
             Command::AuthenticatorGetNextAssertion => self.process_get_next_assertion(env),
+            Command::AuthenticatorBioEnrollment(params) => {
+                self.process_bio_enrollment(env, params, channel)
+            }
             Command::AuthenticatorGetInfo => self.process_get_info(env),
-            Command::AuthenticatorClientPin(params) => self.client_pin.process_command(env, params),
+            Command::AuthenticatorClientPin(params) => {
+                self.client_pin.process_command(env, params, channel)
+            }
             Command::AuthenticatorReset => self.process_reset(env, channel),
             Command::AuthenticatorCredentialManagement(params) => process_credential_management(
                 env,
@@ -816,16 +1373,47 @@ impl<E: Env> CtapState<E> {
             }
             None => {
                 if options.uv {
-                    return Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION);
+                    // Internal UV is enabled. Check the built in UV and return on error.
+                    // If no error, return the UV_FLAG bit.
+                    self.client_pin
+                        .perform_built_in_uv(env, channel, true)
+                        .map_err(|e| {
+                            // 6.1.2.11.2 error cases:
+                            //
+                            // 1. If the error reason is a user action timeout,
+                            //    then return CTAP2_ERR_USER_ACTION_TIMEOUT.
+                            // 2. If the ClientPin option ID is true and the
+                            //    noMcGaPermissionsWithClientPin option ID is
+                            //    absent or false, end the operation by
+                            //    returning CTAP2_ERR_PUAT_REQUIRED.
+                            // 3. If the uvRetries counter is <= 0, return
+                            //    CTAP2_ERR_PIN_BLOCKED.
+                            // 4. Otherwise, end the operation by returning
+                            //    CTAP2_ERR_OPERATION_DENIED.
+                            match e {
+                                Ctap2StatusCode::CTAP2_ERR_USER_ACTION_TIMEOUT => {
+                                    Ctap2StatusCode::CTAP2_ERR_USER_ACTION_TIMEOUT
+                                }
+                                Ctap2StatusCode::CTAP2_ERR_UV_BLOCKED => {
+                                    Ctap2StatusCode::CTAP2_ERR_PIN_BLOCKED
+                                }
+                                _ => {
+                                    let client_pin_option =
+                                        env.persist().pin_hash().unwrap_or(None).is_some();
+                                    if client_pin_option {
+                                        // noMcGaPermissionsWithClientPin is absent
+                                        Ctap2StatusCode::CTAP2_ERR_PUAT_REQUIRED
+                                    } else {
+                                        Ctap2StatusCode::CTAP2_ERR_OPERATION_DENIED
+                                    }
+                                }
+                            }
+                        })?;
+                    UV_FLAG
+                } else {
+                    // Flags set to 0
+                    0x00
                 }
-                if storage::has_always_uv(env)? {
-                    return Err(Ctap2StatusCode::CTAP2_ERR_PUAT_REQUIRED);
-                }
-                // Corresponds to makeCredUvNotRqd set to true.
-                if options.rk && env.persist().pin_hash()?.is_some() {
-                    return Err(Ctap2StatusCode::CTAP2_ERR_PUAT_REQUIRED);
-                }
-                0x00
             }
         };
         flags |= UP_FLAG | AT_FLAG;
@@ -857,7 +1445,11 @@ impl<E: Env> CtapState<E> {
         self.client_pin.clear_token_flags();
 
         let default_cred_protect = env.customization().default_cred_protect();
-        let mut cred_protect_policy = extensions.cred_protect;
+        let mut cred_protect_policy = Some(
+            extensions
+                .cred_protect
+                .unwrap_or(CredentialProtectionPolicy::UserVerificationOptional),
+        );
         if cred_protect_policy.unwrap_or(CredentialProtectionPolicy::UserVerificationOptional)
             < default_cred_protect.unwrap_or(CredentialProtectionPolicy::UserVerificationOptional)
         {
@@ -1185,15 +1777,19 @@ impl<E: Env> CtapState<E> {
                 UV_FLAG
             }
             None => {
+                debug_ctap!(env, "process_get_assertion: use UV (no pin_uv_auth_param)");
                 if options.uv {
-                    return Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION);
+                    // Internal UV is enabled. Check the built in UV and return on error.
+                    // If no error, return the UV_FLAG bit.
+                    self.client_pin.perform_built_in_uv(env, channel, true)?;
+                    UV_FLAG
+                } else {
+                    // Flags set to 0
+                    0
                 }
-                if options.up && storage::has_always_uv(env)? {
-                    return Err(Ctap2StatusCode::CTAP2_ERR_PUAT_REQUIRED);
-                }
-                0x00
             }
         };
+
         if options.up {
             flags |= UP_FLAG;
         }
@@ -1289,6 +1885,7 @@ impl<E: Env> CtapState<E> {
         let mut versions = vec![
             String::from(FIDO2_VERSION_STRING),
             String::from(FIDO2_1_VERSION_STRING),
+            String::from(FIDO2_1_PRE_VERSION_STRING),
         ];
         #[cfg(feature = "with_ctap1")]
         if !has_always_uv {
@@ -1298,25 +1895,35 @@ impl<E: Env> CtapState<E> {
         if env.customization().enterprise_attestation_mode().is_some() {
             options.push((String::from("ep"), storage::enterprise_attestation(env)?));
         }
+        let client_pin_result = match env.persist().pin_hash() {
+            Ok(Some(pin_hash)) => Some(pin_hash),
+            Ok(None) => None,
+            Err(_) => None,
+        };
+        // `uv` is included in the options map since we have a fingerprint
+        // sensor, but we set the option to false if the sensor is not
+        // "configured" meaning it has no registered fingerprints (and therefore
+        // cannot provide user verification).
+        let uv = env.fingerprint().get_enrollment_count() > 0;
         options.append(&mut vec![
             (String::from("rk"), true),
             (String::from("up"), true),
+            (String::from("uv"), uv),
+            (String::from("alwaysUv"), has_always_uv),
             (String::from("credMgmt"), true),
-            #[cfg(feature = "config_command")]
             (String::from("authnrCfg"), true),
-            (
-                String::from("clientPin"),
-                env.persist().pin_hash()?.is_some(),
-            ),
+            //(String::from("clientPin"), storage::pin_hash(env)?.is_some()),
+            (String::from("clientPin"), client_pin_result.is_some()),
             (String::from("largeBlobs"), true),
             (String::from("pinUvAuthToken"), true),
-            #[cfg(feature = "config_command")]
             (String::from("setMinPINLength"), true),
             (String::from("makeCredUvNotRqd"), !has_always_uv),
+            (String::from("bioEnroll"), true),
+            (String::from("credentialMgmtPreview"), true),
+            (String::from("userVerificationMgmtPreview"), true),
+            (String::from("uvToken"), true),
+            (String::from("plat"), false),
         ]);
-        if cfg!(feature = "config_command") || env.customization().enforce_always_uv() {
-            options.push((String::from("alwaysUv"), has_always_uv));
-        }
         let mut pin_protocols = vec![PinUvAuthProtocol::V2 as u64];
         if env.customization().allows_pin_protocol_v1() {
             pin_protocols.push(PinUvAuthProtocol::V1 as u64);
@@ -1358,6 +1965,10 @@ impl<E: Env> CtapState<E> {
                 remaining_discoverable_credentials: Some(
                     storage::remaining_credentials(env)? as u64
                 ),
+                preferred_platform_uv_attempts: Some(
+                    env.customization().preferred_platform_uv_attempts() as u64,
+                ),
+                uv_modality: Some(2),
             },
         ))
     }
@@ -1373,6 +1984,10 @@ impl<E: Env> CtapState<E> {
 
         reset(env)?;
         self.client_pin.reset(env);
+
+        // FF is a special case to delete all fingerprints
+        env.fingerprint().delete_enrollment(0xff);
+
         #[cfg(feature = "with_ctap1")]
         {
             // We create a block statement to wrap this assignment expression, because attributes

--- a/libraries/opensk/src/ctap/response.rs
+++ b/libraries/opensk/src/ctap/response.rs
@@ -38,6 +38,8 @@ pub enum ResponseData {
     AuthenticatorLargeBlobs(Option<AuthenticatorLargeBlobsResponse>),
     #[cfg(feature = "config_command")]
     AuthenticatorConfig,
+
+    AuthenticatorBioEnrollment(Option<AuthenticatorBioEnrollmentResponse>),
 }
 
 impl From<ResponseData> for Option<cbor::Value> {
@@ -54,6 +56,8 @@ impl From<ResponseData> for Option<cbor::Value> {
             ResponseData::AuthenticatorLargeBlobs(data) => data.map(|d| d.into()),
             #[cfg(feature = "config_command")]
             ResponseData::AuthenticatorConfig => None,
+
+            ResponseData::AuthenticatorBioEnrollment(data) => data.map(|d| d.into()),
         }
     }
 }
@@ -143,6 +147,9 @@ pub struct AuthenticatorGetInfoResponse {
     // - 0x12: uvModality
     // Add them when your hardware supports any kind of user verification within
     // the boundary of the device, e.g. fingerprint or built-in keyboard.
+    pub preferred_platform_uv_attempts: Option<u64>,
+    pub uv_modality: Option<u64>,
+
     pub certifications: Option<Vec<(String, i64)>>,
     pub remaining_discoverable_credentials: Option<u64>,
     // - 0x15: vendorPrototypeConfigCommands missing as we don't support it.
@@ -167,6 +174,10 @@ impl From<AuthenticatorGetInfoResponse> for cbor::Value {
             firmware_version,
             max_cred_blob_length,
             max_rp_ids_for_set_min_pin_length,
+
+            preferred_platform_uv_attempts,
+            uv_modality,
+
             certifications,
             remaining_discoverable_credentials,
         } = get_info_response;
@@ -204,6 +215,8 @@ impl From<AuthenticatorGetInfoResponse> for cbor::Value {
             0x0E => firmware_version,
             0x0F => max_cred_blob_length,
             0x10 => max_rp_ids_for_set_min_pin_length,
+            0x11 => preferred_platform_uv_attempts,
+            0x12 => uv_modality,
             0x13 => certifications_cbor,
             0x14 => remaining_discoverable_credentials,
         }
@@ -216,7 +229,7 @@ pub struct AuthenticatorClientPinResponse {
     pub pin_uv_auth_token: Option<Vec<u8>>,
     pub retries: Option<u64>,
     pub power_cycle_state: Option<bool>,
-    // - 0x05: uvRetries missing as we don't support internal UV.
+    pub uv_retries: Option<u64>,
 }
 
 impl From<AuthenticatorClientPinResponse> for cbor::Value {
@@ -226,6 +239,7 @@ impl From<AuthenticatorClientPinResponse> for cbor::Value {
             pin_uv_auth_token,
             retries,
             power_cycle_state,
+            uv_retries,
         } = client_pin_response;
 
         cbor_map_options! {
@@ -233,8 +247,21 @@ impl From<AuthenticatorClientPinResponse> for cbor::Value {
             0x02 => pin_uv_auth_token,
             0x03 => retries,
             0x04 => power_cycle_state,
+            0x05 => uv_retries,
         }
     }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct AuthenticatorBioEnrollmentResponse {
+    pub modality: Option<u64>,
+    pub fingerprint_kind: Option<u64>,
+    pub max_capture_samples_required_for_enroll: Option<u64>,
+    pub max_template_friendly_name: Option<u64>,
+    pub template_id: Option<Vec<u8>>,
+    pub last_enroll_sample_status: Option<u64>,
+    pub remaining_samples: Option<u64>,
+    pub template_infos: Option<cbor::Value>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -265,6 +292,21 @@ pub struct AuthenticatorCredentialManagementResponse {
     pub total_credentials: Option<u64>,
     pub cred_protect: Option<CredentialProtectionPolicy>,
     pub large_blob_key: Option<Vec<u8>>,
+}
+
+impl From<AuthenticatorBioEnrollmentResponse> for cbor::Value {
+    fn from(bio_enrollment_response: AuthenticatorBioEnrollmentResponse) -> Self {
+        cbor_map_options! {
+            0x01 => bio_enrollment_response.modality,
+            0x02 => bio_enrollment_response.fingerprint_kind,
+            0x03 => bio_enrollment_response.max_capture_samples_required_for_enroll,
+            0x04 => bio_enrollment_response.template_id,
+            0x05 => bio_enrollment_response.last_enroll_sample_status,
+            0x06 => bio_enrollment_response.remaining_samples,
+            0x07 => bio_enrollment_response.template_infos,
+            0x08 => bio_enrollment_response.max_template_friendly_name,
+        }
+    }
 }
 
 impl From<AuthenticatorCredentialManagementResponse> for cbor::Value {
@@ -472,6 +514,7 @@ mod test {
             pin_uv_auth_token: Some(vec![70]),
             retries: Some(8),
             power_cycle_state: Some(false),
+            uv_retries: Some(0),
         };
         let response_cbor: Option<cbor::Value> =
             ResponseData::AuthenticatorClientPin(Some(client_pin_response)).into();

--- a/libraries/opensk/src/ctap/storage.rs
+++ b/libraries/opensk/src/ctap/storage.rs
@@ -203,6 +203,24 @@ pub fn reset_pin_retries(env: &mut impl Env) -> CtapResult<()> {
     env.persist().reset_pin_retries()
 }
 
+/// Returns the number of remaining UV retries.
+pub fn uv_retries(env: &mut impl Env) -> CtapResult<u8> {
+    Ok(env
+        .customization()
+        .max_uv_retries()
+        .saturating_sub(env.persist().uv_fails()?))
+}
+
+/// Decrements the number of remaining UV retries.
+pub fn decr_uv_retries(env: &mut impl Env) -> CtapResult<()> {
+    env.persist().incr_uv_fails()
+}
+
+/// Resets the number of remaining UV retries.
+pub fn reset_uv_retries(env: &mut impl Env) -> CtapResult<()> {
+    env.persist().reset_uv_retries()
+}
+
 /// Returns the minimum PIN length.
 pub fn min_pin_length(env: &mut impl Env) -> CtapResult<u8> {
     Ok(env
@@ -285,6 +303,21 @@ pub fn toggle_always_uv(env: &mut impl Env) -> CtapResult<()> {
         return Err(Ctap2StatusCode::CTAP2_ERR_OPERATION_DENIED);
     }
     env.persist().toggle_always_uv()
+}
+
+/// Store a Bio Enrollment friendly name for a given template_id.
+pub fn store_friendly_name<E: Env>(
+    env: &mut E,
+    template_id: u8,
+    friendly_name: &str,
+) -> CtapResult<()> {
+    env.persist()
+        .store_friendly_name(template_id, friendly_name)
+}
+
+/// Retrieve the Bio Enrollment friendly name for a given template_id.
+pub fn get_friendly_name<E: Env>(env: &mut E, template_id: u8) -> CtapResult<String> {
+    env.persist().get_friendly_name(template_id)
 }
 
 /// Iterator for credentials.

--- a/libraries/opensk/src/env/mod.rs
+++ b/libraries/opensk/src/env/mod.rs
@@ -18,6 +18,7 @@ use crate::api::crypto::ecdh::Ecdh;
 use crate::api::crypto::ecdsa::Ecdsa;
 use crate::api::crypto::Crypto;
 use crate::api::customization::Customization;
+use crate::api::fingerprint::Fingerprint;
 use crate::api::key_store::KeyStore;
 use crate::api::persist::Persist;
 use crate::api::rng::Rng;
@@ -49,12 +50,14 @@ pub trait Env {
     type HidConnection: HidConnection;
     type Clock: Clock;
     type Crypto: Crypto;
+    type Fingerprint: Fingerprint;
 
     fn rng(&mut self) -> &mut Self::Rng;
     fn user_presence(&mut self) -> &mut Self::UserPresence;
     fn persist(&mut self) -> &mut Self::Persist;
     fn key_store(&mut self) -> &mut Self::KeyStore;
     fn clock(&mut self) -> &mut Self::Clock;
+    fn fingerprint(&mut self) -> &mut Self::Fingerprint;
 
     /// Creates a write instance for debugging.
     ///

--- a/libraries/opensk/src/env/test/customization.rs
+++ b/libraries/opensk/src/env/test/customization.rs
@@ -35,6 +35,9 @@ pub struct TestCustomization {
     max_large_blob_array_size: usize,
     max_rp_ids_length: usize,
     max_supported_resident_keys: usize,
+    preferred_platform_uv_attempts: usize,
+    max_uv_retries: u8,
+    max_uv_attempts_for_internal_retries: u8,
 }
 
 impl TestCustomization {
@@ -126,6 +129,18 @@ impl Customization for TestCustomization {
     fn max_supported_resident_keys(&self) -> usize {
         self.max_supported_resident_keys
     }
+
+    fn preferred_platform_uv_attempts(&self) -> usize {
+        self.preferred_platform_uv_attempts
+    }
+
+    fn max_uv_retries(&self) -> u8 {
+        self.max_uv_retries
+    }
+
+    fn max_uv_attempts_for_internal_retries(&self) -> u8 {
+        self.max_uv_attempts_for_internal_retries
+    }
 }
 
 impl From<CustomizationImpl> for TestCustomization {
@@ -148,6 +163,9 @@ impl From<CustomizationImpl> for TestCustomization {
             max_large_blob_array_size,
             max_rp_ids_length,
             max_supported_resident_keys,
+            preferred_platform_uv_attempts,
+            max_uv_retries,
+            max_uv_attempts_for_internal_retries,
         } = c;
 
         let default_min_pin_length_rp_ids = default_min_pin_length_rp_ids
@@ -178,6 +196,9 @@ impl From<CustomizationImpl> for TestCustomization {
             max_large_blob_array_size,
             max_rp_ids_length,
             max_supported_resident_keys,
+            preferred_platform_uv_attempts,
+            max_uv_retries,
+            max_uv_attempts_for_internal_retries,
         }
     }
 }

--- a/libraries/opensk/src/env/test/mod.rs
+++ b/libraries/opensk/src/env/test/mod.rs
@@ -16,6 +16,7 @@ use crate::api::clock::Clock;
 use crate::api::connection::{HidConnection, RecvStatus, UsbEndpoint};
 use crate::api::crypto::software_crypto::SoftwareCrypto;
 use crate::api::customization::DEFAULT_CUSTOMIZATION;
+use crate::api::fingerprint::{Fingerprint, FingerprintCaptureError, FingerprintCheckError};
 use crate::api::key_store;
 use crate::api::persist::{Persist, PersistIter};
 use crate::api::rng::Rng;
@@ -37,6 +38,7 @@ pub struct TestEnv {
     customization: TestCustomization,
     clock: TestClock,
     soft_reset: bool,
+    fingerprint: TestFingerprint,
 }
 
 pub type TestRng = StdRng;
@@ -88,6 +90,8 @@ impl Clock for TestClock {
 pub struct TestUserPresence {
     check: Box<dyn Fn() -> UserPresenceResult>,
 }
+
+pub struct TestFingerprint {}
 
 pub struct TestWrite;
 
@@ -155,6 +159,7 @@ impl Default for TestEnv {
         let store = Store::new(storage).ok().unwrap();
         let customization = DEFAULT_CUSTOMIZATION.into();
         let clock = TestClock::default();
+        let fingerprint = TestFingerprint {};
         TestEnv {
             rng,
             user_presence,
@@ -162,6 +167,7 @@ impl Default for TestEnv {
             customization,
             clock,
             soft_reset: false,
+            fingerprint,
         }
     }
 }
@@ -198,6 +204,42 @@ impl UserPresence for TestUserPresence {
     fn check_complete(&mut self) {}
 }
 
+impl Fingerprint for TestFingerprint {
+    fn get_enrollment_count_maximum(&self) -> u8 {
+        10
+    }
+
+    fn get_enrollment_count(&self) -> u8 {
+        0
+    }
+
+    fn prepare_enrollment(&self, _index: u8) {}
+
+    fn capture_sample(&self, _timeout: usize) -> Result<(), FingerprintCaptureError> {
+        Ok(())
+    }
+
+    fn commit_enrollment(&self) -> Result<(), ()> {
+        Ok(())
+    }
+
+    fn cancel_enrollment(&self) {}
+
+    fn get_enrollments(&self, _fingerlist: &mut [u8; 5]) {}
+
+    fn check_fingerprint_init(&mut self) {}
+
+    fn check_fingerprint(&self, _timeout: usize) -> Result<u8, FingerprintCheckError> {
+        Ok(0)
+    }
+
+    fn check_fingerprint_complete(&mut self) {}
+
+    fn delete_enrollment(&self, _index: u8) {}
+
+    fn setloglevel(&self, _level: u8) {}
+}
+
 impl key_store::Helper for TestEnv {}
 
 impl Env for TestEnv {
@@ -210,6 +252,7 @@ impl Env for TestEnv {
     type Customization = TestCustomization;
     type HidConnection = Self;
     type Crypto = SoftwareCrypto;
+    type Fingerprint = TestFingerprint;
 
     fn rng(&mut self) -> &mut Self::Rng {
         &mut self.rng
@@ -217,6 +260,10 @@ impl Env for TestEnv {
 
     fn user_presence(&mut self) -> &mut Self::UserPresence {
         &mut self.user_presence
+    }
+
+    fn fingerprint(&mut self) -> &mut Self::Fingerprint {
+        &mut self.fingerprint
     }
 
     fn persist(&mut self) -> &mut Self {

--- a/src/env/tock/mod.rs
+++ b/src/env/tock/mod.rs
@@ -31,6 +31,7 @@ use opensk::api::clock::Clock;
 use opensk::api::connection::{HidConnection, RecvStatus, UsbEndpoint};
 use opensk::api::crypto::software_crypto::SoftwareCrypto;
 use opensk::api::customization::{CustomizationImpl, AAGUID_LENGTH, DEFAULT_CUSTOMIZATION};
+use opensk::api::fingerprint::{Fingerprint, FingerprintCaptureError, FingerprintCheckError};
 use opensk::api::key_store;
 use opensk::api::persist::{Persist, PersistIter};
 use opensk::api::rng::Rng;
@@ -337,6 +338,46 @@ where
     }
 }
 
+impl<S, C> Fingerprint for TockEnv<S, C>
+where
+    S: Syscalls,
+    C: platform::subscribe::Config + platform::allow_ro::Config,
+{
+    fn get_enrollment_count_maximum(&self) -> u8 {
+        0
+    }
+
+    fn get_enrollment_count(&self) -> u8 {
+        0
+    }
+
+    fn prepare_enrollment(&self, _index: u8) {}
+
+    fn capture_sample(&self, _timeout_ms: usize) -> Result<(), FingerprintCaptureError> {
+        Err(FingerprintCaptureError::Other)
+    }
+
+    fn commit_enrollment(&self) -> Result<(), ()> {
+        Err(())
+    }
+
+    fn cancel_enrollment(&self) {}
+
+    fn get_enrollments(&self, _fingerlist: &mut [u8; 5]) {}
+
+    fn check_fingerprint_init(&mut self) {}
+
+    fn check_fingerprint(&self, _timeout_ms: usize) -> Result<u8, FingerprintCheckError> {
+        Err(FingerprintCheckError::Other)
+    }
+
+    fn check_fingerprint_complete(&mut self) {}
+
+    fn delete_enrollment(&self, _index: u8) {}
+
+    fn setloglevel(&self, _level: u8) {}
+}
+
 impl<S, C> key_store::Helper for TockEnv<S, C>
 where
     S: Syscalls,
@@ -356,12 +397,17 @@ impl<S: Syscalls, C: platform::subscribe::Config + platform::allow_ro::Config> E
     type Customization = CustomizationImpl;
     type HidConnection = Self;
     type Crypto = SoftwareCrypto;
+    type Fingerprint = Self;
 
     fn rng(&mut self) -> &mut Self::Rng {
         &mut self.rng
     }
 
     fn user_presence(&mut self) -> &mut Self::UserPresence {
+        self
+    }
+
+    fn fingerprint(&mut self) -> &mut Self::Fingerprint {
         self
     }
 


### PR DESCRIPTION

This PR includes our changes to OpenSK to support UV and bioenrollment. Because there is no fingerprint sensor on the nRF52840dk or in Tock, the environment implementation is just a stub.

We are happy to test this PR against our internal hardware platform as updates are made to this PR after feedback.

-   [ ] Local tests pass (running `run_desktop_tests.sh`)
-   [ ] Tested against boards
    -   [ ] Nordic nRF52840 DK
    -   [ ] Nordic nRF52840 Dongle (JTAG programmed)
    -   [ ] Nordic nRF52840 Dongle (DFU programmed)
    -   [ ] Makerdiary nRF52840 MDK USB Dongle
-   [ ] Appropriate changes to README are included in PR
