### PR TITLE
Re-export rand_core from api::rng

### DIFF
--- a/libraries/opensk/src/api/rng.rs
+++ b/libraries/opensk/src/api/rng.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub use rand_core;
 use rand_core::{CryptoRng, RngCore};
 
 /// Random number generator.


### PR DESCRIPTION
This is ok to re-export rand_core, because it is part of our public API. It is also good to re-export it, because then users don't need to keep track of the exact version we use by simply using this re-export. Without this, users have to explicitly depend on rand_core and then tools like cargo upgrade will break them.

Note that this is fairly common practice, for example https://docs.rs/crypto-common re-export rand_core.