### PR TITLE
Fixes pylint for later versions

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -427,7 +427,7 @@ class OpenSKInstaller:
 
     command = [
         "cargo", "build", "--release", f"--target={props.arch}",
-        f"--features={','.join(self.args.features)}"
+        f'--features={",".join(self.args.features)}'
     ]
     if is_example:
       command.extend(["--example", self.args.application])
@@ -447,7 +447,7 @@ class OpenSKInstaller:
     features = ["std"]
     features.extend(self.args.features)
     self.checked_command_output([
-        "cargo", "test", f"--features={','.join(features)}", "--lib",
+        "cargo", "test", f'--features={",".join(features)}', "--lib",
         "customization"
     ])
 

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -154,8 +154,8 @@ def main(args):
       )
       status = {"cert": result[1], "pkey": result[2]}
       responses.append(status)
-      info(f"Certificate: {'Present' if result[1] else 'Missing'}")
-      info(f"Private Key: {'Present' if result[2] else 'Missing'}")
+      info(f'Certificate: {"Present" if result[1] else "Missing"}')
+      info(f'Private Key: {"Present" if result[2] else "Missing"}')
       if args.lock:
         info("Device is now locked down!")
     except ctap.CtapError as ex:


### PR DESCRIPTION
While not caught by the pylint version in the GitHub workflows yet, this fails locally:

```
py_virtual_env/bin/pylint --score=n `git ls-files --deduplicate --exclude-standard --full-name '*.py'`
```