### PR TITLE
Uv bio enrollment, continued

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ with_ctap1 = ["opensk/with_ctap1"]
 with_nfc = ["libtock_drivers/with_nfc"]
 vendor_hid = ["opensk/vendor_hid"]
 ed25519 = ["ed25519-compact", "opensk/ed25519"]
+fingerprint = ["opensk/fingerprint"]
 
 [dev-dependencies]
 enum-iterator = "0.6.0"

--- a/libraries/opensk/Cargo.toml
+++ b/libraries/opensk/Cargo.toml
@@ -42,6 +42,7 @@ with_ctap1 = []
 vendor_hid = []
 fuzz = ["arbitrary", "std"]
 ed25519 = ["ed25519-compact"]
+fingerprint = []
 
 [dev-dependencies]
 enum-iterator = "0.6.0"

--- a/libraries/opensk/src/api/customization.rs
+++ b/libraries/opensk/src/api/customization.rs
@@ -145,7 +145,7 @@ pub trait Customization {
     /// this value.
     fn max_msg_size(&self) -> usize;
 
-    /// Sets the number of consecutive failed PINs before blocking interaction.
+    /// The number of consecutive failed PINs before blocking interaction.
     ///
     /// # Invariant
     ///
@@ -154,6 +154,42 @@ pub trait Customization {
     ///
     /// The fail retry counter is reset after entering the correct PIN.
     fn max_pin_retries(&self) -> u8;
+
+    /// Maximum number of UV retries performed before returning an error.
+    ///
+    /// Corresponds to maxUvAttemptsForInternalRetries in CTAP 2.1 onwards.
+    /// When internal retries are allowed, the authenticator will retry UV
+    /// before communicating its result through CTAP.
+    ///
+    /// # Invariant
+    ///
+    /// - Must be in the range [1, `max_uv_retries`].
+    /// - If `preferred_platform_uv_attempts` is not 1, must be in [1, 5].
+    #[cfg(feature = "fingerprint")]
+    fn max_uv_attempts_for_internal_retries(&self) -> u8;
+
+    /// The number of consecutive failed UV attempts before blocking built-in UV.
+    ///
+    /// Corresponds to maxUvRetries in CTAP 2.1 onwards.
+    ///
+    /// # Invariant
+    ///
+    /// - Must be in the range [1, 25].
+    #[cfg(feature = "fingerprint")]
+    fn max_uv_retries(&self) -> u8;
+
+    /// Preferred number of UV attempts before falling back to PIN.
+    ///
+    /// Corresponds to preferredPlatformUvAttempts in CTAP 2.1 onwards.
+    /// States the preference how often the platform should invoke
+    /// `getPinUvAuthTokenUsingUvWithPermissions` before falling back to
+    /// `getPinUvAuthTokenUsingPinWithPermissions` or displaying an error.
+    ///
+    /// # Invariant
+    ///
+    /// - Must be greater than 0.
+    #[cfg(feature = "fingerprint")]
+    fn preferred_platform_uv_attempts(&self) -> usize;
 
     /// Enables or disables basic attestation for FIDO2.
     ///
@@ -253,30 +289,11 @@ pub trait Customization {
     /// for 10 years.
     fn max_supported_resident_keys(&self) -> usize;
 
-    /// This specifies the preferred number of invocations of the
-    /// `getPinUvAuthTokenUsingUvWithPermissions` subCommand the platform may
-    /// attempt before falling back to the
-    /// `getPinUvAuthTokenUsingPinWithPermissions` subCommand or displaying an
-    /// error.
+    /// Maximum size of a friendly name for a UV template.
     ///
-    /// MUST be greater than zero. If the value is 1 then all uvRetries are
-    /// internal and the platform MUST only invoke the
-    /// getPinUvAuthTokenUsingUvWithPermissions subCommand a single time. If the
-    /// value is > 1 the authenticator MUST only decrement uvRetries by 1 for
-    /// each iteration.
-    fn preferred_platform_uv_attempts(&self) -> usize;
-
-    /// Sets the number of consecutive failed User Verification attempts before
-    /// blocking built-in UV.
-    ///
-    /// # Invariant
-    ///
-    /// - CTAP2.1: Maximum PIN retries must be 25 at most.
-    fn max_uv_retries(&self) -> u8;
-
-    /// The maximum number of times the authenticator will retry internally when
-    /// internalRetry is true as part of the performBuiltInUv() algorithm.
-    fn max_uv_attempts_for_internal_retries(&self) -> u8;
+    /// This value limits storage requirements for fingerprints.
+    #[cfg(feature = "fingerprint")]
+    fn max_template_friendly_name(&self) -> usize;
 }
 
 #[derive(Clone)]
@@ -291,6 +308,12 @@ pub struct CustomizationImpl {
     pub enterprise_rp_id_list: &'static [&'static str],
     pub max_msg_size: usize,
     pub max_pin_retries: u8,
+    #[cfg(feature = "fingerprint")]
+    pub max_uv_attempts_for_internal_retries: u8,
+    #[cfg(feature = "fingerprint")]
+    pub max_uv_retries: u8,
+    #[cfg(feature = "fingerprint")]
+    pub preferred_platform_uv_attempts: usize,
     pub use_batch_attestation: bool,
     pub use_signature_counter: bool,
     pub max_cred_blob_length: usize,
@@ -298,22 +321,27 @@ pub struct CustomizationImpl {
     pub max_large_blob_array_size: usize,
     pub max_rp_ids_length: usize,
     pub max_supported_resident_keys: usize,
-    pub preferred_platform_uv_attempts: usize,
-    pub max_uv_retries: u8,
-    pub max_uv_attempts_for_internal_retries: u8,
+    #[cfg(feature = "fingerprint")]
+    pub max_template_friendly_name: usize,
 }
 
 pub const DEFAULT_CUSTOMIZATION: CustomizationImpl = CustomizationImpl {
     aaguid: &[0; AAGUID_LENGTH],
     allows_pin_protocol_v1: true,
-    default_cred_protect: Some(CredentialProtectionPolicy::UserVerificationOptional),
+    default_cred_protect: None,
     default_min_pin_length: 4,
     default_min_pin_length_rp_ids: &[],
-    enforce_always_uv: true,
+    enforce_always_uv: false,
     enterprise_attestation_mode: None,
     enterprise_rp_id_list: &[],
     max_msg_size: 7609,
     max_pin_retries: 8,
+    #[cfg(feature = "fingerprint")]
+    max_uv_attempts_for_internal_retries: 1,
+    #[cfg(feature = "fingerprint")]
+    max_uv_retries: 8,
+    #[cfg(feature = "fingerprint")]
+    preferred_platform_uv_attempts: 1,
     use_batch_attestation: false,
     use_signature_counter: true,
     max_cred_blob_length: 32,
@@ -321,9 +349,8 @@ pub const DEFAULT_CUSTOMIZATION: CustomizationImpl = CustomizationImpl {
     max_large_blob_array_size: 2048,
     max_rp_ids_length: 8,
     max_supported_resident_keys: 150,
-    preferred_platform_uv_attempts: 5,
-    max_uv_retries: 8,
-    max_uv_attempts_for_internal_retries: 8,
+    #[cfg(feature = "fingerprint")]
+    max_template_friendly_name: 64,
 };
 
 impl Customization for CustomizationImpl {
@@ -378,6 +405,21 @@ impl Customization for CustomizationImpl {
         self.max_pin_retries
     }
 
+    #[cfg(feature = "fingerprint")]
+    fn max_uv_attempts_for_internal_retries(&self) -> u8 {
+        self.max_uv_attempts_for_internal_retries
+    }
+
+    #[cfg(feature = "fingerprint")]
+    fn max_uv_retries(&self) -> u8 {
+        self.max_uv_retries
+    }
+
+    #[cfg(feature = "fingerprint")]
+    fn preferred_platform_uv_attempts(&self) -> usize {
+        self.preferred_platform_uv_attempts
+    }
+
     fn use_batch_attestation(&self) -> bool {
         self.use_batch_attestation
     }
@@ -406,16 +448,9 @@ impl Customization for CustomizationImpl {
         self.max_supported_resident_keys
     }
 
-    fn preferred_platform_uv_attempts(&self) -> usize {
-        self.preferred_platform_uv_attempts
-    }
-
-    fn max_uv_retries(&self) -> u8 {
-        self.max_uv_retries
-    }
-
-    fn max_uv_attempts_for_internal_retries(&self) -> u8 {
-        self.max_uv_attempts_for_internal_retries
+    #[cfg(feature = "fingerprint")]
+    fn max_template_friendly_name(&self) -> usize {
+        self.max_template_friendly_name
     }
 }
 
@@ -489,6 +524,31 @@ pub fn is_valid(customization: &impl Customization) -> bool {
         return false;
     }
 
+    #[cfg(feature = "fingerprint")]
+    {
+        // Maximum UV retries must be in range [1, 25].
+        if customization.max_uv_retries() < 1 || customization.max_uv_retries() > 25 {
+            return false;
+        }
+
+        // Maximum internal UV attemps must be in range [1, `max_uv_retries`].
+        if customization.max_uv_attempts_for_internal_retries() < 1
+            || customization.max_uv_attempts_for_internal_retries() > customization.max_uv_retries()
+        {
+            return false;
+        }
+        if customization.preferred_platform_uv_attempts() != 1
+            && customization.max_uv_attempts_for_internal_retries() > 5
+        {
+            return false;
+        }
+
+        // Preferred number of UV attempts must be positive.
+        if customization.preferred_platform_uv_attempts() == 0 {
+            return false;
+        }
+    }
+
     true
 }
 
@@ -514,6 +574,12 @@ mod test {
             enterprise_rp_id_list: &[],
             max_msg_size: 7609,
             max_pin_retries: 8,
+            #[cfg(feature = "fingerprint")]
+            max_uv_attempts_for_internal_retries: 1,
+            #[cfg(feature = "fingerprint")]
+            max_uv_retries: 8,
+            #[cfg(feature = "fingerprint")]
+            preferred_platform_uv_attempts: 1,
             use_batch_attestation: true,
             use_signature_counter: true,
             max_cred_blob_length: 32,
@@ -521,6 +587,8 @@ mod test {
             max_large_blob_array_size: 2048,
             max_rp_ids_length: 8,
             max_supported_resident_keys: 150,
+            #[cfg(feature = "fingerprint")]
+            max_template_friendly_name: 64,
         };
         assert_eq!(customization.aaguid(), &[0; AAGUID_LENGTH]);
         assert!(customization.allows_pin_protocol_v1());
@@ -535,6 +603,12 @@ mod test {
         assert!(customization.enterprise_rp_id_list().is_empty());
         assert_eq!(customization.max_msg_size(), 7609);
         assert_eq!(customization.max_pin_retries(), 8);
+        #[cfg(feature = "fingerprint")]
+        assert_eq!(customization.max_uv_attempts_for_internal_retries(), 1);
+        #[cfg(feature = "fingerprint")]
+        assert_eq!(customization.max_uv_retries(), 8);
+        #[cfg(feature = "fingerprint")]
+        assert_eq!(customization.preferred_platform_uv_attempts(), 1);
         assert!(customization.use_batch_attestation());
         assert!(customization.use_signature_counter());
         assert_eq!(customization.max_cred_blob_length(), 32);
@@ -542,5 +616,7 @@ mod test {
         assert_eq!(customization.max_large_blob_array_size(), 2048);
         assert_eq!(customization.max_rp_ids_length(), 8);
         assert_eq!(customization.max_supported_resident_keys(), 150);
+        #[cfg(feature = "fingerprint")]
+        assert_eq!(customization.max_template_friendly_name(), 64);
     }
 }

--- a/libraries/opensk/src/api/customization.rs
+++ b/libraries/opensk/src/api/customization.rs
@@ -532,6 +532,7 @@ pub fn is_valid(customization: &impl Customization) -> bool {
         }
 
         // Maximum internal UV attemps must be in range [1, `max_uv_retries`].
+        // If preferred platform UV attemps is not 1, must additionally be in [1, 5].
         if customization.max_uv_attempts_for_internal_retries() < 1
             || customization.max_uv_attempts_for_internal_retries() > customization.max_uv_retries()
         {

--- a/libraries/opensk/src/api/customization.rs
+++ b/libraries/opensk/src/api/customization.rs
@@ -252,6 +252,31 @@ pub trait Customization {
     /// With P=20 and K=150, we have I=2M which is enough for 500 increments per day
     /// for 10 years.
     fn max_supported_resident_keys(&self) -> usize;
+
+    /// This specifies the preferred number of invocations of the
+    /// `getPinUvAuthTokenUsingUvWithPermissions` subCommand the platform may
+    /// attempt before falling back to the
+    /// `getPinUvAuthTokenUsingPinWithPermissions` subCommand or displaying an
+    /// error.
+    ///
+    /// MUST be greater than zero. If the value is 1 then all uvRetries are
+    /// internal and the platform MUST only invoke the
+    /// getPinUvAuthTokenUsingUvWithPermissions subCommand a single time. If the
+    /// value is > 1 the authenticator MUST only decrement uvRetries by 1 for
+    /// each iteration.
+    fn preferred_platform_uv_attempts(&self) -> usize;
+
+    /// Sets the number of consecutive failed User Verification attempts before
+    /// blocking built-in UV.
+    ///
+    /// # Invariant
+    ///
+    /// - CTAP2.1: Maximum PIN retries must be 25 at most.
+    fn max_uv_retries(&self) -> u8;
+
+    /// The maximum number of times the authenticator will retry internally when
+    /// internalRetry is true as part of the performBuiltInUv() algorithm.
+    fn max_uv_attempts_for_internal_retries(&self) -> u8;
 }
 
 #[derive(Clone)]
@@ -273,15 +298,18 @@ pub struct CustomizationImpl {
     pub max_large_blob_array_size: usize,
     pub max_rp_ids_length: usize,
     pub max_supported_resident_keys: usize,
+    pub preferred_platform_uv_attempts: usize,
+    pub max_uv_retries: u8,
+    pub max_uv_attempts_for_internal_retries: u8,
 }
 
 pub const DEFAULT_CUSTOMIZATION: CustomizationImpl = CustomizationImpl {
     aaguid: &[0; AAGUID_LENGTH],
     allows_pin_protocol_v1: true,
-    default_cred_protect: None,
+    default_cred_protect: Some(CredentialProtectionPolicy::UserVerificationOptional),
     default_min_pin_length: 4,
     default_min_pin_length_rp_ids: &[],
-    enforce_always_uv: false,
+    enforce_always_uv: true,
     enterprise_attestation_mode: None,
     enterprise_rp_id_list: &[],
     max_msg_size: 7609,
@@ -293,6 +321,9 @@ pub const DEFAULT_CUSTOMIZATION: CustomizationImpl = CustomizationImpl {
     max_large_blob_array_size: 2048,
     max_rp_ids_length: 8,
     max_supported_resident_keys: 150,
+    preferred_platform_uv_attempts: 5,
+    max_uv_retries: 8,
+    max_uv_attempts_for_internal_retries: 8,
 };
 
 impl Customization for CustomizationImpl {
@@ -373,6 +404,18 @@ impl Customization for CustomizationImpl {
 
     fn max_supported_resident_keys(&self) -> usize {
         self.max_supported_resident_keys
+    }
+
+    fn preferred_platform_uv_attempts(&self) -> usize {
+        self.preferred_platform_uv_attempts
+    }
+
+    fn max_uv_retries(&self) -> u8 {
+        self.max_uv_retries
+    }
+
+    fn max_uv_attempts_for_internal_retries(&self) -> u8 {
+        self.max_uv_attempts_for_internal_retries
     }
 }
 

--- a/libraries/opensk/src/api/fingerprint.rs
+++ b/libraries/opensk/src/api/fingerprint.rs
@@ -1,0 +1,81 @@
+#[derive(Debug)]
+pub enum FingerprintCaptureError {
+    NoTouch,
+    ImageBad,
+    ImagePartial,
+    TooFast,
+    Other,
+}
+
+#[derive(Debug)]
+pub enum FingerprintCheckError {
+    NoMatch,
+    Timeout,
+    Other,
+}
+
+pub trait Fingerprint {
+    /// Get the maximum number of fingerprint enrollments the sensor can
+    /// support.
+    fn get_enrollment_count_maximum(&self) -> u8;
+
+    /// Get the number of fingerprints currently enrolled.
+    fn get_enrollment_count(&self) -> u8;
+
+    /// Start an enrollment session for the fingerprint at the given index.
+    ///
+    /// `index` should be from 0 to `get_enrollment_count_maximum()-1`.
+    fn prepare_enrollment(&self, index: u8);
+
+    /// Capture a fingerprint image.
+    ///
+    /// `prepare_enrollment()` must be called first.
+    ///
+    /// Waits for a fingerprint image or returns if `timeout_ms` happens without
+    /// a touch.
+    ///
+    /// ## Return
+    ///
+    /// `Ok(())` on success and `Err(())` on any failure.
+    fn capture_sample(&self, timeout_ms: usize) -> Result<(), FingerprintCaptureError>;
+
+    /// Store a fingerprint enrollment.
+    ///
+    /// ## Return
+    ///
+    /// `Ok(())` on success and `Err(())` on any failure.
+    fn commit_enrollment(&self) -> Result<(), ()>;
+
+    /// Cancel a fingerprint enrollment.
+    fn cancel_enrollment(&self);
+
+    /// Check all enrollments to see if they are enrolled.
+    fn get_enrollments(&self, fingerlist: &mut [u8; 5]);
+
+    /// Called before [`check_fingerprint()`].
+    ///
+    /// Useful for starting any operation that needs to happen before
+    /// potentially repeated fingerprint checks, such as blinking LEDs.
+    fn check_fingerprint_init(&mut self);
+
+    /// Require the user to touch the sensor and verify the fingerprint is
+    /// valid.
+    ///
+    /// Waits for a fingerprint image or returns if `timeout_ms` happens without
+    /// a touch.
+    ///
+    /// Returns:
+    /// - `Ok(index)`: If fingerprint is valid, returns the index of the matched
+    ///   fingerprint.
+    /// - `Err(e)`: Error if fingerprint is not valid.
+    fn check_fingerprint(&self, timeout_ms: usize) -> Result<u8, FingerprintCheckError>;
+
+    /// Called after checking fingerprints has finished.
+    fn check_fingerprint_complete(&mut self);
+
+    /// Delete the fingerprint enrolled at the given index.
+    fn delete_enrollment(&self, index: u8);
+
+    fn setloglevel(&self, level: u8);
+
+}

--- a/libraries/opensk/src/api/fingerprint.rs
+++ b/libraries/opensk/src/api/fingerprint.rs
@@ -1,81 +1,100 @@
-#[derive(Debug)]
-pub enum FingerprintCaptureError {
-    NoTouch,
-    ImageBad,
-    ImagePartial,
-    TooFast,
-    Other,
+use crate::ctap::status_code::CtapResult;
+use alloc::vec::Vec;
+use sk_cbor as cbor;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum FingerprintKind {
+    Touch = 1,
+    Swipe = 2,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum FingerprintCheckError {
     NoMatch,
     Timeout,
     Other,
 }
 
+/// Status code for enrolling fingerprints
+///
+/// See lastEnrollSampleStatus in section authenticatorBioEnrollment
+#[derive(Debug, PartialEq, Eq)]
+pub enum Ctap2EnrollFeedback {
+    FpGood = 0x00,
+    FpTooHigh = 0x01,
+    FpTooLow = 0x02,
+    FpTooLeft = 0x03,
+    FpTooRight = 0x04,
+    FpTooFast = 0x05,
+    FpTooSlow = 0x06,
+    FpPoorQuality = 0x07,
+    FpTooSkewed = 0x08,
+    FpTooShort = 0x09,
+    FpMergeFailure = 0x0A,
+    FpExists = 0x0B,
+    // 0x0C is intentionally unused
+    NoUserActivity = 0x0D,
+    NoUserPresenceTransition = 0x0E,
+}
+
+impl From<Ctap2EnrollFeedback> for cbor::Value {
+    fn from(feedback: Ctap2EnrollFeedback) -> Self {
+        (feedback as u64).into()
+    }
+}
+
 pub trait Fingerprint {
-    /// Get the maximum number of fingerprint enrollments the sensor can
-    /// support.
-    fn get_enrollment_count_maximum(&self) -> u8;
+    /// Starts the fingerprint enrollment process.
+    ///
+    /// Returns the newly assigned template ID.
+    fn prepare_enrollment(&mut self) -> CtapResult<Vec<u8>>;
 
-    /// Get the number of fingerprints currently enrolled.
-    fn get_enrollment_count(&self) -> u8;
-
-    /// Start an enrollment session for the fingerprint at the given index.
+    /// Captures a fingerprint image.
     ///
-    /// `index` should be from 0 to `get_enrollment_count_maximum()-1`.
-    fn prepare_enrollment(&self, index: u8);
-
-    /// Capture a fingerprint image.
-    ///
-    /// `prepare_enrollment()` must be called first.
-    ///
-    /// Waits for a fingerprint image or returns if `timeout_ms` happens without
-    /// a touch.
-    ///
-    /// ## Return
-    ///
-    /// `Ok(())` on success and `Err(())` on any failure.
-    fn capture_sample(&self, timeout_ms: usize) -> Result<(), FingerprintCaptureError>;
-
-    /// Store a fingerprint enrollment.
-    ///
-    /// ## Return
-    ///
-    /// `Ok(())` on success and `Err(())` on any failure.
-    fn commit_enrollment(&self) -> Result<(), ()>;
+    /// Waits for the user to present a finger.
+    /// If `timeout_ms` is provided, the function times out on user inaction.
+    /// `prepare_enrollment` must be called first.
+    /// A returned `Ctap2StatusCode` indicates an unexpected failure processing
+    /// the command.
+    /// The `Ctap2EnrollFeedback` contains expected errors from the fingerprint
+    /// capture process.
+    /// Also returns the expected number of remaining samples.
+    fn capture_sample(
+        &mut self,
+        template_id: &[u8],
+        timeout_ms: Option<usize>,
+    ) -> CtapResult<(Ctap2EnrollFeedback, usize)>;
 
     /// Cancel a fingerprint enrollment.
-    fn cancel_enrollment(&self);
+    fn cancel_enrollment(&mut self) -> CtapResult<()>;
 
-    /// Check all enrollments to see if they are enrolled.
-    fn get_enrollments(&self, fingerlist: &mut [u8; 5]);
-
-    /// Called before [`check_fingerprint()`].
+    /// Delete the fingerprint matching the given template ID.
     ///
+    /// Does not delete stored information from persistent storage.
+    /// This function signals to the sensor to remove the enrollment only.
+    fn remove_enrollment(&mut self, template_id: &[u8]) -> CtapResult<()>;
+
+    /// Initialize hardware to prepare a fingerprint check.
+    ///
+    /// Called before [`check_fingerprint`].
     /// Useful for starting any operation that needs to happen before
     /// potentially repeated fingerprint checks, such as blinking LEDs.
     fn check_fingerprint_init(&mut self);
 
-    /// Require the user to touch the sensor and verify the fingerprint is
-    /// valid.
+    /// Collects a fingerprint from the user and verifies it.
     ///
-    /// Waits for a fingerprint image or returns if `timeout_ms` happens without
-    /// a touch.
-    ///
-    /// Returns:
-    /// - `Ok(index)`: If fingerprint is valid, returns the index of the matched
-    ///   fingerprint.
-    /// - `Err(e)`: Error if fingerprint is not valid.
-    fn check_fingerprint(&self, timeout_ms: usize) -> Result<u8, FingerprintCheckError>;
+    /// Waits for the user to present a finger, or the timeout to pass.
+    /// Returns Ok if the fingerprint was valid, and an error otherwise.
+    fn check_fingerprint(&mut self, timeout_ms: usize) -> Result<(), FingerprintCheckError>;
 
-    /// Called after checking fingerprints has finished.
+    /// Deinitilize hardware after a fingerprint check.
+    ///
+    /// Called after [`check_fingerprint`] is finished.
     fn check_fingerprint_complete(&mut self);
 
-    /// Delete the fingerprint enrolled at the given index.
-    fn delete_enrollment(&self, index: u8);
+    /// The kind of fingerprint sensor.
+    fn fingerprint_kind(&self) -> FingerprintKind;
 
-    fn setloglevel(&self, level: u8);
-
+    /// Maximum number of good samples required for enrollment.
+    fn max_capture_samples_required_for_enroll(&self) -> usize;
 }

--- a/libraries/opensk/src/api/mod.rs
+++ b/libraries/opensk/src/api/mod.rs
@@ -21,6 +21,7 @@ pub mod clock;
 pub mod connection;
 pub mod crypto;
 pub mod customization;
+pub mod fingerprint;
 pub mod firmware_protection;
 pub mod key_store;
 pub mod persist;

--- a/libraries/opensk/src/api/mod.rs
+++ b/libraries/opensk/src/api/mod.rs
@@ -21,6 +21,7 @@ pub mod clock;
 pub mod connection;
 pub mod crypto;
 pub mod customization;
+#[cfg(feature = "fingerprint")]
 pub mod fingerprint;
 pub mod firmware_protection;
 pub mod key_store;

--- a/libraries/opensk/src/api/persist.rs
+++ b/libraries/opensk/src/api/persist.rs
@@ -15,17 +15,24 @@
 mod keys;
 
 use crate::api::crypto::EC_FIELD_SIZE;
+#[cfg(feature = "fingerprint")]
+use crate::ctap::fingerprint::TemplateInfo;
 use crate::ctap::secret::Secret;
 use crate::ctap::status_code::{Ctap2StatusCode, CtapResult};
 use crate::ctap::PIN_AUTH_LENGTH;
+#[cfg(feature = "fingerprint")]
+use crate::ctap::{cbor_read, cbor_write};
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
+#[cfg(feature = "fingerprint")]
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::cmp;
 use core::convert::TryFrom;
 #[cfg(test)]
 use enum_iterator::IntoEnumIterator;
+#[cfg(feature = "fingerprint")]
+use sk_cbor as cbor;
 
 pub type PersistIter<'a> = Box<dyn Iterator<Item = CtapResult<usize>> + 'a>;
 pub type PersistCredentialIter<'a> = Box<dyn Iterator<Item = CtapResult<(usize, Vec<u8>)>> + 'a>;
@@ -206,6 +213,7 @@ pub trait Persist {
     }
 
     /// Returns the number of failed UV attempts.
+    #[cfg(feature = "fingerprint")]
     fn uv_fails(&self) -> CtapResult<u8> {
         match self.find(keys::UV_RETRIES)? {
             None => Ok(0),
@@ -215,6 +223,7 @@ pub trait Persist {
     }
 
     /// Decrements the number of remaining UV retries.
+    #[cfg(feature = "fingerprint")]
     fn incr_uv_fails(&mut self) -> CtapResult<()> {
         let old_value = self.uv_fails()?;
         let new_value = old_value.saturating_add(1);
@@ -222,6 +231,7 @@ pub trait Persist {
     }
 
     /// Resets the number of remaining UV retries.
+    #[cfg(feature = "fingerprint")]
     fn reset_uv_retries(&mut self) -> CtapResult<()> {
         self.remove(keys::UV_RETRIES)
     }
@@ -408,21 +418,100 @@ pub trait Persist {
         }
     }
 
-    /// Store a Bio Enrollment friendly name for a given template_id.
-    fn store_friendly_name(&mut self, template_id: u8, friendly_name: &str) -> CtapResult<()> {
-        let key = keys::FRIENDLY_NAMES.start + template_id as usize;
-        self.insert(key, friendly_name.as_bytes())?;
-        Ok(())
+    /// Lists all stored template IDs.
+    #[cfg(feature = "fingerprint")]
+    fn template_infos(&self) -> CtapResult<Vec<TemplateInfo>> {
+        let mut id_list = Vec::new();
+        for key in keys::FRIENDLY_NAMES {
+            if let Some(data) = self.find(key)? {
+                let cbor_value = cbor_read(&data)
+                    .map_err(|_| Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)?;
+                let template_info = TemplateInfo::try_from(cbor_value)?;
+                id_list.push(template_info);
+            }
+        }
+        Ok(id_list)
     }
 
-    /// Retrieve the Bio Enrollment friendly name for a given template_id.
-    fn get_friendly_name(&mut self, template_id: u8) -> CtapResult<String> {
-        let key = keys::FRIENDLY_NAMES.start + template_id as usize;
-
-        match self.find(key)? {
-            None => Err(Ctap2StatusCode::CTAP1_ERR_OTHER),
-            Some(value) => Ok(String::from_utf8(value).unwrap_or(String::from(""))),
+    /// Stores a new template ID.
+    ///
+    /// Returns `Err(CTAP2_ERR_FP_DATABASE_FULL)` if the storage is full.
+    #[cfg(feature = "fingerprint")]
+    fn store_template_id(&mut self, template_id: &[u8]) -> CtapResult<()> {
+        for key in keys::FRIENDLY_NAMES {
+            if self.find(key)?.is_some() {
+                continue;
+            }
+            let template_info = TemplateInfo {
+                template_id: template_id.to_vec(),
+                template_friendly_name: None,
+            };
+            let mut data = Vec::new();
+            cbor_write(cbor::Value::from(template_info), &mut data)?;
+            self.insert(key, &mut data)?;
+            return Ok(());
         }
+        Err(Ctap2StatusCode::CTAP2_ERR_FP_DATABASE_FULL)
+    }
+
+    /// Removes the template information matching the template ID.
+    ///
+    /// Returns `Err(CTAP2_ERR_INVALID_OPTION)` if the template was not found.
+    #[cfg(feature = "fingerprint")]
+    fn remove_template_id(&mut self, template_id: &[u8]) -> CtapResult<()> {
+        for key in keys::FRIENDLY_NAMES {
+            if let Some(data) = self.find(key)? {
+                let cbor_value = cbor_read(&data)
+                    .map_err(|_| Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)?;
+                let template_info = TemplateInfo::try_from(cbor_value)?;
+                if &template_info.template_id == template_id {
+                    self.remove(key)?;
+                    return Ok(());
+                }
+            }
+        }
+        Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION)
+    }
+
+    /// Retrieve the BioEnrollment friendly name for a given template ID.
+    ///
+    /// Returns `Ok(None)` if the template was not found or no friendly name was set.
+    #[cfg(test)]
+    #[cfg(feature = "fingerprint")]
+    fn get_friendly_name(&self, template_id: &[u8]) -> CtapResult<Option<String>> {
+        for key in keys::FRIENDLY_NAMES {
+            if let Some(data) = self.find(key)? {
+                let cbor_value = cbor_read(&data)
+                    .map_err(|_| Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)?;
+                let template_info = TemplateInfo::try_from(cbor_value)?;
+                if &template_info.template_id == template_id {
+                    return Ok(template_info.template_friendly_name);
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    /// Store a BioEnrollment friendly name for a given template ID.
+    ///
+    /// Returns `Err(CTAP2_ERR_INVALID_OPTION)` if the template was not found.
+    #[cfg(feature = "fingerprint")]
+    fn store_friendly_name(&mut self, template_id: &[u8], friendly_name: &str) -> CtapResult<()> {
+        for key in keys::FRIENDLY_NAMES {
+            if let Some(bytes) = self.find(key)? {
+                let cbor_value = cbor_read(&bytes)
+                    .map_err(|_| Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)?;
+                let mut template_info = TemplateInfo::try_from(cbor_value)?;
+                if &template_info.template_id == template_id {
+                    template_info.template_friendly_name = Some(String::from(friendly_name));
+                    let mut data = Vec::new();
+                    cbor_write(cbor::Value::from(template_info), &mut data)?;
+                    self.insert(key, &mut data)?;
+                    return Ok(());
+                }
+            }
+        }
+        Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION)
     }
 
     fn get_attestation(&self, id: AttestationId) -> CtapResult<Option<Attestation>> {
@@ -607,5 +696,70 @@ mod test {
         assert_eq!(persist.reset(), Ok(()));
         assert!(persist.pin_hash().unwrap().is_none());
         assert!(persist.pin_code_point_length().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_pin_fails() {
+        let mut env = TestEnv::default();
+        let persist = env.persist();
+
+        assert_eq!(persist.pin_fails().unwrap(), 0);
+        assert_eq!(persist.incr_pin_fails(), Ok(()));
+        assert_eq!(persist.pin_fails().unwrap(), 1);
+        assert_eq!(persist.reset_pin_retries(), Ok(()));
+        assert_eq!(persist.pin_fails().unwrap(), 0);
+    }
+
+    #[test]
+    #[cfg(feature = "fingerprint")]
+    fn test_uv_fails() {
+        let mut env = TestEnv::default();
+        let persist = env.persist();
+
+        assert_eq!(persist.uv_fails().unwrap(), 0);
+        assert_eq!(persist.incr_uv_fails(), Ok(()));
+        assert_eq!(persist.uv_fails().unwrap(), 1);
+        assert_eq!(persist.reset_uv_retries(), Ok(()));
+        assert_eq!(persist.uv_fails().unwrap(), 0);
+    }
+
+    #[test]
+    #[cfg(feature = "fingerprint")]
+    fn test_fingerprint_template_id() {
+        let mut env = TestEnv::default();
+        let persist = env.persist();
+
+        assert_eq!(persist.template_infos().unwrap(), vec![]);
+        assert_eq!(persist.store_template_id(&[0x00]), Ok(()));
+        let template_info = &persist.template_infos().unwrap()[0];
+        assert_eq!(template_info.template_id, &[0x00]);
+        assert_eq!(template_info.template_friendly_name, None);
+        assert_eq!(persist.remove_template_id(&[0x00]), Ok(()));
+        assert_eq!(persist.template_infos().unwrap(), vec![]);
+        assert_eq!(
+            persist.remove_template_id(&[0x00]),
+            Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION)
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "fingerprint")]
+    fn test_fingerprint_friendly_name() {
+        let mut env = TestEnv::default();
+        let persist = env.persist();
+
+        assert_eq!(persist.get_friendly_name(&[0x00]).unwrap(), None);
+        assert_eq!(
+            persist.store_friendly_name(&[0x00], "Name"),
+            Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION)
+        );
+        assert_eq!(persist.store_template_id(&[0x00]), Ok(()));
+        assert_eq!(persist.store_friendly_name(&[0x00], "Name"), Ok(()));
+        assert_eq!(
+            persist.get_friendly_name(&[0x00]).unwrap(),
+            Some(String::from("Name"))
+        );
+        assert_eq!(persist.remove_template_id(&[0x00]), Ok(()));
+        assert_eq!(persist.get_friendly_name(&[0x00]).unwrap(), None);
     }
 }

--- a/libraries/opensk/src/api/persist.rs
+++ b/libraries/opensk/src/api/persist.rs
@@ -435,23 +435,37 @@ pub trait Persist {
 
     /// Stores a new template ID.
     ///
+    /// We shouldn't try to create the same template ID twice, so if it already
+    /// exists, return an internal error.
+    ///
     /// Returns `Err(CTAP2_ERR_FP_DATABASE_FULL)` if the storage is full.
     #[cfg(feature = "fingerprint")]
-    fn store_template_id(&mut self, template_id: &[u8]) -> CtapResult<()> {
+    fn store_template_id(&mut self, template_id: Vec<u8>) -> CtapResult<()> {
+        let mut new_key = None;
         for key in keys::FRIENDLY_NAMES {
-            if self.find(key)?.is_some() {
-                continue;
+            if let Some(data) = self.find(key)? {
+                let cbor_value = cbor_read(&data)
+                    .map_err(|_| Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)?;
+                let template_info = TemplateInfo::try_from(cbor_value)?;
+                if template_info.template_id == template_id {
+                    return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
+                }
+            } else if new_key.is_none() {
+                new_key = Some(key);
             }
+        }
+        if let Some(key) = new_key {
             let template_info = TemplateInfo {
-                template_id: template_id.to_vec(),
+                template_id,
                 template_friendly_name: None,
             };
             let mut data = Vec::new();
             cbor_write(cbor::Value::from(template_info), &mut data)?;
-            self.insert(key, &mut data)?;
-            return Ok(());
+            self.insert(key, &data)?;
+            Ok(())
+        } else {
+            Err(Ctap2StatusCode::CTAP2_ERR_FP_DATABASE_FULL)
         }
-        Err(Ctap2StatusCode::CTAP2_ERR_FP_DATABASE_FULL)
     }
 
     /// Removes the template information matching the template ID.
@@ -464,7 +478,7 @@ pub trait Persist {
                 let cbor_value = cbor_read(&data)
                     .map_err(|_| Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)?;
                 let template_info = TemplateInfo::try_from(cbor_value)?;
-                if &template_info.template_id == template_id {
+                if template_info.template_id == template_id {
                     self.remove(key)?;
                     return Ok(());
                 }
@@ -496,17 +510,17 @@ pub trait Persist {
     ///
     /// Returns `Err(CTAP2_ERR_INVALID_OPTION)` if the template was not found.
     #[cfg(feature = "fingerprint")]
-    fn store_friendly_name(&mut self, template_id: &[u8], friendly_name: &str) -> CtapResult<()> {
+    fn store_friendly_name(&mut self, template_id: &[u8], friendly_name: String) -> CtapResult<()> {
         for key in keys::FRIENDLY_NAMES {
             if let Some(bytes) = self.find(key)? {
                 let cbor_value = cbor_read(&bytes)
                     .map_err(|_| Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)?;
                 let mut template_info = TemplateInfo::try_from(cbor_value)?;
-                if &template_info.template_id == template_id {
-                    template_info.template_friendly_name = Some(String::from(friendly_name));
+                if template_info.template_id == template_id {
+                    template_info.template_friendly_name = Some(friendly_name);
                     let mut data = Vec::new();
                     cbor_write(cbor::Value::from(template_info), &mut data)?;
-                    self.insert(key, &mut data)?;
+                    self.insert(key, &data)?;
                     return Ok(());
                 }
             }
@@ -730,7 +744,7 @@ mod test {
         let persist = env.persist();
 
         assert_eq!(persist.template_infos().unwrap(), vec![]);
-        assert_eq!(persist.store_template_id(&[0x00]), Ok(()));
+        assert_eq!(persist.store_template_id(vec![0x00]), Ok(()));
         let template_info = &persist.template_infos().unwrap()[0];
         assert_eq!(template_info.template_id, &[0x00]);
         assert_eq!(template_info.template_friendly_name, None);
@@ -750,11 +764,14 @@ mod test {
 
         assert_eq!(persist.get_friendly_name(&[0x00]).unwrap(), None);
         assert_eq!(
-            persist.store_friendly_name(&[0x00], "Name"),
+            persist.store_friendly_name(&[0x00], "Name".to_string()),
             Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION)
         );
-        assert_eq!(persist.store_template_id(&[0x00]), Ok(()));
-        assert_eq!(persist.store_friendly_name(&[0x00], "Name"), Ok(()));
+        assert_eq!(persist.store_template_id(vec![0x00]), Ok(()));
+        assert_eq!(
+            persist.store_friendly_name(&[0x00], "Name".to_string()),
+            Ok(())
+        );
         assert_eq!(
             persist.get_friendly_name(&[0x00]).unwrap(),
             Some(String::from("Name"))

--- a/libraries/opensk/src/api/persist.rs
+++ b/libraries/opensk/src/api/persist.rs
@@ -20,6 +20,7 @@ use crate::ctap::status_code::{Ctap2StatusCode, CtapResult};
 use crate::ctap::PIN_AUTH_LENGTH;
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
+use alloc::string::String;
 use alloc::vec::Vec;
 use core::cmp;
 use core::convert::TryFrom;
@@ -204,6 +205,27 @@ pub trait Persist {
         self.remove(keys::PIN_RETRIES)
     }
 
+    /// Returns the number of failed UV attempts.
+    fn uv_fails(&self) -> CtapResult<u8> {
+        match self.find(keys::UV_RETRIES)? {
+            None => Ok(0),
+            Some(value) if value.len() == 1 => Ok(value[0]),
+            _ => Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR),
+        }
+    }
+
+    /// Decrements the number of remaining UV retries.
+    fn incr_uv_fails(&mut self) -> CtapResult<()> {
+        let old_value = self.uv_fails()?;
+        let new_value = old_value.saturating_add(1);
+        self.insert(keys::UV_RETRIES, &[new_value])
+    }
+
+    /// Resets the number of remaining UV retries.
+    fn reset_uv_retries(&mut self) -> CtapResult<()> {
+        self.remove(keys::UV_RETRIES)
+    }
+
     /// Returns the minimum PIN length, if stored.
     fn min_pin_length(&self) -> CtapResult<Option<u8>> {
         match self.find(keys::MIN_PIN_LENGTH)? {
@@ -383,6 +405,23 @@ pub trait Persist {
             Ok(self.remove(keys::ALWAYS_UV)?)
         } else {
             Ok(self.insert(keys::ALWAYS_UV, &[])?)
+        }
+    }
+
+    /// Store a Bio Enrollment friendly name for a given template_id.
+    fn store_friendly_name(&mut self, template_id: u8, friendly_name: &str) -> CtapResult<()> {
+        let key = keys::FRIENDLY_NAMES.start + template_id as usize;
+        self.insert(key, friendly_name.as_bytes())?;
+        Ok(())
+    }
+
+    /// Retrieve the Bio Enrollment friendly name for a given template_id.
+    fn get_friendly_name(&mut self, template_id: u8) -> CtapResult<String> {
+        let key = keys::FRIENDLY_NAMES.start + template_id as usize;
+
+        match self.find(key)? {
+            None => Err(Ctap2StatusCode::CTAP1_ERR_OTHER),
+            Some(value) => Ok(String::from_utf8(value).unwrap_or(String::from(""))),
         }
     }
 

--- a/libraries/opensk/src/api/persist/keys.rs
+++ b/libraries/opensk/src/api/persist/keys.rs
@@ -103,6 +103,16 @@ make_partition! {
     /// The stored large blob can be too big for one key, so it has to be sharded.
     LARGE_BLOB_SHARDS = 2000..2004;
 
+    /// Stored friendly names for enrolled fingerprints.
+    #[cfg(feature = "fingerprint")]
+    FRIENDLY_NAMES = 2031..2036;
+
+    /// Stores UV retry counter information.
+    ///
+    /// If the entry is absent, the number of UV retries is `Customization::max_uv_retries()`.
+    #[cfg(feature = "fingerprint")]
+    UV_RETRIES = 2037;
+
     /// If this entry exists and is empty, alwaysUv is enabled.
     ALWAYS_UV = 2038;
 
@@ -142,12 +152,6 @@ make_partition! {
     ///
     /// If the entry is absent, the counter is 0.
     GLOBAL_SIGNATURE_COUNTER = 2047;
-
-    /// Stored counter  UV retries.
-    UV_RETRIES = 2048;
-
-    /// Stored friendly names for enrolled fingerprints.
-    FRIENDLY_NAMES = 2100..2105;
 }
 
 #[cfg(test)]

--- a/libraries/opensk/src/api/persist/keys.rs
+++ b/libraries/opensk/src/api/persist/keys.rs
@@ -142,6 +142,12 @@ make_partition! {
     ///
     /// If the entry is absent, the counter is 0.
     GLOBAL_SIGNATURE_COUNTER = 2047;
+
+    /// Stored counter  UV retries.
+    UV_RETRIES = 2048;
+
+    /// Stored friendly names for enrolled fingerprints.
+    FRIENDLY_NAMES = 2100..2105;
 }
 
 #[cfg(test)]

--- a/libraries/opensk/src/api/persist/keys.rs
+++ b/libraries/opensk/src/api/persist/keys.rs
@@ -105,7 +105,7 @@ make_partition! {
 
     /// Stored friendly names for enrolled fingerprints.
     #[cfg(feature = "fingerprint")]
-    FRIENDLY_NAMES = 2031..2036;
+    FRIENDLY_NAMES = 2031..2037;
 
     /// Stores UV retry counter information.
     ///

--- a/libraries/opensk/src/ctap/client_pin.rs
+++ b/libraries/opensk/src/ctap/client_pin.rs
@@ -21,11 +21,13 @@ use super::response::{AuthenticatorClientPinResponse, ResponseData};
 use super::secret::Secret;
 use super::status_code::Ctap2StatusCode;
 use super::token_state::PinUvAuthTokenState;
+use super::Channel;
 #[cfg(test)]
 use crate::api::crypto::ecdh::SecretKey as _;
 use crate::api::crypto::hmac256::Hmac256;
 use crate::api::crypto::sha256::Sha256;
 use crate::api::customization::Customization;
+use crate::api::fingerprint::{Fingerprint, FingerprintCheckError};
 use crate::api::key_store::KeyStore;
 use crate::api::persist::Persist;
 use crate::ctap::status_code::CtapResult;
@@ -224,6 +226,7 @@ impl<E: Env> ClientPin<E> {
             pin_uv_auth_token: None,
             retries: Some(storage::pin_retries(env)? as u64),
             power_cycle_state: Some(self.consecutive_pin_mismatches >= 3),
+            uv_retries: None,
         })
     }
 
@@ -240,6 +243,7 @@ impl<E: Env> ClientPin<E> {
             pin_uv_auth_token: None,
             retries: None,
             power_cycle_state: None,
+            uv_retries: None,
         })
     }
 
@@ -342,27 +346,218 @@ impl<E: Env> ClientPin<E> {
                 .get_pin_uv_auth_token(),
         )?;
 
+        // Because using a PIN succeeded, we can clear the UV retry counter.
+        let _ = storage::reset_uv_retries(env);
+
         Ok(AuthenticatorClientPinResponse {
             key_agreement: None,
             pin_uv_auth_token: Some(pin_uv_auth_token),
             retries: None,
             power_cycle_state: None,
+            uv_retries: None,
         })
     }
 
     fn process_get_pin_uv_auth_token_using_uv_with_permissions(
-        &self,
-        // If you want to support local user verification, implement this function.
-        // Lacking a fingerprint reader, this subcommand is currently unsupported.
-        _client_pin_params: AuthenticatorClientPinParameters,
+        &mut self,
+        env: &mut E,
+        client_pin_params: AuthenticatorClientPinParameters,
+        channel: Channel,
     ) -> CtapResult<AuthenticatorClientPinResponse> {
-        // User verification is only supported through PIN currently.
-        Err(Ctap2StatusCode::CTAP2_ERR_INVALID_SUBCOMMAND)
+        let AuthenticatorClientPinParameters {
+            pin_uv_auth_protocol,
+            key_agreement,
+            permissions,
+            permissions_rp_id,
+            ..
+        } = client_pin_params;
+        let key_agreement = ok_or_missing(key_agreement)?;
+
+        // If the authenticator does not receive mandatory parameters for this
+        // command, it returns CTAP2_ERR_MISSING_PARAMETER error.
+        if permissions.is_none() {
+            debug_ctap!(env, "CP: getPinUvAuthUv no  permissions",);
+        }
+        let permissions_bitfield =
+            permissions.ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?;
+
+        // If the authenticator receives a permissions parameter with value 0,
+        // return CTAP1_ERR_INVALID_PARAMETER.
+        if permissions_bitfield == 0 {
+            return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
+        }
+
+        // For each pinUvAuthToken permission present in the permissions
+        // parameter, if the statement corresponding to the permission is
+        // currently true, terminate these steps and return
+        // CTAP2_ERR_UNAUTHORIZED_PERMISSION.
+        // - cm: credMgmt is false or absent.
+        // - be: uvBioEnroll is false or absent.
+        // - lbw: largeBlobs is false or absent.
+        // - acfg: uvAcfg is false or absent.
+        //
+        // We set the credMgmt, uvBioEnroll, and largeBlobs options to true, so
+        // we only need to check for acfg.
+        #[cfg(feature = "config_command")]
+        if permissions_bitfield & PinPermission::AuthenticatorConfiguration as u8 > 0 {
+            return Err(Ctap2StatusCode::CTAP2_ERR_UNAUTHORIZED_PERMISSION);
+        }
+
+        let internal_retry = env.customization().preferred_platform_uv_attempts() == 1;
+        self.perform_built_in_uv(env, channel, internal_retry)?;
+
+        let shared_secret = self.get_shared_secret(pin_uv_auth_protocol, key_agreement)?;
+        if env.persist().has_force_pin_change()? {
+            return Err(Ctap2StatusCode::CTAP2_ERR_PIN_INVALID);
+        }
+
+        // Create a new pinUvAuthToken by calling resetPinUvAuthToken() for all
+        // pinUvAuthProtocols supported by this authenticator.
+        self.pin_protocol_v1.reset_pin_uv_auth_token(env);
+        self.pin_protocol_v2.reset_pin_uv_auth_token(env);
+
+        // If the employed built-in user verification method supplied evidence
+        // of user interaction, then call
+        // beginUsingPinUvAuthToken(userIsPresent: true).
+        self.pin_uv_auth_token_state
+            .begin_using_pin_uv_auth_token(env);
+
+        // Assign the requested permissions to the pinUvAuthToken, ignoring any
+        // undefined permissions.
+        self.pin_uv_auth_token_state
+            .set_permissions(permissions_bitfield);
+
+        // If the rpId parameter is present, use its value as the permissions RP
+        // ID and associate it with the pinUvAuthToken.
+        self.pin_uv_auth_token_state
+            .set_permissions_rp_id(permissions_rp_id);
+
+        let pin_uv_auth_token = shared_secret.encrypt(
+            env,
+            self.get_pin_protocol(pin_uv_auth_protocol)
+                .get_pin_uv_auth_token(),
+        )?;
+
+        Ok(AuthenticatorClientPinResponse {
+            key_agreement: None,
+            pin_uv_auth_token: Some(pin_uv_auth_token),
+            retries: None,
+            power_cycle_state: None,
+            uv_retries: None,
+        })
     }
 
-    fn process_get_uv_retries(&self) -> CtapResult<AuthenticatorClientPinResponse> {
-        // User verification is only supported through PIN currently.
-        Err(Ctap2StatusCode::CTAP2_ERR_INVALID_SUBCOMMAND)
+    pub fn perform_built_in_uv(
+        &self,
+        env: &mut E,
+        channel: Channel,
+        internal_retry: bool,
+    ) -> CtapResult<()> {
+        // Create helper function so we can clear LEDs after trying the
+        // fingerprint potentially multiple times.
+        fn check_fingerprint_loop<E: Env>(
+            env: &mut E,
+            channel: Channel,
+            internal_retry: bool,
+        ) -> Result<(), Ctap2StatusCode> {
+            // How long we give the user to touch the device before returning
+            // `CTAP2_ERR_USER_ACTION_TIMEOUT`.
+            const UV_TIMEOUT_MS: usize = 10000;
+            // How long we wait for the fingerprint sensor on each iteration.
+            const FINGERPRINT_TIMEOUT_MS: usize = 500;
+            // How many iterations we need to get the full UV timeout time.
+            const FINGERPRINT_TIMEOUT_LOOPS: usize = UV_TIMEOUT_MS / FINGERPRINT_TIMEOUT_MS;
+
+            // Keep track of the number of times the fingerprint detection timed
+            // out. If this happens too many times we need to return with
+            // `CTAP2_ERR_USER_ACTION_TIMEOUT`.
+            let mut timeouts = 0;
+
+            let mut attempts_before_returning = if internal_retry {
+                env.customization().max_uv_attempts_for_internal_retries()
+            } else {
+                1
+            };
+
+            while attempts_before_returning > 0 {
+                // If uvRetries <= 0 then return error.
+                storage::uv_retries(env).and_then(|retries| {
+                    if retries == 0 {
+                        Err(Ctap2StatusCode::CTAP2_ERR_UV_BLOCKED)
+                    } else {
+                        Ok(())
+                    }
+                })?;
+
+                // Decrement the uvRetries counter by 1.
+                let _ = storage::decr_uv_retries(env);
+
+                // Decrement attemptsBeforeReturning by 1.
+                attempts_before_returning -= 1;
+
+                // We need to give the user time to touch the device during UV.
+                // Also, on Windows, it seems we need to send KEEPALIVEs to
+                // avoid timeouts, so we need to do the check incrementally.
+                //
+                // The total timeout is specified this way in the spec:
+                //
+                // > This refers to a timeout that occurs when the authenticator
+                // > is waiting for direct action from the user, like a touch.
+                // > (I.e. not a command from the platform.) The duration of
+                // > this timeout is chosen by the authenticator but MUST be at
+                // > least 10 seconds. Thirty seconds is a reasonable value.
+                while timeouts < FINGERPRINT_TIMEOUT_LOOPS {
+                    // Perform built-in user verification.
+                    match env.fingerprint().check_fingerprint(FINGERPRINT_TIMEOUT_MS) {
+                        Ok(_finger_index) => {
+                            // set the uvRetries counter to maxUvRetries
+                            let _ = storage::reset_uv_retries(env);
+
+                            return Ok(());
+                        }
+                        Err(e) => {
+                            // Send a KEEPALIVE to avoid timeouts on Windows.
+                            crate::ctap::send_keepalive_packet(env, channel)?;
+
+                            match e {
+                                FingerprintCheckError::NoMatch | FingerprintCheckError::Other => {
+                                    // We got a fingerprint touch, but it was
+                                    // invalid. We break out of the timeouts
+                                    // loop.
+                                    break;
+                                }
+                                FingerprintCheckError::Timeout => {
+                                    timeouts += 1;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if timeouts >= FINGERPRINT_TIMEOUT_LOOPS {
+                    return Err(Ctap2StatusCode::CTAP2_ERR_USER_ACTION_TIMEOUT);
+                }
+            }
+
+            Err(Ctap2StatusCode::CTAP2_ERR_UV_INVALID)
+        }
+
+        env.fingerprint().check_fingerprint_init();
+        let res = check_fingerprint_loop(env, channel, internal_retry);
+        env.fingerprint().check_fingerprint_complete();
+        res
+    }
+
+    fn process_get_uv_retries(&self, env: &mut E) -> CtapResult<AuthenticatorClientPinResponse> {
+        debug_ctap!(env, "CP:  process_get_uv_retries");
+
+        Ok(AuthenticatorClientPinResponse {
+            key_agreement: None,
+            pin_uv_auth_token: None,
+            retries: None,
+            power_cycle_state: None,
+            uv_retries: Some(storage::uv_retries(env)? as u64),
+        })
     }
 
     fn process_get_pin_uv_auth_token_using_pin_with_permissions(
@@ -397,6 +592,7 @@ impl<E: Env> ClientPin<E> {
         &mut self,
         env: &mut E,
         client_pin_params: AuthenticatorClientPinParameters,
+        channel: Channel,
     ) -> CtapResult<ResponseData> {
         if !env.customization().allows_pin_protocol_v1()
             && client_pin_params.pin_uv_auth_protocol == PinUvAuthProtocol::V1
@@ -420,9 +616,13 @@ impl<E: Env> ClientPin<E> {
                 Some(self.process_get_pin_token(env, client_pin_params)?)
             }
             ClientPinSubCommand::GetPinUvAuthTokenUsingUvWithPermissions => Some(
-                self.process_get_pin_uv_auth_token_using_uv_with_permissions(client_pin_params)?,
+                self.process_get_pin_uv_auth_token_using_uv_with_permissions(
+                    env,
+                    client_pin_params,
+                    channel,
+                )?,
             ),
-            ClientPinSubCommand::GetUvRetries => Some(self.process_get_uv_retries()?),
+            ClientPinSubCommand::GetUvRetries => Some(self.process_get_uv_retries(env)?),
             ClientPinSubCommand::GetPinUvAuthTokenUsingPinWithPermissions => Some(
                 self.process_get_pin_uv_auth_token_using_pin_with_permissions(
                     env,

--- a/libraries/opensk/src/ctap/client_pin.rs
+++ b/libraries/opensk/src/ctap/client_pin.rs
@@ -16,22 +16,21 @@ use super::command::AuthenticatorClientPinParameters;
 use super::data_formats::{
     ok_or_missing, ClientPinSubCommand, CoseKey, GetAssertionHmacSecretInput, PinUvAuthProtocol,
 };
+#[cfg(feature = "fingerprint")]
+use super::fingerprint::perform_built_in_uv;
 use super::pin_protocol::{verify_pin_uv_auth_token, PinProtocol, SharedSecret};
 use super::response::{AuthenticatorClientPinResponse, ResponseData};
 use super::secret::Secret;
-use super::status_code::Ctap2StatusCode;
+use super::status_code::{Ctap2StatusCode, CtapResult};
 use super::token_state::PinUvAuthTokenState;
-use super::Channel;
+use super::{storage, Channel};
 #[cfg(test)]
 use crate::api::crypto::ecdh::SecretKey as _;
 use crate::api::crypto::hmac256::Hmac256;
 use crate::api::crypto::sha256::Sha256;
 use crate::api::customization::Customization;
-use crate::api::fingerprint::{Fingerprint, FingerprintCheckError};
 use crate::api::key_store::KeyStore;
 use crate::api::persist::Persist;
-use crate::ctap::status_code::CtapResult;
-use crate::ctap::storage;
 #[cfg(test)]
 use crate::env::EcdhSk;
 use crate::env::{Env, Hmac, Sha};
@@ -118,9 +117,9 @@ pub enum PinPermission {
     MakeCredential = 0x01,
     GetAssertion = 0x02,
     CredentialManagement = 0x04,
-    _BioEnrollment = 0x08,
+    #[cfg(feature = "fingerprint")]
+    BioEnrollment = 0x08,
     LargeBlobWrite = 0x10,
-    #[cfg(feature = "config_command")]
     AuthenticatorConfiguration = 0x20,
 }
 
@@ -216,6 +215,8 @@ impl<E: Env> ClientPin<E> {
             None => return Err(Ctap2StatusCode::CTAP2_ERR_PUAT_REQUIRED),
         }
         storage::reset_pin_retries(env)?;
+        #[cfg(feature = "fingerprint")]
+        storage::reset_uv_retries(env)?;
         self.consecutive_pin_mismatches = 0;
         Ok(())
     }
@@ -346,9 +347,6 @@ impl<E: Env> ClientPin<E> {
                 .get_pin_uv_auth_token(),
         )?;
 
-        // Because using a PIN succeeded, we can clear the UV retry counter.
-        let _ = storage::reset_uv_retries(env);
-
         Ok(AuthenticatorClientPinResponse {
             key_agreement: None,
             pin_uv_auth_token: Some(pin_uv_auth_token),
@@ -358,6 +356,7 @@ impl<E: Env> ClientPin<E> {
         })
     }
 
+    #[cfg(feature = "fingerprint")]
     fn process_get_pin_uv_auth_token_using_uv_with_permissions(
         &mut self,
         env: &mut E,
@@ -372,71 +371,47 @@ impl<E: Env> ClientPin<E> {
             ..
         } = client_pin_params;
         let key_agreement = ok_or_missing(key_agreement)?;
+        let permissions = permissions.ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?;
 
-        // If the authenticator does not receive mandatory parameters for this
-        // command, it returns CTAP2_ERR_MISSING_PARAMETER error.
-        if permissions.is_none() {
-            debug_ctap!(env, "CP: getPinUvAuthUv no  permissions",);
+        if permissions == 0 {
+            return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
         }
-        let permissions_bitfield =
-            permissions.ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?;
-
-        // If the authenticator receives a permissions parameter with value 0,
-        // return CTAP1_ERR_INVALID_PARAMETER.
-        if permissions_bitfield == 0 {
+        // Since credMgmt, uvBioEnroll and largeBlobs are always true in the options,
+        // we only have to check uvAcfg for step 3.4 in CTAP 2.2.
+        // TODO implement perCredMgmtRO
+        #[cfg(not(feature = "config_command"))]
+        if permissions & PinPermission::AuthenticatorConfiguration as u8 > 0 {
+            return Err(Ctap2StatusCode::CTAP2_ERR_UNAUTHORIZED_PERMISSION);
+        }
+        // This check is not mentioned protocol steps, but mentioned in a side note.
+        // Unsure if this is intended by the specification, so I'll keep it strict for now.
+        let mc_gw_permission =
+            PinPermission::MakeCredential as u8 | PinPermission::GetAssertion as u8;
+        if permissions & mc_gw_permission != 0 && permissions_rp_id.is_none() {
             return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
         }
 
-        // For each pinUvAuthToken permission present in the permissions
-        // parameter, if the statement corresponding to the permission is
-        // currently true, terminate these steps and return
-        // CTAP2_ERR_UNAUTHORIZED_PERMISSION.
-        // - cm: credMgmt is false or absent.
-        // - be: uvBioEnroll is false or absent.
-        // - lbw: largeBlobs is false or absent.
-        // - acfg: uvAcfg is false or absent.
-        //
-        // We set the credMgmt, uvBioEnroll, and largeBlobs options to true, so
-        // we only need to check for acfg.
-        #[cfg(feature = "config_command")]
-        if permissions_bitfield & PinPermission::AuthenticatorConfiguration as u8 > 0 {
-            return Err(Ctap2StatusCode::CTAP2_ERR_UNAUTHORIZED_PERMISSION);
-        }
-
         let internal_retry = env.customization().preferred_platform_uv_attempts() == 1;
-        self.perform_built_in_uv(env, channel, internal_retry)?;
+        perform_built_in_uv(env, channel, internal_retry)?;
 
         let shared_secret = self.get_shared_secret(pin_uv_auth_protocol, key_agreement)?;
         if env.persist().has_force_pin_change()? {
             return Err(Ctap2StatusCode::CTAP2_ERR_PIN_INVALID);
         }
 
-        // Create a new pinUvAuthToken by calling resetPinUvAuthToken() for all
-        // pinUvAuthProtocols supported by this authenticator.
         self.pin_protocol_v1.reset_pin_uv_auth_token(env);
         self.pin_protocol_v2.reset_pin_uv_auth_token(env);
-
-        // If the employed built-in user verification method supplied evidence
-        // of user interaction, then call
-        // beginUsingPinUvAuthToken(userIsPresent: true).
         self.pin_uv_auth_token_state
             .begin_using_pin_uv_auth_token(env);
-
-        // Assign the requested permissions to the pinUvAuthToken, ignoring any
-        // undefined permissions.
-        self.pin_uv_auth_token_state
-            .set_permissions(permissions_bitfield);
-
-        // If the rpId parameter is present, use its value as the permissions RP
-        // ID and associate it with the pinUvAuthToken.
-        self.pin_uv_auth_token_state
-            .set_permissions_rp_id(permissions_rp_id);
-
         let pin_uv_auth_token = shared_secret.encrypt(
             env,
             self.get_pin_protocol(pin_uv_auth_protocol)
                 .get_pin_uv_auth_token(),
         )?;
+
+        self.pin_uv_auth_token_state.set_permissions(permissions);
+        self.pin_uv_auth_token_state
+            .set_permissions_rp_id(permissions_rp_id);
 
         Ok(AuthenticatorClientPinResponse {
             key_agreement: None,
@@ -447,110 +422,18 @@ impl<E: Env> ClientPin<E> {
         })
     }
 
-    pub fn perform_built_in_uv(
-        &self,
-        env: &mut E,
-        channel: Channel,
-        internal_retry: bool,
-    ) -> CtapResult<()> {
-        // Create helper function so we can clear LEDs after trying the
-        // fingerprint potentially multiple times.
-        fn check_fingerprint_loop<E: Env>(
-            env: &mut E,
-            channel: Channel,
-            internal_retry: bool,
-        ) -> Result<(), Ctap2StatusCode> {
-            // How long we give the user to touch the device before returning
-            // `CTAP2_ERR_USER_ACTION_TIMEOUT`.
-            const UV_TIMEOUT_MS: usize = 10000;
-            // How long we wait for the fingerprint sensor on each iteration.
-            const FINGERPRINT_TIMEOUT_MS: usize = 500;
-            // How many iterations we need to get the full UV timeout time.
-            const FINGERPRINT_TIMEOUT_LOOPS: usize = UV_TIMEOUT_MS / FINGERPRINT_TIMEOUT_MS;
-
-            // Keep track of the number of times the fingerprint detection timed
-            // out. If this happens too many times we need to return with
-            // `CTAP2_ERR_USER_ACTION_TIMEOUT`.
-            let mut timeouts = 0;
-
-            let mut attempts_before_returning = if internal_retry {
-                env.customization().max_uv_attempts_for_internal_retries()
-            } else {
-                1
-            };
-
-            while attempts_before_returning > 0 {
-                // If uvRetries <= 0 then return error.
-                storage::uv_retries(env).and_then(|retries| {
-                    if retries == 0 {
-                        Err(Ctap2StatusCode::CTAP2_ERR_UV_BLOCKED)
-                    } else {
-                        Ok(())
-                    }
-                })?;
-
-                // Decrement the uvRetries counter by 1.
-                let _ = storage::decr_uv_retries(env);
-
-                // Decrement attemptsBeforeReturning by 1.
-                attempts_before_returning -= 1;
-
-                // We need to give the user time to touch the device during UV.
-                // Also, on Windows, it seems we need to send KEEPALIVEs to
-                // avoid timeouts, so we need to do the check incrementally.
-                //
-                // The total timeout is specified this way in the spec:
-                //
-                // > This refers to a timeout that occurs when the authenticator
-                // > is waiting for direct action from the user, like a touch.
-                // > (I.e. not a command from the platform.) The duration of
-                // > this timeout is chosen by the authenticator but MUST be at
-                // > least 10 seconds. Thirty seconds is a reasonable value.
-                while timeouts < FINGERPRINT_TIMEOUT_LOOPS {
-                    // Perform built-in user verification.
-                    match env.fingerprint().check_fingerprint(FINGERPRINT_TIMEOUT_MS) {
-                        Ok(_finger_index) => {
-                            // set the uvRetries counter to maxUvRetries
-                            let _ = storage::reset_uv_retries(env);
-
-                            return Ok(());
-                        }
-                        Err(e) => {
-                            // Send a KEEPALIVE to avoid timeouts on Windows.
-                            crate::ctap::send_keepalive_packet(env, channel)?;
-
-                            match e {
-                                FingerprintCheckError::NoMatch | FingerprintCheckError::Other => {
-                                    // We got a fingerprint touch, but it was
-                                    // invalid. We break out of the timeouts
-                                    // loop.
-                                    break;
-                                }
-                                FingerprintCheckError::Timeout => {
-                                    timeouts += 1;
-                                }
-                            }
-                        }
-                    }
-                }
-
-                if timeouts >= FINGERPRINT_TIMEOUT_LOOPS {
-                    return Err(Ctap2StatusCode::CTAP2_ERR_USER_ACTION_TIMEOUT);
-                }
-            }
-
-            Err(Ctap2StatusCode::CTAP2_ERR_UV_INVALID)
-        }
-
-        env.fingerprint().check_fingerprint_init();
-        let res = check_fingerprint_loop(env, channel, internal_retry);
-        env.fingerprint().check_fingerprint_complete();
-        res
+    #[cfg(not(feature = "fingerprint"))]
+    fn process_get_pin_uv_auth_token_using_uv_with_permissions(
+        &mut self,
+        _env: &mut E,
+        _client_pin_params: AuthenticatorClientPinParameters,
+        _channel: Channel,
+    ) -> CtapResult<AuthenticatorClientPinResponse> {
+        Err(Ctap2StatusCode::CTAP2_ERR_INVALID_SUBCOMMAND)
     }
 
+    #[cfg(feature = "fingerprint")]
     fn process_get_uv_retries(&self, env: &mut E) -> CtapResult<AuthenticatorClientPinResponse> {
-        debug_ctap!(env, "CP:  process_get_uv_retries");
-
         Ok(AuthenticatorClientPinResponse {
             key_agreement: None,
             pin_uv_auth_token: None,
@@ -558,6 +441,11 @@ impl<E: Env> ClientPin<E> {
             power_cycle_state: None,
             uv_retries: Some(storage::uv_retries(env)? as u64),
         })
+    }
+
+    #[cfg(not(feature = "fingerprint"))]
+    fn process_get_uv_retries(&self, _env: &mut E) -> CtapResult<AuthenticatorClientPinResponse> {
+        Err(Ctap2StatusCode::CTAP2_ERR_INVALID_SUBCOMMAND)
     }
 
     fn process_get_pin_uv_auth_token_using_pin_with_permissions(
@@ -574,8 +462,19 @@ impl<E: Env> ClientPin<E> {
         if permissions == 0 {
             return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
         }
+        // Since credMgmt, uvBioEnroll and largeBlobs are always true in the options,
+        // and noMcGaPermissionsWithClientPin and noMcGaPermissionsWithClientPin are both false,
+        // we only have to check uvAcfg for step 3.4 in CTAP 2.2.
+        // TODO implement perCredMgmtRO
+        #[cfg(not(feature = "config_command"))]
+        if permissions & PinPermission::AuthenticatorConfiguration as u8 > 0 {
+            return Err(Ctap2StatusCode::CTAP2_ERR_UNAUTHORIZED_PERMISSION);
+        }
         // This check is not mentioned protocol steps, but mentioned in a side note.
-        if permissions & 0x03 != 0 && permissions_rp_id.is_none() {
+        // Unsure if this is intended by the specification, so I'll keep it strict for now.
+        let mc_gw_permission =
+            PinPermission::MakeCredential as u8 | PinPermission::GetAssertion as u8;
+        if permissions & mc_gw_permission != 0 && permissions_rp_id.is_none() {
             return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
         }
 
@@ -801,9 +700,14 @@ mod test {
     use super::super::pin_protocol::authenticate_pin_uv_auth_token;
     use super::*;
     use crate::api::crypto::HASH_SIZE;
+    #[cfg(feature = "fingerprint")]
+    use crate::api::fingerprint::Fingerprint;
     use crate::env::test::TestEnv;
     use crate::env::EcdhSk;
     use alloc::vec;
+
+    // Dummy channel to send keepalives on.
+    const DUMMY_CHANNEL: Channel = Channel::MainHid([0x12, 0x34, 0x56, 0x78]);
 
     /// Stores a PIN hash corresponding to the dummy PIN "1234".
     fn set_standard_pin(env: &mut TestEnv) {
@@ -1026,9 +930,10 @@ mod test {
             pin_uv_auth_token: None,
             retries: Some(storage::pin_retries(&mut env).unwrap() as u64),
             power_cycle_state: Some(false),
+            uv_retries: None,
         });
         assert_eq!(
-            client_pin.process_command(&mut env, params.clone()),
+            client_pin.process_command(&mut env, params.clone(), DUMMY_CHANNEL),
             Ok(ResponseData::AuthenticatorClientPin(expected_response))
         );
 
@@ -1038,9 +943,10 @@ mod test {
             pin_uv_auth_token: None,
             retries: Some(storage::pin_retries(&mut env).unwrap() as u64),
             power_cycle_state: Some(true),
+            uv_retries: None,
         });
         assert_eq!(
-            client_pin.process_command(&mut env, params),
+            client_pin.process_command(&mut env, params, DUMMY_CHANNEL),
             Ok(ResponseData::AuthenticatorClientPin(expected_response))
         );
     }
@@ -1066,9 +972,10 @@ mod test {
             pin_uv_auth_token: None,
             retries: None,
             power_cycle_state: None,
+            uv_retries: None,
         });
         assert_eq!(
-            client_pin.process_command(&mut env, params),
+            client_pin.process_command(&mut env, params, DUMMY_CHANNEL),
             Ok(ResponseData::AuthenticatorClientPin(expected_response))
         );
     }
@@ -1092,7 +999,7 @@ mod test {
         let mut env = TestEnv::default();
         env.customization_mut().set_allows_pin_protocol_v1(false);
         assert_eq!(
-            client_pin.process_command(&mut env, params),
+            client_pin.process_command(&mut env, params, DUMMY_CHANNEL),
             Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER)
         );
     }
@@ -1102,7 +1009,7 @@ mod test {
             create_client_pin_and_parameters(pin_uv_auth_protocol, ClientPinSubCommand::SetPin);
         let mut env = TestEnv::default();
         assert_eq!(
-            client_pin.process_command(&mut env, params),
+            client_pin.process_command(&mut env, params, DUMMY_CHANNEL),
             Ok(ResponseData::AuthenticatorClientPin(None))
         );
     }
@@ -1135,14 +1042,14 @@ mod test {
         let pin_uv_auth_param = shared_secret.authenticate(&auth_param_data);
         params.pin_uv_auth_param = Some(pin_uv_auth_param);
         assert_eq!(
-            client_pin.process_command(&mut env, params.clone()),
+            client_pin.process_command(&mut env, params.clone(), DUMMY_CHANNEL),
             Ok(ResponseData::AuthenticatorClientPin(None))
         );
 
         let mut bad_params = params.clone();
         bad_params.pin_hash_enc = Some(vec![0xEE; 16]);
         assert_eq!(
-            client_pin.process_command(&mut env, bad_params),
+            client_pin.process_command(&mut env, bad_params, DUMMY_CHANNEL),
             Err(Ctap2StatusCode::CTAP2_ERR_PIN_AUTH_INVALID)
         );
 
@@ -1150,7 +1057,7 @@ mod test {
             storage::decr_pin_retries(&mut env).unwrap();
         }
         assert_eq!(
-            client_pin.process_command(&mut env, params),
+            client_pin.process_command(&mut env, params, DUMMY_CHANNEL),
             Err(Ctap2StatusCode::CTAP2_ERR_PIN_BLOCKED)
         );
     }
@@ -1181,7 +1088,7 @@ mod test {
         set_standard_pin(&mut env);
 
         let response = client_pin
-            .process_command(&mut env, params.clone())
+            .process_command(&mut env, params.clone(), DUMMY_CHANNEL)
             .unwrap();
         let encrypted_token = match response {
             ResponseData::AuthenticatorClientPin(Some(response)) => {
@@ -1217,7 +1124,7 @@ mod test {
         let mut bad_params = params;
         bad_params.pin_hash_enc = Some(vec![0xEE; 16]);
         assert_eq!(
-            client_pin.process_command(&mut env, bad_params),
+            client_pin.process_command(&mut env, bad_params, DUMMY_CHANNEL),
             Err(Ctap2StatusCode::CTAP2_ERR_PIN_INVALID)
         );
     }
@@ -1242,7 +1149,7 @@ mod test {
 
         assert_eq!(env.persist().force_pin_change(), Ok(()));
         assert_eq!(
-            client_pin.process_command(&mut env, params),
+            client_pin.process_command(&mut env, params, DUMMY_CHANNEL),
             Err(Ctap2StatusCode::CTAP2_ERR_PIN_INVALID),
         );
     }
@@ -1257,12 +1164,13 @@ mod test {
         test_helper_process_get_pin_token_force_pin_change(PinUvAuthProtocol::V2);
     }
 
-    fn test_helper_process_get_pin_uv_auth_token_using_pin_with_permissions(
+    #[cfg(feature = "fingerprint")]
+    fn test_helper_process_get_pin_uv_auth_token_using_uv_with_permissions(
         pin_uv_auth_protocol: PinUvAuthProtocol,
     ) {
         let (mut client_pin, params) = create_client_pin_and_parameters(
             pin_uv_auth_protocol,
-            ClientPinSubCommand::GetPinUvAuthTokenUsingPinWithPermissions,
+            ClientPinSubCommand::GetPinUvAuthTokenUsingUvWithPermissions,
         );
         let shared_secret = client_pin
             .get_pin_protocol(pin_uv_auth_protocol)
@@ -1273,9 +1181,11 @@ mod test {
             .unwrap();
         let mut env = TestEnv::default();
         set_standard_pin(&mut env);
+        let template_id = env.fingerprint().prepare_enrollment().unwrap();
+        let _ = env.fingerprint().capture_sample(&template_id, Some(30_000));
 
         let response = client_pin
-            .process_command(&mut env, params.clone())
+            .process_command(&mut env, params.clone(), DUMMY_CHANNEL)
             .unwrap();
         let encrypted_token = match response {
             ResponseData::AuthenticatorClientPin(Some(response)) => {
@@ -1311,21 +1221,131 @@ mod test {
         let mut bad_params = params.clone();
         bad_params.permissions = Some(0x00);
         assert_eq!(
-            client_pin.process_command(&mut env, bad_params),
+            client_pin.process_command(&mut env, bad_params, DUMMY_CHANNEL),
+            Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER)
+        );
+
+        let mut bad_params = params;
+        bad_params.permissions_rp_id = None;
+        assert_eq!(
+            client_pin.process_command(&mut env, bad_params, DUMMY_CHANNEL),
+            Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER)
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "fingerprint")]
+    fn test_process_get_pin_uv_auth_token_using_uv_with_permissions_v1() {
+        test_helper_process_get_pin_uv_auth_token_using_uv_with_permissions(PinUvAuthProtocol::V1);
+    }
+
+    #[test]
+    #[cfg(feature = "fingerprint")]
+    fn test_process_get_pin_uv_auth_token_using_uv_with_permissions_v2() {
+        test_helper_process_get_pin_uv_auth_token_using_uv_with_permissions(PinUvAuthProtocol::V2);
+    }
+
+    #[cfg(feature = "fingerprint")]
+    fn test_helper_process_get_uv_retries(pin_uv_auth_protocol: PinUvAuthProtocol) {
+        let (mut client_pin, params) = create_client_pin_and_parameters(
+            pin_uv_auth_protocol,
+            ClientPinSubCommand::GetUvRetries,
+        );
+        let mut env = TestEnv::default();
+        let expected_response = Some(AuthenticatorClientPinResponse {
+            key_agreement: None,
+            pin_uv_auth_token: None,
+            retries: None,
+            power_cycle_state: None,
+            uv_retries: Some(storage::uv_retries(&mut env).unwrap() as u64),
+        });
+        assert_eq!(
+            client_pin.process_command(&mut env, params.clone(), DUMMY_CHANNEL),
+            Ok(ResponseData::AuthenticatorClientPin(expected_response))
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "fingerprint")]
+    fn test_process_get_uv_retries_v1() {
+        test_helper_process_get_uv_retries(PinUvAuthProtocol::V1);
+    }
+
+    #[test]
+    #[cfg(feature = "fingerprint")]
+    fn test_process_get_uv_retries_v2() {
+        test_helper_process_get_uv_retries(PinUvAuthProtocol::V2);
+    }
+
+    fn test_helper_process_get_pin_uv_auth_token_using_pin_with_permissions(
+        pin_uv_auth_protocol: PinUvAuthProtocol,
+    ) {
+        let (mut client_pin, params) = create_client_pin_and_parameters(
+            pin_uv_auth_protocol,
+            ClientPinSubCommand::GetPinUvAuthTokenUsingPinWithPermissions,
+        );
+        let shared_secret = client_pin
+            .get_pin_protocol(pin_uv_auth_protocol)
+            .decapsulate(
+                params.key_agreement.clone().unwrap(),
+                params.pin_uv_auth_protocol,
+            )
+            .unwrap();
+        let mut env = TestEnv::default();
+        set_standard_pin(&mut env);
+
+        let response = client_pin
+            .process_command(&mut env, params.clone(), DUMMY_CHANNEL)
+            .unwrap();
+        let encrypted_token = match response {
+            ResponseData::AuthenticatorClientPin(Some(response)) => {
+                response.pin_uv_auth_token.unwrap()
+            }
+            _ => panic!("Invalid response type"),
+        };
+        assert_eq!(
+            &*shared_secret.decrypt(&encrypted_token).unwrap(),
+            client_pin
+                .get_pin_protocol(pin_uv_auth_protocol)
+                .get_pin_uv_auth_token()
+        );
+        assert_eq!(
+            client_pin
+                .pin_uv_auth_token_state
+                .has_permission(PinPermission::MakeCredential),
+            Ok(())
+        );
+        assert_eq!(
+            client_pin
+                .pin_uv_auth_token_state
+                .has_permission(PinPermission::GetAssertion),
+            Ok(())
+        );
+        assert_eq!(
+            client_pin
+                .pin_uv_auth_token_state
+                .has_permissions_rp_id("example.com"),
+            Ok(())
+        );
+
+        let mut bad_params = params.clone();
+        bad_params.permissions = Some(0x00);
+        assert_eq!(
+            client_pin.process_command(&mut env, bad_params, DUMMY_CHANNEL),
             Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER)
         );
 
         let mut bad_params = params.clone();
         bad_params.permissions_rp_id = None;
         assert_eq!(
-            client_pin.process_command(&mut env, bad_params),
+            client_pin.process_command(&mut env, bad_params, DUMMY_CHANNEL),
             Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER)
         );
 
         let mut bad_params = params;
         bad_params.pin_hash_enc = Some(vec![0xEE; 16]);
         assert_eq!(
-            client_pin.process_command(&mut env, bad_params),
+            client_pin.process_command(&mut env, bad_params, DUMMY_CHANNEL),
             Err(Ctap2StatusCode::CTAP2_ERR_PIN_INVALID)
         );
     }
@@ -1352,7 +1372,7 @@ mod test {
 
         assert_eq!(env.persist().force_pin_change(), Ok(()));
         assert_eq!(
-            client_pin.process_command(&mut env, params),
+            client_pin.process_command(&mut env, params, DUMMY_CHANNEL),
             Err(Ctap2StatusCode::CTAP2_ERR_PIN_INVALID)
         );
     }
@@ -1841,7 +1861,9 @@ mod test {
         set_standard_pin(&mut env);
         params.permissions = Some(0xFF);
 
-        assert!(client_pin.process_command(&mut env, params).is_ok());
+        assert!(client_pin
+            .process_command(&mut env, params, DUMMY_CHANNEL)
+            .is_ok());
         for permission in PinPermission::into_enum_iter() {
             assert_eq!(
                 client_pin
@@ -1886,8 +1908,16 @@ mod test {
         let mut env = TestEnv::default();
         set_standard_pin(&mut env);
         params.permissions = Some(0xFF);
+        #[cfg(not(feature = "config_command"))]
+        {
+            params.permissions = params
+                .permissions
+                .map(|p| p & !(PinPermission::AuthenticatorConfiguration as u8));
+        }
 
-        assert!(client_pin.process_command(&mut env, params).is_ok());
+        assert!(client_pin
+            .process_command(&mut env, params, DUMMY_CHANNEL)
+            .is_ok());
         for permission in PinPermission::into_enum_iter() {
             assert_eq!(
                 client_pin

--- a/libraries/opensk/src/ctap/command.rs
+++ b/libraries/opensk/src/ctap/command.rs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 use super::cbor_read;
+#[cfg(feature = "fingerprint")]
+use super::data_formats::extract_bool;
 use super::data_formats::{
-    extract_array, extract_bool, extract_byte_string, extract_map, extract_text_string,
-    extract_unsigned, ok_or_missing, ClientPinSubCommand, CoseKey, CredentialManagementSubCommand,
+    extract_array, extract_byte_string, extract_map, extract_text_string, extract_unsigned,
+    ok_or_missing, ClientPinSubCommand, CoseKey, CredentialManagementSubCommand,
     CredentialManagementSubCommandParameters, GetAssertionExtensions, GetAssertionOptions,
     MakeCredentialExtensions, MakeCredentialOptions, PinUvAuthProtocol,
     PublicKeyCredentialDescriptor, PublicKeyCredentialParameter, PublicKeyCredentialRpEntity,
@@ -30,7 +32,11 @@ use alloc::vec::Vec;
 #[cfg(feature = "fuzz")]
 use arbitrary::Arbitrary;
 use core::convert::TryFrom;
+#[cfg(all(test, feature = "fingerprint"))]
+use enum_iterator::IntoEnumIterator;
 use sk_cbor as cbor;
+#[cfg(feature = "fingerprint")]
+use sk_cbor::cbor_map_options;
 use sk_cbor::destructure_cbor_map;
 
 // CTAP specification (version 20190130) section 6.1
@@ -43,6 +49,7 @@ pub enum Command {
     AuthenticatorClientPin(AuthenticatorClientPinParameters),
     AuthenticatorReset,
     AuthenticatorGetNextAssertion,
+    #[cfg(feature = "fingerprint")]
     AuthenticatorBioEnrollment(AuthenticatorBioEnrollmentParameters),
     AuthenticatorCredentialManagement(AuthenticatorCredentialManagementParameters),
     AuthenticatorSelection,
@@ -58,7 +65,7 @@ impl Command {
     const AUTHENTICATOR_CLIENT_PIN: u8 = 0x06;
     const AUTHENTICATOR_RESET: u8 = 0x07;
     const AUTHENTICATOR_GET_NEXT_ASSERTION: u8 = 0x08;
-    // Implement Bio Enrollment when your hardware supports biometrics.
+    #[cfg(feature = "fingerprint")]
     const AUTHENTICATOR_BIO_ENROLLMENT: u8 = 0x09;
     const AUTHENTICATOR_CREDENTIAL_MANAGEMENT: u8 = 0x0A;
     const AUTHENTICATOR_SELECTION: u8 = 0x0B;
@@ -110,6 +117,7 @@ impl Command {
                 // Parameters are ignored.
                 Ok(Command::AuthenticatorGetNextAssertion)
             }
+            #[cfg(feature = "fingerprint")]
             Command::AUTHENTICATOR_BIO_ENROLLMENT => {
                 let decoded_cbor = cbor_read(&bytes[1..])?;
                 Ok(Command::AuthenticatorBioEnrollment(
@@ -142,49 +150,6 @@ impl Command {
             }
             _ => Err(Ctap2StatusCode::CTAP1_ERR_INVALID_COMMAND),
         }
-    }
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub struct AuthenticatorBioEnrollmentParameters {
-    pub modality: Option<u64>,
-    pub sub_command: Option<u64>,
-    pub sub_command_params: Option<cbor::Value>,
-    pub pin_protocol: Option<u64>,
-    pub pin_auth: Option<Vec<u8>>,
-    pub get_modality: Option<bool>,
-}
-
-impl TryFrom<cbor::Value> for AuthenticatorBioEnrollmentParameters {
-    type Error = Ctap2StatusCode;
-
-    fn try_from(cbor_value: cbor::Value) -> Result<Self, Self::Error> {
-        destructure_cbor_map! {
-            let {
-                0x01 => modality,
-                0x02 => sub_command,
-                0x03 => sub_command_params,
-                0x04 => pin_protocol,
-                0x05 => pin_auth,
-                0x06 => get_modality,
-            } = extract_map(cbor_value)?;
-        }
-
-        let modality = modality.map(extract_unsigned).transpose()?;
-        let sub_command = sub_command.map(extract_unsigned).transpose()?;
-        let sub_command_params = sub_command_params;
-        let pin_protocol = pin_protocol.map(extract_unsigned).transpose()?;
-        let pin_auth = pin_auth.map(extract_byte_string).transpose()?;
-        let get_modality = get_modality.map(extract_bool).transpose()?;
-
-        Ok(AuthenticatorBioEnrollmentParameters {
-            modality,
-            sub_command,
-            sub_command_params,
-            pin_protocol,
-            pin_auth,
-            get_modality,
-        })
     }
 }
 
@@ -408,6 +373,147 @@ impl TryFrom<cbor::Value> for AuthenticatorClientPinParameters {
     }
 }
 
+#[cfg(feature = "fingerprint")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AuthenticatorBioEnrollmentParameters {
+    pub modality: Option<u64>,
+    pub sub_command: Option<BioEnrollmentSubCommand>,
+    pub sub_command_params: Option<BioEnrollmentSubCommandParams>,
+    pub pin_uv_auth_protocol: Option<PinUvAuthProtocol>,
+    pub pin_uv_auth_param: Option<Vec<u8>>,
+    pub get_modality: Option<bool>,
+}
+
+#[cfg(feature = "fingerprint")]
+impl TryFrom<cbor::Value> for AuthenticatorBioEnrollmentParameters {
+    type Error = Ctap2StatusCode;
+
+    fn try_from(cbor_value: cbor::Value) -> Result<Self, Self::Error> {
+        destructure_cbor_map! {
+            let {
+                0x01 => modality,
+                0x02 => sub_command,
+                0x03 => sub_command_params,
+                0x04 => pin_uv_auth_protocol,
+                0x05 => pin_uv_auth_param,
+                0x06 => get_modality,
+            } = extract_map(cbor_value)?;
+        }
+
+        let modality = modality.map(extract_unsigned).transpose()?;
+        let sub_command = sub_command
+            .map(BioEnrollmentSubCommand::try_from)
+            .transpose()?;
+        let sub_command_params = sub_command_params
+            .map(BioEnrollmentSubCommandParams::try_from)
+            .transpose()?;
+        let pin_uv_auth_protocol = pin_uv_auth_protocol
+            .map(PinUvAuthProtocol::try_from)
+            .transpose()?;
+        let pin_uv_auth_param = pin_uv_auth_param.map(extract_byte_string).transpose()?;
+        let get_modality = get_modality.map(extract_bool).transpose()?;
+
+        Ok(AuthenticatorBioEnrollmentParameters {
+            modality,
+            sub_command,
+            sub_command_params,
+            pin_uv_auth_protocol,
+            pin_uv_auth_param,
+            get_modality,
+        })
+    }
+}
+
+#[cfg(feature = "fingerprint")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(test, derive(IntoEnumIterator))]
+pub enum BioEnrollmentSubCommand {
+    EnrollBegin = 0x01,
+    EnrollCaptureNextSample = 0x02,
+    CancelCurrentEnrollment = 0x03,
+    EnumerateEnrollments = 0x04,
+    SetFriendlyName = 0x05,
+    RemoveEnrollment = 0x06,
+    GetFingerprintSensorInfo = 0x07,
+}
+
+#[cfg(feature = "fingerprint")]
+impl From<BioEnrollmentSubCommand> for cbor::Value {
+    fn from(subcommand: BioEnrollmentSubCommand) -> Self {
+        (subcommand as u64).into()
+    }
+}
+
+#[cfg(feature = "fingerprint")]
+impl TryFrom<cbor::Value> for BioEnrollmentSubCommand {
+    type Error = Ctap2StatusCode;
+
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
+        let subcommand_int = extract_unsigned(cbor_value)?;
+        match subcommand_int {
+            0x01 => Ok(BioEnrollmentSubCommand::EnrollBegin),
+            0x02 => Ok(BioEnrollmentSubCommand::EnrollCaptureNextSample),
+            0x03 => Ok(BioEnrollmentSubCommand::CancelCurrentEnrollment),
+            0x04 => Ok(BioEnrollmentSubCommand::EnumerateEnrollments),
+            0x05 => Ok(BioEnrollmentSubCommand::SetFriendlyName),
+            0x06 => Ok(BioEnrollmentSubCommand::RemoveEnrollment),
+            0x07 => Ok(BioEnrollmentSubCommand::GetFingerprintSensorInfo),
+            _ => Err(Ctap2StatusCode::CTAP2_ERR_INVALID_SUBCOMMAND),
+        }
+    }
+}
+
+#[cfg(feature = "fingerprint")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BioEnrollmentSubCommandParams {
+    pub template_id: Option<Vec<u8>>,
+    pub template_friendly_name: Option<String>,
+    pub timeout_milliseconds: Option<usize>,
+}
+
+#[cfg(feature = "fingerprint")]
+impl TryFrom<cbor::Value> for BioEnrollmentSubCommandParams {
+    type Error = Ctap2StatusCode;
+
+    fn try_from(cbor_value: cbor::Value) -> Result<Self, Self::Error> {
+        destructure_cbor_map! {
+            let {
+                0x01 => template_id,
+                0x02 => template_friendly_name,
+                0x03 => timeout_milliseconds,
+            } = extract_map(cbor_value)?;
+        }
+
+        let template_id = template_id.map(extract_byte_string).transpose()?;
+        let template_friendly_name = template_friendly_name
+            .map(extract_text_string)
+            .transpose()?;
+        let timeout_milliseconds = timeout_milliseconds
+            .map(extract_unsigned)
+            .transpose()?
+            .map(usize::try_from)
+            .transpose()
+            .map_err(|_| Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER)?;
+
+        Ok(BioEnrollmentSubCommandParams {
+            template_id,
+            template_friendly_name,
+            timeout_milliseconds,
+        })
+    }
+}
+
+#[cfg(feature = "fingerprint")]
+impl From<BioEnrollmentSubCommandParams> for cbor::Value {
+    fn from(sub_command_params: BioEnrollmentSubCommandParams) -> Self {
+        cbor_map_options! {
+            0x01 => sub_command_params.template_id,
+            0x02 => sub_command_params.template_friendly_name,
+            0x03 => sub_command_params.timeout_milliseconds.map(|u| u as u64),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct AuthenticatorLargeBlobsParameters {
     pub get: Option<usize>,
@@ -561,6 +667,8 @@ mod test {
     };
     use super::super::ES256_CRED_PARAM;
     use super::*;
+    #[cfg(feature = "fingerprint")]
+    use cbor::cbor_int;
     use cbor::{cbor_array, cbor_map};
 
     #[test]
@@ -697,7 +805,6 @@ mod test {
             permissions: Some(0x03),
             permissions_rp_id: Some("example.com".to_string()),
         };
-
         assert_eq!(
             returned_client_pin_parameters,
             expected_client_pin_parameters
@@ -724,6 +831,81 @@ mod test {
         let cbor_bytes = [Command::AUTHENTICATOR_GET_NEXT_ASSERTION];
         let command = Command::deserialize(&cbor_bytes);
         assert_eq!(command, Ok(Command::AuthenticatorGetNextAssertion));
+    }
+
+    #[test]
+    #[cfg(feature = "fingerprint")]
+    fn test_from_cbor_bio_enrollment_parameters() {
+        let sub_command_params_cbor_value = cbor_map! {
+            0x01 => vec![0x01],
+            0x02 => "Name",
+            0x03 => 1000,
+        };
+        let cbor_value = cbor_map! {
+            0x01 => 1,
+            0x02 => BioEnrollmentSubCommand::EnrollBegin,
+            0x03 => sub_command_params_cbor_value,
+            0x04 => 1,
+            0x05 => vec![0xBB],
+            0x06 => true,
+        };
+        let returned_bio_enrollment_parameters =
+            AuthenticatorBioEnrollmentParameters::try_from(cbor_value).unwrap();
+
+        let expected_sub_command_params = BioEnrollmentSubCommandParams {
+            template_id: Some(vec![0x01]),
+            template_friendly_name: Some(String::from("Name")),
+            timeout_milliseconds: Some(1000),
+        };
+        let expected_bio_enrollment_parameters = AuthenticatorBioEnrollmentParameters {
+            modality: Some(1),
+            sub_command: Some(BioEnrollmentSubCommand::EnrollBegin),
+            sub_command_params: Some(expected_sub_command_params),
+            pin_uv_auth_protocol: Some(PinUvAuthProtocol::V1),
+            pin_uv_auth_param: Some(vec![0xBB]),
+            get_modality: Some(true),
+        };
+        assert_eq!(
+            returned_bio_enrollment_parameters,
+            expected_bio_enrollment_parameters
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "fingerprint")]
+    fn test_from_into_bio_enrollment_sub_command() {
+        let cbor_sub_command: cbor::Value = cbor_int!(0x01);
+        let sub_command = BioEnrollmentSubCommand::try_from(cbor_sub_command.clone());
+        let expected_sub_command = BioEnrollmentSubCommand::EnrollBegin;
+        assert_eq!(sub_command, Ok(expected_sub_command));
+        let created_cbor: cbor::Value = sub_command.unwrap().into();
+        assert_eq!(created_cbor, cbor_sub_command);
+
+        for command in BioEnrollmentSubCommand::into_enum_iter() {
+            let created_cbor: cbor::Value = command.clone().into();
+            let reconstructed = BioEnrollmentSubCommand::try_from(created_cbor).unwrap();
+            assert_eq!(command, reconstructed);
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "fingerprint")]
+    fn test_from_into_bio_enrollment_sub_command_params() {
+        let cbor_sub_command_params = cbor_map! {
+            0x01 => vec![0x1D; 32],
+            0x02 => "Name",
+            0x03 => 30_000,
+        };
+        let sub_command_params =
+            BioEnrollmentSubCommandParams::try_from(cbor_sub_command_params.clone());
+        let expected_sub_command_params = BioEnrollmentSubCommandParams {
+            template_id: Some(vec![0x1D; 32]),
+            template_friendly_name: Some(String::from("Name")),
+            timeout_milliseconds: Some(30_000),
+        };
+        assert_eq!(sub_command_params, Ok(expected_sub_command_params));
+        let created_cbor: cbor::Value = sub_command_params.unwrap().into();
+        assert_eq!(created_cbor, cbor_sub_command_params);
     }
 
     #[test]

--- a/libraries/opensk/src/ctap/command.rs
+++ b/libraries/opensk/src/ctap/command.rs
@@ -14,8 +14,8 @@
 
 use super::cbor_read;
 use super::data_formats::{
-    extract_array, extract_byte_string, extract_map, extract_text_string, extract_unsigned,
-    ok_or_missing, ClientPinSubCommand, CoseKey, CredentialManagementSubCommand,
+    extract_array, extract_bool, extract_byte_string, extract_map, extract_text_string,
+    extract_unsigned, ok_or_missing, ClientPinSubCommand, CoseKey, CredentialManagementSubCommand,
     CredentialManagementSubCommandParameters, GetAssertionExtensions, GetAssertionOptions,
     MakeCredentialExtensions, MakeCredentialOptions, PinUvAuthProtocol,
     PublicKeyCredentialDescriptor, PublicKeyCredentialParameter, PublicKeyCredentialRpEntity,
@@ -43,6 +43,7 @@ pub enum Command {
     AuthenticatorClientPin(AuthenticatorClientPinParameters),
     AuthenticatorReset,
     AuthenticatorGetNextAssertion,
+    AuthenticatorBioEnrollment(AuthenticatorBioEnrollmentParameters),
     AuthenticatorCredentialManagement(AuthenticatorCredentialManagementParameters),
     AuthenticatorSelection,
     AuthenticatorLargeBlobs(AuthenticatorLargeBlobsParameters),
@@ -58,7 +59,7 @@ impl Command {
     const AUTHENTICATOR_RESET: u8 = 0x07;
     const AUTHENTICATOR_GET_NEXT_ASSERTION: u8 = 0x08;
     // Implement Bio Enrollment when your hardware supports biometrics.
-    const _AUTHENTICATOR_BIO_ENROLLMENT: u8 = 0x09;
+    const AUTHENTICATOR_BIO_ENROLLMENT: u8 = 0x09;
     const AUTHENTICATOR_CREDENTIAL_MANAGEMENT: u8 = 0x0A;
     const AUTHENTICATOR_SELECTION: u8 = 0x0B;
     const AUTHENTICATOR_LARGE_BLOBS: u8 = 0x0C;
@@ -109,6 +110,12 @@ impl Command {
                 // Parameters are ignored.
                 Ok(Command::AuthenticatorGetNextAssertion)
             }
+            Command::AUTHENTICATOR_BIO_ENROLLMENT => {
+                let decoded_cbor = cbor_read(&bytes[1..])?;
+                Ok(Command::AuthenticatorBioEnrollment(
+                    AuthenticatorBioEnrollmentParameters::try_from(decoded_cbor)?,
+                ))
+            }
             Command::AUTHENTICATOR_CREDENTIAL_MANAGEMENT
             | Command::AUTHENTICATOR_VENDOR_CREDENTIAL_MANAGEMENT => {
                 let decoded_cbor = cbor_read(&bytes[1..])?;
@@ -135,6 +142,49 @@ impl Command {
             }
             _ => Err(Ctap2StatusCode::CTAP1_ERR_INVALID_COMMAND),
         }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct AuthenticatorBioEnrollmentParameters {
+    pub modality: Option<u64>,
+    pub sub_command: Option<u64>,
+    pub sub_command_params: Option<cbor::Value>,
+    pub pin_protocol: Option<u64>,
+    pub pin_auth: Option<Vec<u8>>,
+    pub get_modality: Option<bool>,
+}
+
+impl TryFrom<cbor::Value> for AuthenticatorBioEnrollmentParameters {
+    type Error = Ctap2StatusCode;
+
+    fn try_from(cbor_value: cbor::Value) -> Result<Self, Self::Error> {
+        destructure_cbor_map! {
+            let {
+                0x01 => modality,
+                0x02 => sub_command,
+                0x03 => sub_command_params,
+                0x04 => pin_protocol,
+                0x05 => pin_auth,
+                0x06 => get_modality,
+            } = extract_map(cbor_value)?;
+        }
+
+        let modality = modality.map(extract_unsigned).transpose()?;
+        let sub_command = sub_command.map(extract_unsigned).transpose()?;
+        let sub_command_params = sub_command_params;
+        let pin_protocol = pin_protocol.map(extract_unsigned).transpose()?;
+        let pin_auth = pin_auth.map(extract_byte_string).transpose()?;
+        let get_modality = get_modality.map(extract_bool).transpose()?;
+
+        Ok(AuthenticatorBioEnrollmentParameters {
+            modality,
+            sub_command,
+            sub_command_params,
+            pin_protocol,
+            pin_auth,
+            get_modality,
+        })
     }
 }
 

--- a/libraries/opensk/src/ctap/fingerprint.rs
+++ b/libraries/opensk/src/ctap/fingerprint.rs
@@ -119,8 +119,7 @@ fn check_fingerprint_loop<E: Env>(
     for _ in 0..FINGERPRINT_TIMEOUT_LOOPS {
         match env.fingerprint().check_fingerprint(FINGERPRINT_TIMEOUT_MS) {
             Ok(()) => {
-                storage::reset_uv_retries(env)?;
-                return Ok(());
+                return storage::reset_uv_retries(env);
             }
             Err(error) => {
                 match error {
@@ -328,17 +327,36 @@ mod test {
     #[test]
     fn test_perform_built_in_uv() {
         let mut env = TestEnv::default();
-        assert_eq!(
-            perform_built_in_uv(&mut env, DUMMY_CHANNEL, true),
-            Err(Ctap2StatusCode::CTAP2_ERR_UV_INVALID)
-        );
+        create_fingerprint(&mut env);
+        assert_eq!(perform_built_in_uv(&mut env, DUMMY_CHANNEL, true), Ok(()));
+        assert_eq!(perform_built_in_uv(&mut env, DUMMY_CHANNEL, false), Ok(()));
+    }
+
+    #[test]
+    fn test_perform_built_in_uv_unenrolled() {
+        let mut env = TestEnv::default();
         assert_eq!(
             perform_built_in_uv(&mut env, DUMMY_CHANNEL, false),
             Err(Ctap2StatusCode::CTAP2_ERR_UV_INVALID)
         );
-        create_fingerprint(&mut env);
-        assert_eq!(perform_built_in_uv(&mut env, DUMMY_CHANNEL, true), Ok(()));
-        assert_eq!(perform_built_in_uv(&mut env, DUMMY_CHANNEL, false), Ok(()));
+    }
+
+    #[test]
+    fn test_perform_built_in_uv_unenrolled_internal_retry() {
+        let mut env = TestEnv::default();
+        if env.customization().max_uv_attempts_for_internal_retries()
+            == env.customization().max_uv_retries()
+        {
+            assert_eq!(
+                perform_built_in_uv(&mut env, DUMMY_CHANNEL, true),
+                Err(Ctap2StatusCode::CTAP2_ERR_PIN_BLOCKED)
+            );
+        } else {
+            assert_eq!(
+                perform_built_in_uv(&mut env, DUMMY_CHANNEL, true),
+                Err(Ctap2StatusCode::CTAP2_ERR_UV_INVALID)
+            );
+        }
     }
 
     #[test]

--- a/libraries/opensk/src/ctap/fingerprint.rs
+++ b/libraries/opensk/src/ctap/fingerprint.rs
@@ -172,7 +172,7 @@ fn enroll_capture_next_sample<E: Env>(
     let (sample_status, remaining_samples) =
         env.fingerprint().capture_sample(&template_id, timeout_ms)?;
     if remaining_samples == 0 {
-        env.persist().store_template_id(&template_id)?;
+        env.persist().store_template_id(template_id)?;
     }
     let response = AuthenticatorBioEnrollmentResponse {
         last_enroll_sample_status: Some(sample_status),
@@ -209,7 +209,7 @@ fn set_friendly_name<E: Env>(
         return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_LENGTH);
     }
     env.persist()
-        .store_friendly_name(&template_id, &friendly_name)?;
+        .store_friendly_name(&template_id, friendly_name)?;
     Ok(ResponseData::AuthenticatorBioEnrollment(None))
 }
 
@@ -321,7 +321,7 @@ mod test {
             .1
             > 0
         {}
-        assert_eq!(env.persist().store_template_id(&template_id), Ok(()));
+        assert_eq!(env.persist().store_template_id(template_id.clone()), Ok(()));
         template_id
     }
 

--- a/libraries/opensk/src/ctap/fingerprint.rs
+++ b/libraries/opensk/src/ctap/fingerprint.rs
@@ -1,0 +1,407 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::client_pin::{ClientPin, PinPermission};
+use super::command::{
+    AuthenticatorBioEnrollmentParameters, BioEnrollmentSubCommand, BioEnrollmentSubCommandParams,
+};
+use super::data_formats::{extract_byte_string, extract_map, extract_text_string, ok_or_missing};
+use super::response::{AuthenticatorBioEnrollmentResponse, ResponseData};
+use super::status_code::{Ctap2StatusCode, CtapResult};
+use super::{send_packets, storage, Channel, CtapHid, KeepaliveStatus};
+use crate::api::customization::Customization;
+use crate::api::fingerprint::{Fingerprint, FingerprintCheckError};
+use crate::api::persist::Persist;
+use crate::env::Env;
+use crate::Transport;
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
+use sk_cbor as cbor;
+use sk_cbor::{cbor_map_options, destructure_cbor_map};
+
+/// Identifier for internal fingerprint modality.
+const MODALITY: u64 = 1;
+/// Maximum wait time for fingerprint authentication.
+const UV_TIMEOUT_MS: usize = 30000;
+/// Wait time for a fingerprint sensor response per iteration.
+const FINGERPRINT_TIMEOUT_MS: usize = 500;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct TemplateInfo {
+    pub template_id: Vec<u8>,
+    pub template_friendly_name: Option<String>,
+}
+
+impl TryFrom<cbor::Value> for TemplateInfo {
+    type Error = Ctap2StatusCode;
+
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
+        destructure_cbor_map! {
+            let {
+                0x01 => template_id,
+                0x02 => template_friendly_name,
+            } = extract_map(cbor_value)?;
+        }
+
+        let template_id = extract_byte_string(ok_or_missing(template_id)?)?;
+        let template_friendly_name = template_friendly_name
+            .map(extract_text_string)
+            .transpose()?;
+
+        Ok(Self {
+            template_id,
+            template_friendly_name,
+        })
+    }
+}
+
+impl From<TemplateInfo> for cbor::Value {
+    fn from(template_info: TemplateInfo) -> Self {
+        cbor_map_options! {
+            0x01 => template_info.template_id,
+            0x02 => template_info.template_friendly_name,
+        }
+    }
+}
+
+/// Uses to fingerprint sensor to establish user verification.
+pub fn perform_built_in_uv<E: Env>(
+    env: &mut E,
+    channel: Channel,
+    internal_retry: bool,
+) -> CtapResult<()> {
+    if storage::uv_retries(env)? == 0 {
+        return Err(Ctap2StatusCode::CTAP2_ERR_PIN_BLOCKED);
+    }
+    env.fingerprint().check_fingerprint_init();
+    let result = check_fingerprint_loop(env, channel, internal_retry);
+    env.fingerprint().check_fingerprint_complete();
+    result
+}
+
+/// Helper function that blinks LEDs while trying fingerprint UV.
+///
+/// Does not clear LEDs.
+fn check_fingerprint_loop<E: Env>(
+    env: &mut E,
+    channel: Channel,
+    internal_retry: bool,
+) -> CtapResult<()> {
+    const FINGERPRINT_TIMEOUT_LOOPS: usize = UV_TIMEOUT_MS / FINGERPRINT_TIMEOUT_MS;
+    let mut retries = if internal_retry {
+        env.customization().max_uv_attempts_for_internal_retries()
+    } else {
+        1
+    };
+    let (cid, transport) = match channel {
+        Channel::MainHid(cid) => (cid, Transport::MainHid),
+        #[cfg(feature = "vendor_hid")]
+        Channel::VendorHid(cid) => (cid, Transport::VendorHid),
+    };
+    let endpoint = transport.usb_endpoint();
+
+    // We need to give the user time to touch the device during UV.
+    // Also, on Windows, it seems we need to send KEEPALIVEs to
+    // avoid timeouts, so we need to do the check incrementally.
+    for _ in 0..FINGERPRINT_TIMEOUT_LOOPS {
+        match env.fingerprint().check_fingerprint(FINGERPRINT_TIMEOUT_MS) {
+            Ok(()) => {
+                storage::reset_uv_retries(env)?;
+                return Ok(());
+            }
+            Err(error) => {
+                match error {
+                    FingerprintCheckError::NoMatch | FingerprintCheckError::Other => {
+                        storage::decr_uv_retries(env)?;
+                        if storage::uv_retries(env)? == 0 {
+                            return Err(Ctap2StatusCode::CTAP2_ERR_PIN_BLOCKED);
+                        }
+                        retries -= 1;
+                        if retries == 0 {
+                            return Err(Ctap2StatusCode::CTAP2_ERR_UV_INVALID);
+                        }
+                    }
+                    FingerprintCheckError::Timeout => {
+                        // Send a KEEPALIVE to avoid timeouts on Windows.
+                        let keepalive_msg = CtapHid::<E>::keepalive(cid, KeepaliveStatus::UpNeeded);
+                        send_packets(env, endpoint, keepalive_msg)?;
+                    }
+                }
+            }
+        }
+    }
+    Err(Ctap2StatusCode::CTAP2_ERR_USER_ACTION_TIMEOUT)
+}
+
+fn enroll_begin<E: Env>(
+    env: &mut E,
+    sub_command_params: BioEnrollmentSubCommandParams,
+) -> CtapResult<ResponseData> {
+    let template_id = env.fingerprint().prepare_enrollment()?;
+    let timeout_ms = sub_command_params.timeout_milliseconds;
+    let (sample_status, remaining_samples) =
+        env.fingerprint().capture_sample(&template_id, timeout_ms)?;
+    let response = AuthenticatorBioEnrollmentResponse {
+        template_id: Some(template_id),
+        last_enroll_sample_status: Some(sample_status),
+        remaining_samples: Some(remaining_samples as u64),
+        ..Default::default()
+    };
+    Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
+}
+
+fn enroll_capture_next_sample<E: Env>(
+    env: &mut E,
+    sub_command_params: BioEnrollmentSubCommandParams,
+) -> CtapResult<ResponseData> {
+    let template_id = ok_or_missing(sub_command_params.template_id)?;
+    let timeout_ms = sub_command_params.timeout_milliseconds;
+    let (sample_status, remaining_samples) =
+        env.fingerprint().capture_sample(&template_id, timeout_ms)?;
+    if remaining_samples == 0 {
+        env.persist().store_template_id(&template_id)?;
+    }
+    let response = AuthenticatorBioEnrollmentResponse {
+        last_enroll_sample_status: Some(sample_status),
+        remaining_samples: Some(remaining_samples as u64),
+        ..Default::default()
+    };
+    Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
+}
+
+fn cancel_current_enrollment<E: Env>(env: &mut E) -> CtapResult<ResponseData> {
+    env.fingerprint().cancel_enrollment()?;
+    Ok(ResponseData::AuthenticatorBioEnrollment(None))
+}
+
+fn enumerate_enrollments<E: Env>(env: &mut E) -> CtapResult<ResponseData> {
+    let template_infos = env.persist().template_infos()?;
+    if template_infos.is_empty() {
+        return Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION);
+    }
+    let response = AuthenticatorBioEnrollmentResponse {
+        template_infos: Some(template_infos),
+        ..Default::default()
+    };
+    Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
+}
+
+fn set_friendly_name<E: Env>(
+    env: &mut E,
+    sub_command_params: BioEnrollmentSubCommandParams,
+) -> CtapResult<ResponseData> {
+    let template_id = ok_or_missing(sub_command_params.template_id)?;
+    let friendly_name = ok_or_missing(sub_command_params.template_friendly_name)?;
+    if friendly_name.len() > env.customization().max_template_friendly_name() {
+        return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_LENGTH);
+    }
+    env.persist()
+        .store_friendly_name(&template_id, &friendly_name)?;
+    Ok(ResponseData::AuthenticatorBioEnrollment(None))
+}
+
+fn remove_enrollment<E: Env>(
+    env: &mut E,
+    sub_command_params: BioEnrollmentSubCommandParams,
+) -> CtapResult<ResponseData> {
+    let template_id = ok_or_missing(sub_command_params.template_id)?;
+    // Will return an error if the template_id is unknown.
+    env.persist().remove_template_id(&template_id)?;
+    env.fingerprint().remove_enrollment(&template_id)?;
+    Ok(ResponseData::AuthenticatorBioEnrollment(None))
+}
+
+fn get_fingerprint_sensor_info<E: Env>(env: &mut E) -> CtapResult<ResponseData> {
+    let response = AuthenticatorBioEnrollmentResponse {
+        modality: Some(MODALITY),
+        fingerprint_kind: Some(env.fingerprint().fingerprint_kind() as u64),
+        max_capture_samples_required_for_enroll: Some(
+            env.fingerprint().max_capture_samples_required_for_enroll() as u64,
+        ),
+        max_template_friendly_name: Some(env.customization().max_template_friendly_name() as u64),
+        ..Default::default()
+    };
+    Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
+}
+
+pub fn process_bio_enrollment<E: Env>(
+    env: &mut E,
+    client_pin: &mut ClientPin<E>,
+    params: AuthenticatorBioEnrollmentParameters,
+) -> CtapResult<ResponseData> {
+    // Enforcing modaility is not explicitly mentioned in the specification.
+    // https://github.com/fido-alliance/fido-2-specs/issues/1673
+    // Let's be strict until we know which is correct.
+    if params.sub_command.is_some() {
+        let modality = ok_or_missing(params.modality)?;
+        if modality != MODALITY {
+            return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
+        }
+    }
+    // Some subcommands don't need parameters or authentication.
+    match params.sub_command {
+        Some(BioEnrollmentSubCommand::CancelCurrentEnrollment) => {
+            return cancel_current_enrollment(env);
+        }
+        Some(BioEnrollmentSubCommand::GetFingerprintSensorInfo) => {
+            return get_fingerprint_sensor_info(env);
+        }
+        None => {
+            if params.get_modality != Some(true) {
+                return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
+            }
+            let response = AuthenticatorBioEnrollmentResponse {
+                modality: Some(MODALITY),
+                ..Default::default()
+            };
+            return Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)));
+        }
+        _ => {}
+    }
+    let sub_command = params.sub_command.unwrap();
+    let pin_uv_auth_param = params
+        .pin_uv_auth_param
+        .ok_or(Ctap2StatusCode::CTAP2_ERR_PUAT_REQUIRED)?;
+    let pin_uv_auth_protocol = params
+        .pin_uv_auth_protocol
+        .ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?;
+    let mut command_data = vec![MODALITY as u8, sub_command as u8];
+    if let Some(sub_command_params) = params.sub_command_params.clone() {
+        super::cbor_write(sub_command_params.into(), &mut command_data)?;
+    }
+    client_pin.verify_pin_uv_auth_token(&command_data, &pin_uv_auth_param, pin_uv_auth_protocol)?;
+    client_pin.has_permission(PinPermission::BioEnrollment)?;
+    // Now we process all other subcommands that need PIN UV authentication.
+    if sub_command == BioEnrollmentSubCommand::EnumerateEnrollments {
+        return enumerate_enrollments(env);
+    }
+    let sub_command_params = ok_or_missing(params.sub_command_params)?;
+    match sub_command {
+        BioEnrollmentSubCommand::EnrollBegin => enroll_begin(env, sub_command_params),
+        BioEnrollmentSubCommand::EnrollCaptureNextSample => {
+            enroll_capture_next_sample(env, sub_command_params)
+        }
+        BioEnrollmentSubCommand::SetFriendlyName => set_friendly_name(env, sub_command_params),
+        BioEnrollmentSubCommand::RemoveEnrollment => remove_enrollment(env, sub_command_params),
+        _ => unreachable!(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::api::crypto::ecdh::SecretKey;
+    use crate::ctap::data_formats::PinUvAuthProtocol;
+    use crate::ctap::pin_protocol::authenticate_pin_uv_auth_token;
+    use crate::env::test::TestEnv;
+    use crate::env::EcdhSk;
+    use sk_cbor::cbor_map;
+
+    const DUMMY_CHANNEL: Channel = Channel::MainHid([0x12, 0x34, 0x56, 0x78]);
+
+    fn create_fingerprint(env: &mut TestEnv) -> Vec<u8> {
+        let template_id = env.fingerprint().prepare_enrollment().unwrap();
+        while env
+            .fingerprint()
+            .capture_sample(&template_id, Some(30_000))
+            .unwrap()
+            .1
+            > 0
+        {}
+        assert_eq!(env.persist().store_template_id(&template_id), Ok(()));
+        template_id
+    }
+
+    #[test]
+    fn test_perform_built_in_uv() {
+        let mut env = TestEnv::default();
+        assert_eq!(
+            perform_built_in_uv(&mut env, DUMMY_CHANNEL, true),
+            Err(Ctap2StatusCode::CTAP2_ERR_UV_INVALID)
+        );
+        assert_eq!(
+            perform_built_in_uv(&mut env, DUMMY_CHANNEL, false),
+            Err(Ctap2StatusCode::CTAP2_ERR_UV_INVALID)
+        );
+        create_fingerprint(&mut env);
+        assert_eq!(perform_built_in_uv(&mut env, DUMMY_CHANNEL, true), Ok(()));
+        assert_eq!(perform_built_in_uv(&mut env, DUMMY_CHANNEL, false), Ok(()));
+    }
+
+    #[test]
+    fn test_from_into_template_info() {
+        let cbor_template_info = cbor_map! {
+            0x01 => vec![0x00],
+            0x02 => "Name",
+        };
+        let template_info = TemplateInfo::try_from(cbor_template_info.clone());
+        let expected_template_info = TemplateInfo {
+            template_id: vec![0x00],
+            template_friendly_name: Some(String::from("Name")),
+        };
+        assert_eq!(template_info, Ok(expected_template_info));
+        let created_cbor: cbor::Value = template_info.unwrap().into();
+        assert_eq!(created_cbor, cbor_template_info);
+    }
+
+    #[test]
+    fn test_enumerate_enrollments() {
+        let mut env = TestEnv::default();
+        let key_agreement_key = EcdhSk::<TestEnv>::random(env.rng());
+        let pin_uv_auth_token = [0x55; 32];
+        let pin_uv_auth_protocol = PinUvAuthProtocol::V2;
+        let mut client_pin = ClientPin::<TestEnv>::new_test(
+            &mut env,
+            key_agreement_key,
+            pin_uv_auth_token,
+            pin_uv_auth_protocol,
+        );
+        env.persist().set_pin(&[0x88; 16], 4).unwrap();
+
+        let sub_command = BioEnrollmentSubCommand::EnumerateEnrollments;
+        let command_data = vec![MODALITY as u8, sub_command as u8];
+        let pin_uv_auth_param =
+            authenticate_pin_uv_auth_token(&pin_uv_auth_token, &command_data, pin_uv_auth_protocol);
+        let params = AuthenticatorBioEnrollmentParameters {
+            modality: Some(MODALITY),
+            sub_command: Some(sub_command),
+            sub_command_params: None,
+            pin_uv_auth_protocol: Some(pin_uv_auth_protocol),
+            pin_uv_auth_param: Some(pin_uv_auth_param),
+            get_modality: None,
+        };
+        let response = process_bio_enrollment(&mut env, &mut client_pin, params.clone());
+        assert_eq!(response, Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION));
+
+        let template_id = create_fingerprint(&mut env);
+        let response = process_bio_enrollment(&mut env, &mut client_pin, params);
+        match response.unwrap() {
+            ResponseData::AuthenticatorBioEnrollment(Some(response)) => {
+                assert!(response.modality.is_none());
+                assert!(response.fingerprint_kind.is_none());
+                assert!(response.max_capture_samples_required_for_enroll.is_none());
+                assert!(response.template_id.is_none());
+                assert!(response.last_enroll_sample_status.is_none());
+                assert!(response.remaining_samples.is_none());
+                assert!(response.max_template_friendly_name.is_none());
+                let template_infos = response.template_infos.unwrap();
+                assert_eq!(template_infos.len(), 1);
+                assert_eq!(template_infos[0].template_id, template_id);
+            }
+            _ => panic!("Invalid response type"),
+        };
+    }
+}

--- a/libraries/opensk/src/ctap/mod.rs
+++ b/libraries/opensk/src/ctap/mod.rs
@@ -22,6 +22,8 @@ pub mod crypto_wrapper;
 #[cfg(feature = "with_ctap1")]
 mod ctap1;
 pub mod data_formats;
+#[cfg(feature = "fingerprint")]
+pub mod fingerprint;
 pub mod hid;
 mod large_blobs;
 pub mod main_hid;
@@ -39,8 +41,7 @@ pub mod vendor_hid;
 pub use self::client_pin::PIN_AUTH_LENGTH;
 use self::client_pin::{ClientPin, PinPermission};
 use self::command::{
-    AuthenticatorBioEnrollmentParameters, AuthenticatorGetAssertionParameters,
-    AuthenticatorMakeCredentialParameters, Command,
+    AuthenticatorGetAssertionParameters, AuthenticatorMakeCredentialParameters, Command,
 };
 #[cfg(feature = "config_command")]
 use self::config_command::process_config;
@@ -51,13 +52,15 @@ use self::data_formats::{
     PublicKeyCredentialDescriptor, PublicKeyCredentialParameter, PublicKeyCredentialSource,
     PublicKeyCredentialType, PublicKeyCredentialUserEntity, SignatureAlgorithm,
 };
+#[cfg(feature = "fingerprint")]
+use self::fingerprint::{perform_built_in_uv, process_bio_enrollment};
 use self::hid::{
     ChannelID, CtapHid, CtapHidCommand, HidPacketIterator, KeepaliveStatus, ProcessedPacket,
 };
 use self::large_blobs::LargeBlobState;
 use self::response::{
-    AuthenticatorBioEnrollmentResponse, AuthenticatorGetAssertionResponse,
-    AuthenticatorGetInfoResponse, AuthenticatorMakeCredentialResponse, ResponseData,
+    AuthenticatorGetAssertionResponse, AuthenticatorGetInfoResponse,
+    AuthenticatorMakeCredentialResponse, ResponseData,
 };
 use self::secret::Secret;
 use self::status_code::{Ctap2StatusCode, CtapResult};
@@ -70,7 +73,8 @@ use crate::api::crypto::hkdf256::Hkdf256;
 use crate::api::crypto::sha256::Sha256;
 use crate::api::crypto::HASH_SIZE;
 use crate::api::customization::Customization;
-use crate::api::fingerprint::{Fingerprint, FingerprintCaptureError};
+#[cfg(feature = "fingerprint")]
+use crate::api::fingerprint::Fingerprint;
 use crate::api::key_store::{CredentialSource, KeyStore, MAX_CREDENTIAL_ID_SIZE};
 use crate::api::persist::{Attestation, AttestationId, Persist};
 use crate::api::private_key::PrivateKey;
@@ -108,7 +112,6 @@ pub const FIDO2_VERSION_STRING: &str = "FIDO_2_0";
 #[cfg(feature = "with_ctap1")]
 pub const U2F_VERSION_STRING: &str = "U2F_V2";
 pub const FIDO2_1_VERSION_STRING: &str = "FIDO_2_1";
-pub const FIDO2_1_PRE_VERSION_STRING: &str = "FIDO_2_1_PRE";
 
 // We currently only support one algorithm for signatures: ES256.
 // This algorithm is requested in MakeCredential and advertized in GetInfo.
@@ -128,34 +131,6 @@ const SUPPORTED_CRED_PARAMS: &[PublicKeyCredentialParameter] = &[
     #[cfg(feature = "ed25519")]
     EDDSA_CRED_PARAM,
 ];
-
-#[derive(Debug)]
-pub enum BioEnrollmentSubCommand {
-    EnrollBegin = 1,
-    EnrollCaptureNextSample = 2,
-    CancelCurrentEnrollment = 3,
-    EnumerateEnrollments = 4,
-    SetFriendlyName = 5,
-    RemoveEnrollment = 6,
-    GetFingerSensorInfo = 7,
-}
-
-impl TryFrom<u64> for BioEnrollmentSubCommand {
-    type Error = ();
-
-    fn try_from(value: u64) -> Result<Self, Self::Error> {
-        match value {
-            1 => Ok(BioEnrollmentSubCommand::EnrollBegin),
-            2 => Ok(BioEnrollmentSubCommand::EnrollCaptureNextSample),
-            3 => Ok(BioEnrollmentSubCommand::CancelCurrentEnrollment),
-            4 => Ok(BioEnrollmentSubCommand::EnumerateEnrollments),
-            5 => Ok(BioEnrollmentSubCommand::SetFriendlyName),
-            6 => Ok(BioEnrollmentSubCommand::RemoveEnrollment),
-            7 => Ok(BioEnrollmentSubCommand::GetFingerSensorInfo),
-            _ => Err(()),
-        }
-    }
-}
 
 fn get_preferred_cred_param(
     params: &[PublicKeyCredentialParameter],
@@ -289,7 +264,7 @@ fn truncate_to_char_boundary(s: &str, mut max: usize) -> &str {
 }
 
 /// Send non-critical packets using fire-and-forget.
-fn send_packets<E: Env>(
+pub fn send_packets<E: Env>(
     env: &mut E,
     endpoint: UsbEndpoint,
     packets: HidPacketIterator,
@@ -305,17 +280,6 @@ fn is_cancel(packet: &ProcessedPacket) -> bool {
         ProcessedPacket::InitPacket { cmd, .. } => *cmd == CtapHidCommand::Cancel as u8,
         ProcessedPacket::ContinuationPacket { .. } => false,
     }
-}
-
-pub fn send_keepalive_packet<E: Env>(env: &mut E, channel: Channel) -> CtapResult<()> {
-    let (cid, transport) = match channel {
-        Channel::MainHid(cid) => (cid, Transport::MainHid),
-        #[cfg(feature = "vendor_hid")]
-        Channel::VendorHid(cid) => (cid, Transport::VendorHid),
-    };
-    let endpoint = transport.usb_endpoint();
-    let keepalive_msg = CtapHid::<E>::keepalive(cid, KeepaliveStatus::UpNeeded);
-    send_packets(env, endpoint, keepalive_msg)
 }
 
 fn wait_and_respond_busy<E: Env>(env: &mut E, channel: Channel) -> CtapResult<()> {
@@ -409,30 +373,6 @@ pub enum StatefulCommand {
     EnumerateRps(usize),
     EnumerateCredentials(Vec<usize>),
     LargeBlob(LargeBlobState),
-}
-
-//https://fidoalliance.org/specs/fido2/vendor/BioEnrollmentPrototype.pdf
-#[repr(u64)]
-enum Ctap2EnrollFeedback {
-    FpGood = 0,
-    FpPoorQuality = 7,
-    FpMergeFailure = 10,
-    FpTooFast = 0x5,
-    FpTooHigh = 0x1,
-    NoUserActivity = 0xd,
-}
-
-#[repr(u64)]
-enum BioEnrollmentSubCommandParamFields {
-    TemplateId = 0x01,
-    TemplateFriendlyName = 0x02,
-    TimeoutMilliseconds = 0x03,
-}
-
-#[repr(u64)]
-enum BioEnrollmentSubCommandTemplateInfoFields {
-    TemplateId = 0x01,
-    TemplateFriendlyName = 0x02,
 }
 
 /// Stores the current CTAP command state and when it times out.
@@ -612,9 +552,6 @@ pub struct CtapState<E: Env> {
     pub(crate) u2f_up_state: U2fUserPresenceState<E>,
     // The state initializes to Reset and its timeout, and never goes back to Reset.
     stateful_command_permission: StatefulPermission<E>,
-    // Bio enrollment variables
-    remaining_samples: u64,
-    current_template_id: u8,
 }
 
 impl<E: Env> CtapState<E> {
@@ -631,8 +568,6 @@ impl<E: Env> CtapState<E> {
             #[cfg(feature = "with_ctap1")]
             u2f_up_state: U2fUserPresenceState::new(),
             stateful_command_permission,
-            remaining_samples: 3,
-            current_template_id: 0,
         }
     }
 
@@ -667,486 +602,6 @@ impl<E: Env> CtapState<E> {
     pub fn can_sleep(&mut self, env: &mut E) -> bool {
         !self.client_pin.has_token(env)
             && self.stateful_command_permission.get_command(env).is_err()
-    }
-
-    pub fn process_bio_enrollment(
-        &mut self,
-        env: &mut E,
-        params: AuthenticatorBioEnrollmentParameters,
-        _channel: Channel,
-    ) -> CtapResult<ResponseData> {
-        let sub_command = params
-            .sub_command
-            .map(|cmd| BioEnrollmentSubCommand::try_from(cmd))
-            .transpose()
-            .map_err(|_| Ctap2StatusCode::CTAP2_ERR_INVALID_SUBCOMMAND)?;
-
-        debug_ctap!(
-            env,
-            "CT: Received bio enrollment sub_command {:?}",
-            sub_command
-        );
-
-        match sub_command {
-            Some(BioEnrollmentSubCommand::EnrollBegin) => {
-                // Check which fingerprint slots are open, and use the first
-                // one. If none is open we will eventually return an error.
-                let mut fingerlist = [0u8; 5];
-                env.fingerprint().get_enrollments(&mut fingerlist);
-                debug_ctap!(env, "CT: EnrollBegin fingerlist {:?}", fingerlist);
-                let open_index = fingerlist.iter().position(|&x| x == 0);
-
-                let timeout_ms = params.sub_command_params.map_or(2000, |p| {
-                    p.extract_map().map_or(2000, |m| {
-                        m.iter()
-                            .find_map(|e| {
-                                if e.0.clone().extract_unsigned().unwrap_or(0)
-                                    == BioEnrollmentSubCommandParamFields::TimeoutMilliseconds
-                                        as u64
-                                {
-                                    e.1.clone().extract_unsigned()
-                                } else {
-                                    None
-                                }
-                            })
-                            .unwrap_or(2000) as usize
-                    })
-                });
-
-                match open_index {
-                    Some(index) => {
-                        self.remaining_samples =
-                            env.fingerprint().get_enrollment_count_maximum() as u64;
-                        self.current_template_id = index as u8;
-
-                        debug_ctap!(
-                            env,
-                            "CT: EnrollBegin remaining samples {:?}    enrollment_count {:?}   timeout_ms {:?}",
-                            self.remaining_samples,
-                            self.current_template_id,
-                            timeout_ms,
-                        );
-                        env.fingerprint()
-                            .prepare_enrollment(self.current_template_id);
-                        let sample_ret = env.fingerprint().capture_sample(timeout_ms);
-
-                        let sample_status = match sample_ret {
-                            Ok(()) => {
-                                self.remaining_samples -= 1;
-                                Ctap2EnrollFeedback::FpGood
-                            }
-                            Err(e) => {
-                                debug_ctap!(env, "CT: EnrollBegin capture_sample() - Err\n");
-                                match e {
-                                    FingerprintCaptureError::NoTouch => {
-                                        Ctap2EnrollFeedback::NoUserActivity
-                                    }
-                                    FingerprintCaptureError::ImageBad => {
-                                        Ctap2EnrollFeedback::FpPoorQuality
-                                    }
-                                    FingerprintCaptureError::ImagePartial => {
-                                        Ctap2EnrollFeedback::FpTooHigh
-                                    }
-                                    FingerprintCaptureError::TooFast => {
-                                        Ctap2EnrollFeedback::FpTooFast
-                                    }
-                                    FingerprintCaptureError::Other => {
-                                        Ctap2EnrollFeedback::FpPoorQuality
-                                    }
-                                }
-                            }
-                        };
-
-                        let response = AuthenticatorBioEnrollmentResponse {
-                            modality: Some(1),
-                            fingerprint_kind: None,
-                            max_capture_samples_required_for_enroll: Some(self.remaining_samples),
-                            template_id: Some(vec![self.current_template_id]),
-                            last_enroll_sample_status: Some(sample_status as u64),
-                            remaining_samples: Some(self.remaining_samples),
-                            template_infos: None,
-                            max_template_friendly_name: Some(32),
-                        };
-
-                        Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
-                    }
-                    None => {
-                        debug_ctap!(
-                            env,
-                            "CT: EnrollBegin no space (timeout_ms {:?})",
-                            timeout_ms,
-                        );
-
-                        Err(Ctap2StatusCode::CTAP2_ERR_FP_DATABASE_FULL)
-                    }
-                }
-            }
-            Some(BioEnrollmentSubCommand::EnrollCaptureNextSample) => {
-                //check_user_presence(env, channel)?;
-
-                let timeout_ms = params.sub_command_params.map_or(2000, |p| {
-                    p.extract_map().map_or(2000, |m| {
-                        m.iter()
-                            .find_map(|e| {
-                                if e.0.clone().extract_unsigned().unwrap_or(0)
-                                    == BioEnrollmentSubCommandParamFields::TimeoutMilliseconds
-                                        as u64
-                                {
-                                    e.1.clone().extract_unsigned()
-                                } else {
-                                    None
-                                }
-                            })
-                            .unwrap_or(2000) as usize
-                    })
-                });
-
-                let sample_ret = env.fingerprint().capture_sample(timeout_ms);
-
-                debug_ctap!(
-                    env,
-                    "CT: EnrollCaptureNext capture_sample return {:?} remaining_sample {:?} timeout_ms {:?}",
-                    sample_ret,
-                    self.remaining_samples,
-                    timeout_ms,
-                );
-
-                let sample_status = match sample_ret {
-                    Ok(()) => {
-                        if self.remaining_samples == 1 {
-                            let commit_ret = env.fingerprint().commit_enrollment();
-                            debug_ctap!(
-                                env,
-                                "CT: EnrollCaptureNext return from commit enroll {:?}",
-                                commit_ret
-                            );
-                            match commit_ret {
-                                Ok(()) => {
-                                    // nothing to do
-                                    debug_ctap!(
-                                        env,
-                                        "CT: EnrollCaptureNext commit_enrollment() - OK\n"
-                                    );
-                                    self.remaining_samples -= 1;
-                                    Ctap2EnrollFeedback::FpGood
-                                }
-
-                                Err(()) => {
-                                    debug_ctap!(
-                                        env,
-                                        "CT: EnrollCaptureNext commit_enrollment() - Err\n"
-                                    );
-                                    Ctap2EnrollFeedback::FpMergeFailure
-                                }
-                            }
-                        } else {
-                            self.remaining_samples -= 1;
-                            Ctap2EnrollFeedback::FpGood
-                        }
-                    }
-
-                    Err(e) => {
-                        debug_ctap!(env, "CT: EnrollCaptureNext capture_sample() - Err\n");
-                        match e {
-                            FingerprintCaptureError::NoTouch => Ctap2EnrollFeedback::NoUserActivity,
-                            FingerprintCaptureError::ImageBad => Ctap2EnrollFeedback::FpPoorQuality,
-                            FingerprintCaptureError::ImagePartial => Ctap2EnrollFeedback::FpTooHigh,
-                            FingerprintCaptureError::TooFast => Ctap2EnrollFeedback::FpTooFast,
-                            FingerprintCaptureError::Other => Ctap2EnrollFeedback::FpPoorQuality,
-                        }
-                    }
-                };
-
-                let response = AuthenticatorBioEnrollmentResponse {
-                    modality: Some(1),
-                    fingerprint_kind: None,
-                    max_capture_samples_required_for_enroll: None,
-                    template_id: Some(vec![self.current_template_id]),
-                    last_enroll_sample_status: Some(sample_status as u64),
-                    remaining_samples: Some(self.remaining_samples),
-                    template_infos: None,
-                    max_template_friendly_name: Some(32),
-                };
-                Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
-            }
-
-            Some(BioEnrollmentSubCommand::CancelCurrentEnrollment) => {
-                {
-                    env.fingerprint().cancel_enrollment();
-                }
-
-                let response = AuthenticatorBioEnrollmentResponse {
-                    modality: Some(1),
-                    fingerprint_kind: None,
-                    max_capture_samples_required_for_enroll: None,
-                    template_id: None,
-                    last_enroll_sample_status: None,
-                    remaining_samples: None,
-                    template_infos: None,
-                    max_template_friendly_name: Some(32),
-                };
-                Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
-            }
-
-            Some(BioEnrollmentSubCommand::EnumerateEnrollments) => {
-                let mut fingerlist = [0u8; 5];
-                env.fingerprint().get_enrollments(&mut fingerlist);
-
-                debug_ctap!(env, "CT: EnumerateEnrollment fingerlist {:?}", fingerlist);
-
-                let template_ids: Vec<u8> = fingerlist
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(index, &id)| if id != 0 { Some(index as u8) } else { None })
-                    .collect();
-
-                debug_ctap!(
-                    env,
-                    "CT: EnumerateEnrollment template_ids {:?}",
-                    template_ids
-                );
-
-                // Check if there are no enrolled fingers
-                if template_ids.is_empty() {
-                    debug_ctap!(
-                        env,
-                        "CT: No enrolled fingers found. Returning CTAP2_ERR_INVALID_OPTION."
-                    );
-                    return Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION);
-                }
-
-                let template_infos_array: Vec<cbor::Value> = template_ids
-                    .iter()
-                    .map(|template_id| {
-                        let template_id = *template_id;
-                        let friendly_name =
-                            storage::get_friendly_name(env, template_id).unwrap_or("".to_string());
-                        debug_ctap!(env, "CT: Friendly name for template_id {}:", template_id);
-                        if friendly_name.len() > 0 {
-                            debug_ctap!(env, "'{}'", friendly_name);
-                        }
-                        let entries = vec![
-                            (
-                                cbor::Value::unsigned(
-                                    BioEnrollmentSubCommandTemplateInfoFields::TemplateId as u64,
-                                ),
-                                cbor::Value::byte_string(vec![template_id]),
-                            ),
-                            (
-                                cbor::Value::unsigned(
-                                    BioEnrollmentSubCommandTemplateInfoFields::TemplateFriendlyName
-                                        as u64,
-                                ),
-                                cbor::Value::text_string(friendly_name),
-                            ),
-                        ];
-                        cbor::Value::map(entries)
-                    })
-                    .collect();
-
-                let template_infos = cbor::Value::array(template_infos_array);
-
-                let response = AuthenticatorBioEnrollmentResponse {
-                    modality: Some(1),
-                    fingerprint_kind: None,
-                    max_capture_samples_required_for_enroll: None,
-                    template_id: None,
-                    last_enroll_sample_status: None,
-                    remaining_samples: None,
-                    template_infos: Some(template_infos),
-                    max_template_friendly_name: Some(32),
-                };
-                Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
-            }
-
-            Some(BioEnrollmentSubCommand::RemoveEnrollment) => {
-                debug_ctap!(env, "CT: RemoveEnrollment");
-
-                let template_id = params.sub_command_params.map_or(
-                    Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER),
-                    |p| {
-                        p.extract_map().map_or(
-                            Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER),
-                            |m| {
-                                m.iter()
-                                    .find_map(|e| {
-                                        if e.0.clone().extract_unsigned().unwrap_or(0)
-                                            == BioEnrollmentSubCommandParamFields::TemplateId as u64
-                                        {
-                                            Some(Ok(*e
-                                                .1
-                                                .clone()
-                                                .extract_byte_string()
-                                                .unwrap_or(vec![])
-                                                .get(0)
-                                                .unwrap_or(&0)))
-                                        } else {
-                                            None
-                                        }
-                                    })
-                                    .unwrap_or(Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER))
-                            },
-                        )
-                    },
-                )?;
-
-                debug_ctap!(env, "Remove enrollment tempate_id {:?}", template_id);
-
-                env.fingerprint().delete_enrollment(template_id);
-
-                let response = AuthenticatorBioEnrollmentResponse {
-                    modality: Some(1),
-                    fingerprint_kind: None,
-                    max_capture_samples_required_for_enroll: None,
-                    template_id: None,
-                    last_enroll_sample_status: None,
-                    remaining_samples: None,
-                    template_infos: None,
-                    max_template_friendly_name: Some(32),
-                };
-                Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
-            }
-
-            Some(BioEnrollmentSubCommand::SetFriendlyName) => {
-                debug_ctap!(env, "CT: SetFriendlyName");
-
-                // placeholder:  Check token permission for "be"
-
-                let template_id = params.sub_command_params.clone().map_or(
-                    Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER),
-                    |p| {
-                        p.extract_map().map_or(
-                            Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER),
-                            |m| {
-                                m.iter()
-                                    .find_map(|e| {
-                                        if e.0.clone().extract_unsigned().unwrap_or(0)
-                                            == BioEnrollmentSubCommandParamFields::TemplateId as u64
-                                        {
-                                            Some(Ok(*e
-                                                .1
-                                                .clone()
-                                                .extract_byte_string()
-                                                .unwrap_or(vec![])
-                                                .get(0)
-                                                .unwrap_or(&0)))
-                                        } else {
-                                            None
-                                        }
-                                    })
-                                    .unwrap_or(Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER))
-                            },
-                        )
-                    },
-                )?;
-
-                let friendly_name = params.sub_command_params.clone().map_or(
-                    Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER),
-                    |p| {
-                        p.extract_map().map_or(
-                            Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER),
-                            |m| {
-                                m.iter()
-                                    .find_map(|e| {
-                                        if e.0.clone().extract_unsigned().unwrap_or(0)
-                                            == BioEnrollmentSubCommandParamFields::TemplateFriendlyName as u64
-                                        {
-                                            Some(Ok(e
-                                                .1
-                                                .clone()
-                                                .extract_text_string()
-                                                .unwrap_or("".to_string())
-                                                ))
-                                        } else {
-                                            None
-                                        }
-                                    })
-                                    .unwrap_or(Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER))
-                            },
-                        )
-                    },
-                )?;
-
-                debug_ctap!(env, "CT: SetFriendlyName {} {}", template_id, friendly_name);
-
-                // Check if the friendly name length exceeds the maximum allowed
-                const MAX_TEMPLATE_FRIENDLY_NAME: usize = 32; // set it to 32 for now
-                if friendly_name.len() > MAX_TEMPLATE_FRIENDLY_NAME {
-                    return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_LENGTH);
-                }
-
-                // Check if there's an existing enrollment for the given template_id
-                let mut fingerlist = [0u8; 5];
-                env.fingerprint().get_enrollments(&mut fingerlist);
-                if !fingerlist.contains(&template_id) {
-                    return Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION);
-                }
-
-                storage::store_friendly_name(env, template_id, &friendly_name)?;
-
-                // Create a template_info map with the new friendly name
-                let template_info = cbor::Value::map(vec![
-                    (
-                        cbor::Value::unsigned(
-                            BioEnrollmentSubCommandTemplateInfoFields::TemplateId as u64,
-                        ),
-                        cbor::Value::byte_string(vec![template_id]),
-                    ),
-                    (
-                        cbor::Value::unsigned(
-                            BioEnrollmentSubCommandTemplateInfoFields::TemplateFriendlyName as u64,
-                        ),
-                        cbor::Value::text_string(friendly_name.clone()),
-                    ),
-                ]);
-
-                // Create the template_infos array with the single template_info
-                let template_infos = cbor::Value::array(vec![template_info]);
-
-                let response = AuthenticatorBioEnrollmentResponse {
-                    modality: Some(1),
-                    fingerprint_kind: None,
-                    max_capture_samples_required_for_enroll: None,
-                    template_id: None,
-                    last_enroll_sample_status: None,
-                    remaining_samples: None,
-                    template_infos: Some(template_infos),
-                    max_template_friendly_name: Some(32),
-                };
-                Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
-            }
-
-            Some(BioEnrollmentSubCommand::GetFingerSensorInfo) => {
-                // Finger sensor information
-                debug_ctap!(env, "CT: GetFingerSensorInfo");
-
-                let response = AuthenticatorBioEnrollmentResponse {
-                    modality: Some(1),
-                    fingerprint_kind: Some(1),
-                    max_capture_samples_required_for_enroll: Some(6), // change to 6 to match RT
-                    max_template_friendly_name: Some(32),
-                    template_id: None,
-                    last_enroll_sample_status: None,
-                    remaining_samples: None,
-                    template_infos: None,
-                };
-                Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
-            }
-
-            _ => {
-                let response = AuthenticatorBioEnrollmentResponse {
-                    modality: Some(1),
-                    fingerprint_kind: Some(1),
-                    max_capture_samples_required_for_enroll: Some(5),
-                    max_template_friendly_name: Some(32),
-                    template_id: None,
-                    last_enroll_sample_status: None,
-                    remaining_samples: None,
-                    template_infos: None,
-                };
-                Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
-            }
-        }
     }
 
     pub fn process_command(
@@ -1198,7 +653,6 @@ impl<E: Env> CtapState<E> {
             (Command::AuthenticatorGetNextAssertion, Ok(StatefulCommand::GetAssertion(_)))
             | (Command::AuthenticatorLargeBlobs(_), Ok(StatefulCommand::LargeBlob(_)))
             | (Command::AuthenticatorReset, Ok(StatefulCommand::Reset))
-            | (Command::AuthenticatorBioEnrollment(_), Ok(StatefulCommand::Reset))
             // AuthenticatorGetInfo still allows Reset.
             | (Command::AuthenticatorGetInfo, Ok(StatefulCommand::Reset))
             // AuthenticatorSelection still allows Reset.
@@ -1237,14 +691,15 @@ impl<E: Env> CtapState<E> {
                 self.process_get_assertion(env, params, channel)
             }
             Command::AuthenticatorGetNextAssertion => self.process_get_next_assertion(env),
-            Command::AuthenticatorBioEnrollment(params) => {
-                self.process_bio_enrollment(env, params, channel)
-            }
             Command::AuthenticatorGetInfo => self.process_get_info(env),
             Command::AuthenticatorClientPin(params) => {
                 self.client_pin.process_command(env, params, channel)
             }
             Command::AuthenticatorReset => self.process_reset(env, channel),
+            #[cfg(feature = "fingerprint")]
+            Command::AuthenticatorBioEnrollment(params) => {
+                process_bio_enrollment(env, &mut self.client_pin, params)
+            }
             Command::AuthenticatorCredentialManagement(params) => process_credential_management(
                 env,
                 &mut self.stateful_command_permission,
@@ -1373,45 +828,24 @@ impl<E: Env> CtapState<E> {
             }
             None => {
                 if options.uv {
-                    // Internal UV is enabled. Check the built in UV and return on error.
-                    // If no error, return the UV_FLAG bit.
-                    self.client_pin
-                        .perform_built_in_uv(env, channel, true)
-                        .map_err(|e| {
-                            // 6.1.2.11.2 error cases:
-                            //
-                            // 1. If the error reason is a user action timeout,
-                            //    then return CTAP2_ERR_USER_ACTION_TIMEOUT.
-                            // 2. If the ClientPin option ID is true and the
-                            //    noMcGaPermissionsWithClientPin option ID is
-                            //    absent or false, end the operation by
-                            //    returning CTAP2_ERR_PUAT_REQUIRED.
-                            // 3. If the uvRetries counter is <= 0, return
-                            //    CTAP2_ERR_PIN_BLOCKED.
-                            // 4. Otherwise, end the operation by returning
-                            //    CTAP2_ERR_OPERATION_DENIED.
-                            match e {
-                                Ctap2StatusCode::CTAP2_ERR_USER_ACTION_TIMEOUT => {
-                                    Ctap2StatusCode::CTAP2_ERR_USER_ACTION_TIMEOUT
-                                }
-                                Ctap2StatusCode::CTAP2_ERR_UV_BLOCKED => {
-                                    Ctap2StatusCode::CTAP2_ERR_PIN_BLOCKED
-                                }
-                                _ => {
-                                    let client_pin_option =
-                                        env.persist().pin_hash().unwrap_or(None).is_some();
-                                    if client_pin_option {
-                                        // noMcGaPermissionsWithClientPin is absent
-                                        Ctap2StatusCode::CTAP2_ERR_PUAT_REQUIRED
-                                    } else {
-                                        Ctap2StatusCode::CTAP2_ERR_OPERATION_DENIED
-                                    }
-                                }
-                            }
-                        })?;
+                    #[cfg(not(feature = "fingerprint"))]
+                    return Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION);
+                    // The specification says:
+                    // If the uvRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED.
+                    // But I assume this is a typo and should be UV_BLOCKED instead.
+                    // https://github.com/fido-alliance/fido-2-specs/issues/1672
+                    #[cfg(feature = "fingerprint")]
+                    perform_built_in_uv(env, channel, true)?;
+                    #[cfg(feature = "fingerprint")]
                     UV_FLAG
                 } else {
-                    // Flags set to 0
+                    if storage::has_always_uv(env)? {
+                        return Err(Ctap2StatusCode::CTAP2_ERR_PUAT_REQUIRED);
+                    }
+                    // Corresponds to makeCredUvNotRqd set to true.
+                    if options.rk && env.persist().pin_hash()?.is_some() {
+                        return Err(Ctap2StatusCode::CTAP2_ERR_PUAT_REQUIRED);
+                    }
                     0x00
                 }
             }
@@ -1445,11 +879,7 @@ impl<E: Env> CtapState<E> {
         self.client_pin.clear_token_flags();
 
         let default_cred_protect = env.customization().default_cred_protect();
-        let mut cred_protect_policy = Some(
-            extensions
-                .cred_protect
-                .unwrap_or(CredentialProtectionPolicy::UserVerificationOptional),
-        );
+        let mut cred_protect_policy = extensions.cred_protect;
         if cred_protect_policy.unwrap_or(CredentialProtectionPolicy::UserVerificationOptional)
             < default_cred_protect.unwrap_or(CredentialProtectionPolicy::UserVerificationOptional)
         {
@@ -1777,15 +1207,20 @@ impl<E: Env> CtapState<E> {
                 UV_FLAG
             }
             None => {
-                debug_ctap!(env, "process_get_assertion: use UV (no pin_uv_auth_param)");
                 if options.uv {
-                    // Internal UV is enabled. Check the built in UV and return on error.
-                    // If no error, return the UV_FLAG bit.
-                    self.client_pin.perform_built_in_uv(env, channel, true)?;
+                    #[cfg(not(feature = "fingerprint"))]
+                    return Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION);
+                    // Same error code ambiguity as in MakeCredential.
+                    // https://github.com/fido-alliance/fido-2-specs/issues/1672
+                    #[cfg(feature = "fingerprint")]
+                    perform_built_in_uv(env, channel, true)?;
+                    #[cfg(feature = "fingerprint")]
                     UV_FLAG
                 } else {
-                    // Flags set to 0
-                    0
+                    if options.up && storage::has_always_uv(env)? {
+                        return Err(Ctap2StatusCode::CTAP2_ERR_PUAT_REQUIRED);
+                    }
+                    0x00
                 }
             }
         };
@@ -1885,45 +1320,39 @@ impl<E: Env> CtapState<E> {
         let mut versions = vec![
             String::from(FIDO2_VERSION_STRING),
             String::from(FIDO2_1_VERSION_STRING),
-            String::from(FIDO2_1_PRE_VERSION_STRING),
         ];
         #[cfg(feature = "with_ctap1")]
         if !has_always_uv {
             versions.insert(0, String::from(U2F_VERSION_STRING))
         }
-        let mut options = vec![];
+        let mut options = vec![
+            (String::from("rk"), true),
+            (
+                String::from("clientPin"),
+                env.persist().pin_hash()?.is_some(),
+            ),
+            (String::from("up"), true),
+            (String::from("pinUvAuthToken"), true),
+            (String::from("largeBlobs"), true),
+            #[cfg(feature = "config_command")]
+            (String::from("authnrCfg"), true),
+            #[cfg(feature = "config_command")]
+            (String::from("uvAcfg"), true),
+            (String::from("credMgmt"), true),
+            #[cfg(feature = "config_command")]
+            (String::from("setMinPINLength"), true),
+            (String::from("makeCredUvNotRqd"), !has_always_uv),
+            (String::from("alwaysUv"), has_always_uv),
+        ];
+        #[cfg(feature = "fingerprint")]
+        {
+            let has_fingerprint = !env.persist().template_infos()?.is_empty();
+            options.push((String::from("uv"), has_fingerprint));
+            options.push((String::from("bioEnroll"), has_fingerprint));
+        }
         if env.customization().enterprise_attestation_mode().is_some() {
             options.push((String::from("ep"), storage::enterprise_attestation(env)?));
         }
-        let client_pin_result = match env.persist().pin_hash() {
-            Ok(Some(pin_hash)) => Some(pin_hash),
-            Ok(None) => None,
-            Err(_) => None,
-        };
-        // `uv` is included in the options map since we have a fingerprint
-        // sensor, but we set the option to false if the sensor is not
-        // "configured" meaning it has no registered fingerprints (and therefore
-        // cannot provide user verification).
-        let uv = env.fingerprint().get_enrollment_count() > 0;
-        options.append(&mut vec![
-            (String::from("rk"), true),
-            (String::from("up"), true),
-            (String::from("uv"), uv),
-            (String::from("alwaysUv"), has_always_uv),
-            (String::from("credMgmt"), true),
-            (String::from("authnrCfg"), true),
-            //(String::from("clientPin"), storage::pin_hash(env)?.is_some()),
-            (String::from("clientPin"), client_pin_result.is_some()),
-            (String::from("largeBlobs"), true),
-            (String::from("pinUvAuthToken"), true),
-            (String::from("setMinPINLength"), true),
-            (String::from("makeCredUvNotRqd"), !has_always_uv),
-            (String::from("bioEnroll"), true),
-            (String::from("credentialMgmtPreview"), true),
-            (String::from("userVerificationMgmtPreview"), true),
-            (String::from("uvToken"), true),
-            (String::from("plat"), false),
-        ]);
         let mut pin_protocols = vec![PinUvAuthProtocol::V2 as u64];
         if env.customization().allows_pin_protocol_v1() {
             pin_protocols.push(PinUvAuthProtocol::V1 as u64);
@@ -1961,14 +1390,21 @@ impl<E: Env> CtapState<E> {
                 max_rp_ids_for_set_min_pin_length: Some(
                     env.customization().max_rp_ids_length() as u64
                 ),
+                #[cfg(feature = "fingerprint")]
+                preferred_platform_uv_attempts: Some(
+                    env.customization().preferred_platform_uv_attempts() as u64,
+                ),
+                #[cfg(not(feature = "fingerprint"))]
+                preferred_platform_uv_attempts: None,
+                // https://fidoalliance.org/specs/common-specs/fido-registry-v2.2-ps-20220523.html#user-verification-methods
+                #[cfg(feature = "fingerprint")]
+                uv_modality: Some(0x02),
+                #[cfg(not(feature = "fingerprint"))]
+                uv_modality: None,
                 certifications: None,
                 remaining_discoverable_credentials: Some(
                     storage::remaining_credentials(env)? as u64
                 ),
-                preferred_platform_uv_attempts: Some(
-                    env.customization().preferred_platform_uv_attempts() as u64,
-                ),
-                uv_modality: Some(2),
             },
         ))
     }
@@ -1985,8 +1421,16 @@ impl<E: Env> CtapState<E> {
         reset(env)?;
         self.client_pin.reset(env);
 
-        // FF is a special case to delete all fingerprints
-        env.fingerprint().delete_enrollment(0xff);
+        #[cfg(feature = "fingerprint")]
+        {
+            let template_infos = env.persist().template_infos()?;
+            for template_info in template_infos {
+                env.fingerprint()
+                    .remove_enrollment(&template_info.template_id)?;
+                env.persist()
+                    .remove_template_id(&template_info.template_id)?;
+            }
+        }
 
         #[cfg(feature = "with_ctap1")]
         {
@@ -2108,6 +1552,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "fingerprint")]
     fn test_get_info() {
         let mut env = TestEnv::default();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
@@ -2134,6 +1579,74 @@ mod test {
                 "ep" => env.customization().enterprise_attestation_mode().map(|_| false),
                 "rk" => true,
                 "up" => true,
+                "uv" => false,
+                #[cfg(feature = "config_command")]
+                "uvAcfg" => true,
+                #[cfg(feature = "config_command")]
+                "alwaysUv" => false,
+                "credMgmt" => true,
+                #[cfg(feature = "config_command")]
+                "authnrCfg" => true,
+                "bioEnroll" => false,
+                "clientPin" => false,
+                "largeBlobs" => true,
+                "pinUvAuthToken" => true,
+                #[cfg(feature = "config_command")]
+                "setMinPINLength" => true,
+                "makeCredUvNotRqd" => true,
+            },
+            0x05 => env.customization().max_msg_size() as u64,
+            0x06 => cbor_array![2, 1],
+            0x07 => env.customization().max_credential_count_in_list().map(|c| c as u64),
+            0x08 => MAX_CREDENTIAL_ID_SIZE as u64,
+            0x09 => cbor_array!["usb"],
+            0x0A => cbor_array_vec!(SUPPORTED_CRED_PARAMS.to_vec()),
+            0x0B => env.customization().max_large_blob_array_size() as u64,
+            0x0C => false,
+            0x0D => storage::min_pin_length(&mut env).unwrap() as u64,
+            0x0E => 0,
+            0x0F => env.customization().max_cred_blob_length() as u64,
+            0x10 => env.customization().max_rp_ids_length() as u64,
+            0x11 => env.customization().preferred_platform_uv_attempts() as u64,
+            0x12 => 0x02,
+            0x14 => storage::remaining_credentials(&mut env).unwrap() as u64,
+        };
+
+        let mut response_cbor = vec![0x00];
+        assert!(cbor_write(expected_cbor, &mut response_cbor).is_ok());
+        assert_eq!(info_reponse, response_cbor);
+    }
+
+    #[test]
+    #[cfg(not(feature = "fingerprint"))]
+    fn test_get_info() {
+        let mut env = TestEnv::default();
+        let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
+        let info_reponse = ctap_state.process_command(&mut env, &[0x04], DUMMY_CHANNEL);
+
+        // Fails when removing `to_vec` for `SUPPORTED_CRED_PARAMS` as linted.
+        #[allow(clippy::unnecessary_to_owned)]
+        let expected_cbor = cbor_map_options! {
+             0x01 => cbor_array_vec![vec![
+                    #[cfg(feature = "with_ctap1")]
+                    String::from(U2F_VERSION_STRING),
+                    String::from(FIDO2_VERSION_STRING),
+                    String::from(FIDO2_1_VERSION_STRING),
+                ]],
+            0x02 => cbor_array![
+                    String::from("hmac-secret"),
+                    String::from("credProtect"),
+                    String::from("minPinLength"),
+                    String::from("credBlob"),
+                    String::from("largeBlobKey"),
+                ],
+            0x03 => env.customization().aaguid(),
+            0x04 => cbor_map_options! {
+                "ep" => env.customization().enterprise_attestation_mode().map(|_| false),
+                "rk" => true,
+                "up" => true,
+                #[cfg(feature = "config_command")]
+                "uvAcfg" => true,
                 #[cfg(feature = "config_command")]
                 "alwaysUv" => false,
                 "credMgmt" => true,
@@ -3062,9 +2575,10 @@ mod test {
             permissions: None,
             permissions_rp_id: None,
         };
-        let key_agreement_response = ctap_state
-            .client_pin
-            .process_command(&mut env, client_pin_params);
+        let key_agreement_response =
+            ctap_state
+                .client_pin
+                .process_command(&mut env, client_pin_params, DUMMY_CHANNEL);
         let get_assertion_params = get_assertion_hmac_secret_params(
             key_agreement_key,
             key_agreement_response.unwrap(),
@@ -3113,9 +2627,10 @@ mod test {
             permissions: None,
             permissions_rp_id: None,
         };
-        let key_agreement_response = ctap_state
-            .client_pin
-            .process_command(&mut env, client_pin_params);
+        let key_agreement_response =
+            ctap_state
+                .client_pin
+                .process_command(&mut env, client_pin_params, DUMMY_CHANNEL);
         let get_assertion_params = get_assertion_hmac_secret_params(
             key_agreement_key,
             key_agreement_response.unwrap(),

--- a/libraries/opensk/src/ctap/mod.rs
+++ b/libraries/opensk/src/ctap/mod.rs
@@ -39,7 +39,8 @@ pub mod vendor_hid;
 pub use self::client_pin::PIN_AUTH_LENGTH;
 use self::client_pin::{ClientPin, PinPermission};
 use self::command::{
-    AuthenticatorGetAssertionParameters, AuthenticatorMakeCredentialParameters, Command,
+    AuthenticatorBioEnrollmentParameters, AuthenticatorGetAssertionParameters,
+    AuthenticatorMakeCredentialParameters, Command,
 };
 #[cfg(feature = "config_command")]
 use self::config_command::process_config;
@@ -55,8 +56,8 @@ use self::hid::{
 };
 use self::large_blobs::LargeBlobState;
 use self::response::{
-    AuthenticatorGetAssertionResponse, AuthenticatorGetInfoResponse,
-    AuthenticatorMakeCredentialResponse, ResponseData,
+    AuthenticatorBioEnrollmentResponse, AuthenticatorGetAssertionResponse,
+    AuthenticatorGetInfoResponse, AuthenticatorMakeCredentialResponse, ResponseData,
 };
 use self::secret::Secret;
 use self::status_code::{Ctap2StatusCode, CtapResult};
@@ -69,6 +70,7 @@ use crate::api::crypto::hkdf256::Hkdf256;
 use crate::api::crypto::sha256::Sha256;
 use crate::api::crypto::HASH_SIZE;
 use crate::api::customization::Customization;
+use crate::api::fingerprint::{Fingerprint, FingerprintCaptureError};
 use crate::api::key_store::{CredentialSource, KeyStore, MAX_CREDENTIAL_ID_SIZE};
 use crate::api::persist::{Attestation, AttestationId, Persist};
 use crate::api::private_key::PrivateKey;
@@ -106,6 +108,7 @@ pub const FIDO2_VERSION_STRING: &str = "FIDO_2_0";
 #[cfg(feature = "with_ctap1")]
 pub const U2F_VERSION_STRING: &str = "U2F_V2";
 pub const FIDO2_1_VERSION_STRING: &str = "FIDO_2_1";
+pub const FIDO2_1_PRE_VERSION_STRING: &str = "FIDO_2_1_PRE";
 
 // We currently only support one algorithm for signatures: ES256.
 // This algorithm is requested in MakeCredential and advertized in GetInfo.
@@ -125,6 +128,34 @@ const SUPPORTED_CRED_PARAMS: &[PublicKeyCredentialParameter] = &[
     #[cfg(feature = "ed25519")]
     EDDSA_CRED_PARAM,
 ];
+
+#[derive(Debug)]
+pub enum BioEnrollmentSubCommand {
+    EnrollBegin = 1,
+    EnrollCaptureNextSample = 2,
+    CancelCurrentEnrollment = 3,
+    EnumerateEnrollments = 4,
+    SetFriendlyName = 5,
+    RemoveEnrollment = 6,
+    GetFingerSensorInfo = 7,
+}
+
+impl TryFrom<u64> for BioEnrollmentSubCommand {
+    type Error = ();
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(BioEnrollmentSubCommand::EnrollBegin),
+            2 => Ok(BioEnrollmentSubCommand::EnrollCaptureNextSample),
+            3 => Ok(BioEnrollmentSubCommand::CancelCurrentEnrollment),
+            4 => Ok(BioEnrollmentSubCommand::EnumerateEnrollments),
+            5 => Ok(BioEnrollmentSubCommand::SetFriendlyName),
+            6 => Ok(BioEnrollmentSubCommand::RemoveEnrollment),
+            7 => Ok(BioEnrollmentSubCommand::GetFingerSensorInfo),
+            _ => Err(()),
+        }
+    }
+}
 
 fn get_preferred_cred_param(
     params: &[PublicKeyCredentialParameter],
@@ -276,6 +307,17 @@ fn is_cancel(packet: &ProcessedPacket) -> bool {
     }
 }
 
+pub fn send_keepalive_packet<E: Env>(env: &mut E, channel: Channel) -> CtapResult<()> {
+    let (cid, transport) = match channel {
+        Channel::MainHid(cid) => (cid, Transport::MainHid),
+        #[cfg(feature = "vendor_hid")]
+        Channel::VendorHid(cid) => (cid, Transport::VendorHid),
+    };
+    let endpoint = transport.usb_endpoint();
+    let keepalive_msg = CtapHid::<E>::keepalive(cid, KeepaliveStatus::UpNeeded);
+    send_packets(env, endpoint, keepalive_msg)
+}
+
 fn wait_and_respond_busy<E: Env>(env: &mut E, channel: Channel) -> CtapResult<()> {
     let (cid, transport) = match channel {
         Channel::MainHid(cid) => (cid, Transport::MainHid),
@@ -367,6 +409,30 @@ pub enum StatefulCommand {
     EnumerateRps(usize),
     EnumerateCredentials(Vec<usize>),
     LargeBlob(LargeBlobState),
+}
+
+//https://fidoalliance.org/specs/fido2/vendor/BioEnrollmentPrototype.pdf
+#[repr(u64)]
+enum Ctap2EnrollFeedback {
+    FpGood = 0,
+    FpPoorQuality = 7,
+    FpMergeFailure = 10,
+    FpTooFast = 0x5,
+    FpTooHigh = 0x1,
+    NoUserActivity = 0xd,
+}
+
+#[repr(u64)]
+enum BioEnrollmentSubCommandParamFields {
+    TemplateId = 0x01,
+    TemplateFriendlyName = 0x02,
+    TimeoutMilliseconds = 0x03,
+}
+
+#[repr(u64)]
+enum BioEnrollmentSubCommandTemplateInfoFields {
+    TemplateId = 0x01,
+    TemplateFriendlyName = 0x02,
 }
 
 /// Stores the current CTAP command state and when it times out.
@@ -546,6 +612,9 @@ pub struct CtapState<E: Env> {
     pub(crate) u2f_up_state: U2fUserPresenceState<E>,
     // The state initializes to Reset and its timeout, and never goes back to Reset.
     stateful_command_permission: StatefulPermission<E>,
+    // Bio enrollment variables
+    remaining_samples: u64,
+    current_template_id: u8,
 }
 
 impl<E: Env> CtapState<E> {
@@ -562,6 +631,8 @@ impl<E: Env> CtapState<E> {
             #[cfg(feature = "with_ctap1")]
             u2f_up_state: U2fUserPresenceState::new(),
             stateful_command_permission,
+            remaining_samples: 3,
+            current_template_id: 0,
         }
     }
 
@@ -596,6 +667,486 @@ impl<E: Env> CtapState<E> {
     pub fn can_sleep(&mut self, env: &mut E) -> bool {
         !self.client_pin.has_token(env)
             && self.stateful_command_permission.get_command(env).is_err()
+    }
+
+    pub fn process_bio_enrollment(
+        &mut self,
+        env: &mut E,
+        params: AuthenticatorBioEnrollmentParameters,
+        _channel: Channel,
+    ) -> CtapResult<ResponseData> {
+        let sub_command = params
+            .sub_command
+            .map(|cmd| BioEnrollmentSubCommand::try_from(cmd))
+            .transpose()
+            .map_err(|_| Ctap2StatusCode::CTAP2_ERR_INVALID_SUBCOMMAND)?;
+
+        debug_ctap!(
+            env,
+            "CT: Received bio enrollment sub_command {:?}",
+            sub_command
+        );
+
+        match sub_command {
+            Some(BioEnrollmentSubCommand::EnrollBegin) => {
+                // Check which fingerprint slots are open, and use the first
+                // one. If none is open we will eventually return an error.
+                let mut fingerlist = [0u8; 5];
+                env.fingerprint().get_enrollments(&mut fingerlist);
+                debug_ctap!(env, "CT: EnrollBegin fingerlist {:?}", fingerlist);
+                let open_index = fingerlist.iter().position(|&x| x == 0);
+
+                let timeout_ms = params.sub_command_params.map_or(2000, |p| {
+                    p.extract_map().map_or(2000, |m| {
+                        m.iter()
+                            .find_map(|e| {
+                                if e.0.clone().extract_unsigned().unwrap_or(0)
+                                    == BioEnrollmentSubCommandParamFields::TimeoutMilliseconds
+                                        as u64
+                                {
+                                    e.1.clone().extract_unsigned()
+                                } else {
+                                    None
+                                }
+                            })
+                            .unwrap_or(2000) as usize
+                    })
+                });
+
+                match open_index {
+                    Some(index) => {
+                        self.remaining_samples =
+                            env.fingerprint().get_enrollment_count_maximum() as u64;
+                        self.current_template_id = index as u8;
+
+                        debug_ctap!(
+                            env,
+                            "CT: EnrollBegin remaining samples {:?}    enrollment_count {:?}   timeout_ms {:?}",
+                            self.remaining_samples,
+                            self.current_template_id,
+                            timeout_ms,
+                        );
+                        env.fingerprint()
+                            .prepare_enrollment(self.current_template_id);
+                        let sample_ret = env.fingerprint().capture_sample(timeout_ms);
+
+                        let sample_status = match sample_ret {
+                            Ok(()) => {
+                                self.remaining_samples -= 1;
+                                Ctap2EnrollFeedback::FpGood
+                            }
+                            Err(e) => {
+                                debug_ctap!(env, "CT: EnrollBegin capture_sample() - Err\n");
+                                match e {
+                                    FingerprintCaptureError::NoTouch => {
+                                        Ctap2EnrollFeedback::NoUserActivity
+                                    }
+                                    FingerprintCaptureError::ImageBad => {
+                                        Ctap2EnrollFeedback::FpPoorQuality
+                                    }
+                                    FingerprintCaptureError::ImagePartial => {
+                                        Ctap2EnrollFeedback::FpTooHigh
+                                    }
+                                    FingerprintCaptureError::TooFast => {
+                                        Ctap2EnrollFeedback::FpTooFast
+                                    }
+                                    FingerprintCaptureError::Other => {
+                                        Ctap2EnrollFeedback::FpPoorQuality
+                                    }
+                                }
+                            }
+                        };
+
+                        let response = AuthenticatorBioEnrollmentResponse {
+                            modality: Some(1),
+                            fingerprint_kind: None,
+                            max_capture_samples_required_for_enroll: Some(self.remaining_samples),
+                            template_id: Some(vec![self.current_template_id]),
+                            last_enroll_sample_status: Some(sample_status as u64),
+                            remaining_samples: Some(self.remaining_samples),
+                            template_infos: None,
+                            max_template_friendly_name: Some(32),
+                        };
+
+                        Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
+                    }
+                    None => {
+                        debug_ctap!(
+                            env,
+                            "CT: EnrollBegin no space (timeout_ms {:?})",
+                            timeout_ms,
+                        );
+
+                        Err(Ctap2StatusCode::CTAP2_ERR_FP_DATABASE_FULL)
+                    }
+                }
+            }
+            Some(BioEnrollmentSubCommand::EnrollCaptureNextSample) => {
+                //check_user_presence(env, channel)?;
+
+                let timeout_ms = params.sub_command_params.map_or(2000, |p| {
+                    p.extract_map().map_or(2000, |m| {
+                        m.iter()
+                            .find_map(|e| {
+                                if e.0.clone().extract_unsigned().unwrap_or(0)
+                                    == BioEnrollmentSubCommandParamFields::TimeoutMilliseconds
+                                        as u64
+                                {
+                                    e.1.clone().extract_unsigned()
+                                } else {
+                                    None
+                                }
+                            })
+                            .unwrap_or(2000) as usize
+                    })
+                });
+
+                let sample_ret = env.fingerprint().capture_sample(timeout_ms);
+
+                debug_ctap!(
+                    env,
+                    "CT: EnrollCaptureNext capture_sample return {:?} remaining_sample {:?} timeout_ms {:?}",
+                    sample_ret,
+                    self.remaining_samples,
+                    timeout_ms,
+                );
+
+                let sample_status = match sample_ret {
+                    Ok(()) => {
+                        if self.remaining_samples == 1 {
+                            let commit_ret = env.fingerprint().commit_enrollment();
+                            debug_ctap!(
+                                env,
+                                "CT: EnrollCaptureNext return from commit enroll {:?}",
+                                commit_ret
+                            );
+                            match commit_ret {
+                                Ok(()) => {
+                                    // nothing to do
+                                    debug_ctap!(
+                                        env,
+                                        "CT: EnrollCaptureNext commit_enrollment() - OK\n"
+                                    );
+                                    self.remaining_samples -= 1;
+                                    Ctap2EnrollFeedback::FpGood
+                                }
+
+                                Err(()) => {
+                                    debug_ctap!(
+                                        env,
+                                        "CT: EnrollCaptureNext commit_enrollment() - Err\n"
+                                    );
+                                    Ctap2EnrollFeedback::FpMergeFailure
+                                }
+                            }
+                        } else {
+                            self.remaining_samples -= 1;
+                            Ctap2EnrollFeedback::FpGood
+                        }
+                    }
+
+                    Err(e) => {
+                        debug_ctap!(env, "CT: EnrollCaptureNext capture_sample() - Err\n");
+                        match e {
+                            FingerprintCaptureError::NoTouch => Ctap2EnrollFeedback::NoUserActivity,
+                            FingerprintCaptureError::ImageBad => Ctap2EnrollFeedback::FpPoorQuality,
+                            FingerprintCaptureError::ImagePartial => Ctap2EnrollFeedback::FpTooHigh,
+                            FingerprintCaptureError::TooFast => Ctap2EnrollFeedback::FpTooFast,
+                            FingerprintCaptureError::Other => Ctap2EnrollFeedback::FpPoorQuality,
+                        }
+                    }
+                };
+
+                let response = AuthenticatorBioEnrollmentResponse {
+                    modality: Some(1),
+                    fingerprint_kind: None,
+                    max_capture_samples_required_for_enroll: None,
+                    template_id: Some(vec![self.current_template_id]),
+                    last_enroll_sample_status: Some(sample_status as u64),
+                    remaining_samples: Some(self.remaining_samples),
+                    template_infos: None,
+                    max_template_friendly_name: Some(32),
+                };
+                Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
+            }
+
+            Some(BioEnrollmentSubCommand::CancelCurrentEnrollment) => {
+                {
+                    env.fingerprint().cancel_enrollment();
+                }
+
+                let response = AuthenticatorBioEnrollmentResponse {
+                    modality: Some(1),
+                    fingerprint_kind: None,
+                    max_capture_samples_required_for_enroll: None,
+                    template_id: None,
+                    last_enroll_sample_status: None,
+                    remaining_samples: None,
+                    template_infos: None,
+                    max_template_friendly_name: Some(32),
+                };
+                Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
+            }
+
+            Some(BioEnrollmentSubCommand::EnumerateEnrollments) => {
+                let mut fingerlist = [0u8; 5];
+                env.fingerprint().get_enrollments(&mut fingerlist);
+
+                debug_ctap!(env, "CT: EnumerateEnrollment fingerlist {:?}", fingerlist);
+
+                let template_ids: Vec<u8> = fingerlist
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(index, &id)| if id != 0 { Some(index as u8) } else { None })
+                    .collect();
+
+                debug_ctap!(
+                    env,
+                    "CT: EnumerateEnrollment template_ids {:?}",
+                    template_ids
+                );
+
+                // Check if there are no enrolled fingers
+                if template_ids.is_empty() {
+                    debug_ctap!(
+                        env,
+                        "CT: No enrolled fingers found. Returning CTAP2_ERR_INVALID_OPTION."
+                    );
+                    return Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION);
+                }
+
+                let template_infos_array: Vec<cbor::Value> = template_ids
+                    .iter()
+                    .map(|template_id| {
+                        let template_id = *template_id;
+                        let friendly_name =
+                            storage::get_friendly_name(env, template_id).unwrap_or("".to_string());
+                        debug_ctap!(env, "CT: Friendly name for template_id {}:", template_id);
+                        if friendly_name.len() > 0 {
+                            debug_ctap!(env, "'{}'", friendly_name);
+                        }
+                        let entries = vec![
+                            (
+                                cbor::Value::unsigned(
+                                    BioEnrollmentSubCommandTemplateInfoFields::TemplateId as u64,
+                                ),
+                                cbor::Value::byte_string(vec![template_id]),
+                            ),
+                            (
+                                cbor::Value::unsigned(
+                                    BioEnrollmentSubCommandTemplateInfoFields::TemplateFriendlyName
+                                        as u64,
+                                ),
+                                cbor::Value::text_string(friendly_name),
+                            ),
+                        ];
+                        cbor::Value::map(entries)
+                    })
+                    .collect();
+
+                let template_infos = cbor::Value::array(template_infos_array);
+
+                let response = AuthenticatorBioEnrollmentResponse {
+                    modality: Some(1),
+                    fingerprint_kind: None,
+                    max_capture_samples_required_for_enroll: None,
+                    template_id: None,
+                    last_enroll_sample_status: None,
+                    remaining_samples: None,
+                    template_infos: Some(template_infos),
+                    max_template_friendly_name: Some(32),
+                };
+                Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
+            }
+
+            Some(BioEnrollmentSubCommand::RemoveEnrollment) => {
+                debug_ctap!(env, "CT: RemoveEnrollment");
+
+                let template_id = params.sub_command_params.map_or(
+                    Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER),
+                    |p| {
+                        p.extract_map().map_or(
+                            Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER),
+                            |m| {
+                                m.iter()
+                                    .find_map(|e| {
+                                        if e.0.clone().extract_unsigned().unwrap_or(0)
+                                            == BioEnrollmentSubCommandParamFields::TemplateId as u64
+                                        {
+                                            Some(Ok(*e
+                                                .1
+                                                .clone()
+                                                .extract_byte_string()
+                                                .unwrap_or(vec![])
+                                                .get(0)
+                                                .unwrap_or(&0)))
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                    .unwrap_or(Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER))
+                            },
+                        )
+                    },
+                )?;
+
+                debug_ctap!(env, "Remove enrollment tempate_id {:?}", template_id);
+
+                env.fingerprint().delete_enrollment(template_id);
+
+                let response = AuthenticatorBioEnrollmentResponse {
+                    modality: Some(1),
+                    fingerprint_kind: None,
+                    max_capture_samples_required_for_enroll: None,
+                    template_id: None,
+                    last_enroll_sample_status: None,
+                    remaining_samples: None,
+                    template_infos: None,
+                    max_template_friendly_name: Some(32),
+                };
+                Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
+            }
+
+            Some(BioEnrollmentSubCommand::SetFriendlyName) => {
+                debug_ctap!(env, "CT: SetFriendlyName");
+
+                // placeholder:  Check token permission for "be"
+
+                let template_id = params.sub_command_params.clone().map_or(
+                    Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER),
+                    |p| {
+                        p.extract_map().map_or(
+                            Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER),
+                            |m| {
+                                m.iter()
+                                    .find_map(|e| {
+                                        if e.0.clone().extract_unsigned().unwrap_or(0)
+                                            == BioEnrollmentSubCommandParamFields::TemplateId as u64
+                                        {
+                                            Some(Ok(*e
+                                                .1
+                                                .clone()
+                                                .extract_byte_string()
+                                                .unwrap_or(vec![])
+                                                .get(0)
+                                                .unwrap_or(&0)))
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                    .unwrap_or(Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER))
+                            },
+                        )
+                    },
+                )?;
+
+                let friendly_name = params.sub_command_params.clone().map_or(
+                    Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER),
+                    |p| {
+                        p.extract_map().map_or(
+                            Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER),
+                            |m| {
+                                m.iter()
+                                    .find_map(|e| {
+                                        if e.0.clone().extract_unsigned().unwrap_or(0)
+                                            == BioEnrollmentSubCommandParamFields::TemplateFriendlyName as u64
+                                        {
+                                            Some(Ok(e
+                                                .1
+                                                .clone()
+                                                .extract_text_string()
+                                                .unwrap_or("".to_string())
+                                                ))
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                    .unwrap_or(Err(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER))
+                            },
+                        )
+                    },
+                )?;
+
+                debug_ctap!(env, "CT: SetFriendlyName {} {}", template_id, friendly_name);
+
+                // Check if the friendly name length exceeds the maximum allowed
+                const MAX_TEMPLATE_FRIENDLY_NAME: usize = 32; // set it to 32 for now
+                if friendly_name.len() > MAX_TEMPLATE_FRIENDLY_NAME {
+                    return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_LENGTH);
+                }
+
+                // Check if there's an existing enrollment for the given template_id
+                let mut fingerlist = [0u8; 5];
+                env.fingerprint().get_enrollments(&mut fingerlist);
+                if !fingerlist.contains(&template_id) {
+                    return Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION);
+                }
+
+                storage::store_friendly_name(env, template_id, &friendly_name)?;
+
+                // Create a template_info map with the new friendly name
+                let template_info = cbor::Value::map(vec![
+                    (
+                        cbor::Value::unsigned(
+                            BioEnrollmentSubCommandTemplateInfoFields::TemplateId as u64,
+                        ),
+                        cbor::Value::byte_string(vec![template_id]),
+                    ),
+                    (
+                        cbor::Value::unsigned(
+                            BioEnrollmentSubCommandTemplateInfoFields::TemplateFriendlyName as u64,
+                        ),
+                        cbor::Value::text_string(friendly_name.clone()),
+                    ),
+                ]);
+
+                // Create the template_infos array with the single template_info
+                let template_infos = cbor::Value::array(vec![template_info]);
+
+                let response = AuthenticatorBioEnrollmentResponse {
+                    modality: Some(1),
+                    fingerprint_kind: None,
+                    max_capture_samples_required_for_enroll: None,
+                    template_id: None,
+                    last_enroll_sample_status: None,
+                    remaining_samples: None,
+                    template_infos: Some(template_infos),
+                    max_template_friendly_name: Some(32),
+                };
+                Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
+            }
+
+            Some(BioEnrollmentSubCommand::GetFingerSensorInfo) => {
+                // Finger sensor information
+                debug_ctap!(env, "CT: GetFingerSensorInfo");
+
+                let response = AuthenticatorBioEnrollmentResponse {
+                    modality: Some(1),
+                    fingerprint_kind: Some(1),
+                    max_capture_samples_required_for_enroll: Some(6), // change to 6 to match RT
+                    max_template_friendly_name: Some(32),
+                    template_id: None,
+                    last_enroll_sample_status: None,
+                    remaining_samples: None,
+                    template_infos: None,
+                };
+                Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
+            }
+
+            _ => {
+                let response = AuthenticatorBioEnrollmentResponse {
+                    modality: Some(1),
+                    fingerprint_kind: Some(1),
+                    max_capture_samples_required_for_enroll: Some(5),
+                    max_template_friendly_name: Some(32),
+                    template_id: None,
+                    last_enroll_sample_status: None,
+                    remaining_samples: None,
+                    template_infos: None,
+                };
+                Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
+            }
+        }
     }
 
     pub fn process_command(
@@ -647,6 +1198,7 @@ impl<E: Env> CtapState<E> {
             (Command::AuthenticatorGetNextAssertion, Ok(StatefulCommand::GetAssertion(_)))
             | (Command::AuthenticatorLargeBlobs(_), Ok(StatefulCommand::LargeBlob(_)))
             | (Command::AuthenticatorReset, Ok(StatefulCommand::Reset))
+            | (Command::AuthenticatorBioEnrollment(_), Ok(StatefulCommand::Reset))
             // AuthenticatorGetInfo still allows Reset.
             | (Command::AuthenticatorGetInfo, Ok(StatefulCommand::Reset))
             // AuthenticatorSelection still allows Reset.
@@ -685,8 +1237,13 @@ impl<E: Env> CtapState<E> {
                 self.process_get_assertion(env, params, channel)
             }
             Command::AuthenticatorGetNextAssertion => self.process_get_next_assertion(env),
+            Command::AuthenticatorBioEnrollment(params) => {
+                self.process_bio_enrollment(env, params, channel)
+            }
             Command::AuthenticatorGetInfo => self.process_get_info(env),
-            Command::AuthenticatorClientPin(params) => self.client_pin.process_command(env, params),
+            Command::AuthenticatorClientPin(params) => {
+                self.client_pin.process_command(env, params, channel)
+            }
             Command::AuthenticatorReset => self.process_reset(env, channel),
             Command::AuthenticatorCredentialManagement(params) => process_credential_management(
                 env,
@@ -816,16 +1373,47 @@ impl<E: Env> CtapState<E> {
             }
             None => {
                 if options.uv {
-                    return Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION);
+                    // Internal UV is enabled. Check the built in UV and return on error.
+                    // If no error, return the UV_FLAG bit.
+                    self.client_pin
+                        .perform_built_in_uv(env, channel, true)
+                        .map_err(|e| {
+                            // 6.1.2.11.2 error cases:
+                            //
+                            // 1. If the error reason is a user action timeout,
+                            //    then return CTAP2_ERR_USER_ACTION_TIMEOUT.
+                            // 2. If the ClientPin option ID is true and the
+                            //    noMcGaPermissionsWithClientPin option ID is
+                            //    absent or false, end the operation by
+                            //    returning CTAP2_ERR_PUAT_REQUIRED.
+                            // 3. If the uvRetries counter is <= 0, return
+                            //    CTAP2_ERR_PIN_BLOCKED.
+                            // 4. Otherwise, end the operation by returning
+                            //    CTAP2_ERR_OPERATION_DENIED.
+                            match e {
+                                Ctap2StatusCode::CTAP2_ERR_USER_ACTION_TIMEOUT => {
+                                    Ctap2StatusCode::CTAP2_ERR_USER_ACTION_TIMEOUT
+                                }
+                                Ctap2StatusCode::CTAP2_ERR_UV_BLOCKED => {
+                                    Ctap2StatusCode::CTAP2_ERR_PIN_BLOCKED
+                                }
+                                _ => {
+                                    let client_pin_option =
+                                        env.persist().pin_hash().unwrap_or(None).is_some();
+                                    if client_pin_option {
+                                        // noMcGaPermissionsWithClientPin is absent
+                                        Ctap2StatusCode::CTAP2_ERR_PUAT_REQUIRED
+                                    } else {
+                                        Ctap2StatusCode::CTAP2_ERR_OPERATION_DENIED
+                                    }
+                                }
+                            }
+                        })?;
+                    UV_FLAG
+                } else {
+                    // Flags set to 0
+                    0x00
                 }
-                if storage::has_always_uv(env)? {
-                    return Err(Ctap2StatusCode::CTAP2_ERR_PUAT_REQUIRED);
-                }
-                // Corresponds to makeCredUvNotRqd set to true.
-                if options.rk && env.persist().pin_hash()?.is_some() {
-                    return Err(Ctap2StatusCode::CTAP2_ERR_PUAT_REQUIRED);
-                }
-                0x00
             }
         };
         flags |= UP_FLAG | AT_FLAG;
@@ -857,7 +1445,11 @@ impl<E: Env> CtapState<E> {
         self.client_pin.clear_token_flags();
 
         let default_cred_protect = env.customization().default_cred_protect();
-        let mut cred_protect_policy = extensions.cred_protect;
+        let mut cred_protect_policy = Some(
+            extensions
+                .cred_protect
+                .unwrap_or(CredentialProtectionPolicy::UserVerificationOptional),
+        );
         if cred_protect_policy.unwrap_or(CredentialProtectionPolicy::UserVerificationOptional)
             < default_cred_protect.unwrap_or(CredentialProtectionPolicy::UserVerificationOptional)
         {
@@ -1185,15 +1777,19 @@ impl<E: Env> CtapState<E> {
                 UV_FLAG
             }
             None => {
+                debug_ctap!(env, "process_get_assertion: use UV (no pin_uv_auth_param)");
                 if options.uv {
-                    return Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION);
+                    // Internal UV is enabled. Check the built in UV and return on error.
+                    // If no error, return the UV_FLAG bit.
+                    self.client_pin.perform_built_in_uv(env, channel, true)?;
+                    UV_FLAG
+                } else {
+                    // Flags set to 0
+                    0
                 }
-                if options.up && storage::has_always_uv(env)? {
-                    return Err(Ctap2StatusCode::CTAP2_ERR_PUAT_REQUIRED);
-                }
-                0x00
             }
         };
+
         if options.up {
             flags |= UP_FLAG;
         }
@@ -1289,6 +1885,7 @@ impl<E: Env> CtapState<E> {
         let mut versions = vec![
             String::from(FIDO2_VERSION_STRING),
             String::from(FIDO2_1_VERSION_STRING),
+            String::from(FIDO2_1_PRE_VERSION_STRING),
         ];
         #[cfg(feature = "with_ctap1")]
         if !has_always_uv {
@@ -1298,25 +1895,35 @@ impl<E: Env> CtapState<E> {
         if env.customization().enterprise_attestation_mode().is_some() {
             options.push((String::from("ep"), storage::enterprise_attestation(env)?));
         }
+        let client_pin_result = match env.persist().pin_hash() {
+            Ok(Some(pin_hash)) => Some(pin_hash),
+            Ok(None) => None,
+            Err(_) => None,
+        };
+        // `uv` is included in the options map since we have a fingerprint
+        // sensor, but we set the option to false if the sensor is not
+        // "configured" meaning it has no registered fingerprints (and therefore
+        // cannot provide user verification).
+        let uv = env.fingerprint().get_enrollment_count() > 0;
         options.append(&mut vec![
             (String::from("rk"), true),
             (String::from("up"), true),
+            (String::from("uv"), uv),
+            (String::from("alwaysUv"), has_always_uv),
             (String::from("credMgmt"), true),
-            #[cfg(feature = "config_command")]
             (String::from("authnrCfg"), true),
-            (
-                String::from("clientPin"),
-                env.persist().pin_hash()?.is_some(),
-            ),
+            //(String::from("clientPin"), storage::pin_hash(env)?.is_some()),
+            (String::from("clientPin"), client_pin_result.is_some()),
             (String::from("largeBlobs"), true),
             (String::from("pinUvAuthToken"), true),
-            #[cfg(feature = "config_command")]
             (String::from("setMinPINLength"), true),
             (String::from("makeCredUvNotRqd"), !has_always_uv),
+            (String::from("bioEnroll"), true),
+            (String::from("credentialMgmtPreview"), true),
+            (String::from("userVerificationMgmtPreview"), true),
+            (String::from("uvToken"), true),
+            (String::from("plat"), false),
         ]);
-        if cfg!(feature = "config_command") || env.customization().enforce_always_uv() {
-            options.push((String::from("alwaysUv"), has_always_uv));
-        }
         let mut pin_protocols = vec![PinUvAuthProtocol::V2 as u64];
         if env.customization().allows_pin_protocol_v1() {
             pin_protocols.push(PinUvAuthProtocol::V1 as u64);
@@ -1358,6 +1965,10 @@ impl<E: Env> CtapState<E> {
                 remaining_discoverable_credentials: Some(
                     storage::remaining_credentials(env)? as u64
                 ),
+                preferred_platform_uv_attempts: Some(
+                    env.customization().preferred_platform_uv_attempts() as u64,
+                ),
+                uv_modality: Some(2),
             },
         ))
     }
@@ -1373,6 +1984,10 @@ impl<E: Env> CtapState<E> {
 
         reset(env)?;
         self.client_pin.reset(env);
+
+        // FF is a special case to delete all fingerprints
+        env.fingerprint().delete_enrollment(0xff);
+
         #[cfg(feature = "with_ctap1")]
         {
             // We create a block statement to wrap this assignment expression, because attributes

--- a/libraries/opensk/src/ctap/response.rs
+++ b/libraries/opensk/src/ctap/response.rs
@@ -17,6 +17,10 @@ use super::data_formats::{
     PublicKeyCredentialDescriptor, PublicKeyCredentialParameter, PublicKeyCredentialRpEntity,
     PublicKeyCredentialUserEntity,
 };
+#[cfg(feature = "fingerprint")]
+use super::fingerprint::TemplateInfo;
+#[cfg(feature = "fingerprint")]
+use crate::api::fingerprint::Ctap2EnrollFeedback;
 use alloc::string::String;
 use alloc::vec::Vec;
 use sk_cbor as cbor;
@@ -33,13 +37,13 @@ pub enum ResponseData {
     AuthenticatorGetInfo(AuthenticatorGetInfoResponse),
     AuthenticatorClientPin(Option<AuthenticatorClientPinResponse>),
     AuthenticatorReset,
+    #[cfg(feature = "fingerprint")]
+    AuthenticatorBioEnrollment(Option<AuthenticatorBioEnrollmentResponse>),
     AuthenticatorCredentialManagement(Option<AuthenticatorCredentialManagementResponse>),
     AuthenticatorSelection,
     AuthenticatorLargeBlobs(Option<AuthenticatorLargeBlobsResponse>),
     #[cfg(feature = "config_command")]
     AuthenticatorConfig,
-
-    AuthenticatorBioEnrollment(Option<AuthenticatorBioEnrollmentResponse>),
 }
 
 impl From<ResponseData> for Option<cbor::Value> {
@@ -51,13 +55,13 @@ impl From<ResponseData> for Option<cbor::Value> {
             ResponseData::AuthenticatorGetInfo(data) => Some(data.into()),
             ResponseData::AuthenticatorClientPin(data) => data.map(|d| d.into()),
             ResponseData::AuthenticatorReset => None,
+            #[cfg(feature = "fingerprint")]
+            ResponseData::AuthenticatorBioEnrollment(data) => data.map(|d| d.into()),
             ResponseData::AuthenticatorCredentialManagement(data) => data.map(|d| d.into()),
             ResponseData::AuthenticatorSelection => None,
             ResponseData::AuthenticatorLargeBlobs(data) => data.map(|d| d.into()),
             #[cfg(feature = "config_command")]
             ResponseData::AuthenticatorConfig => None,
-
-            ResponseData::AuthenticatorBioEnrollment(data) => data.map(|d| d.into()),
         }
     }
 }
@@ -142,14 +146,8 @@ pub struct AuthenticatorGetInfoResponse {
     pub firmware_version: Option<u64>,
     pub max_cred_blob_length: Option<u64>,
     pub max_rp_ids_for_set_min_pin_length: Option<u64>,
-    // Missing response fields as they are only relevant for internal UV:
-    // - 0x11: preferredPlatformUvAttempts
-    // - 0x12: uvModality
-    // Add them when your hardware supports any kind of user verification within
-    // the boundary of the device, e.g. fingerprint or built-in keyboard.
     pub preferred_platform_uv_attempts: Option<u64>,
     pub uv_modality: Option<u64>,
-
     pub certifications: Option<Vec<(String, i64)>>,
     pub remaining_discoverable_credentials: Option<u64>,
     // - 0x15: vendorPrototypeConfigCommands missing as we don't support it.
@@ -174,10 +172,8 @@ impl From<AuthenticatorGetInfoResponse> for cbor::Value {
             firmware_version,
             max_cred_blob_length,
             max_rp_ids_for_set_min_pin_length,
-
             preferred_platform_uv_attempts,
             uv_modality,
-
             certifications,
             remaining_discoverable_credentials,
         } = get_info_response;
@@ -252,16 +248,43 @@ impl From<AuthenticatorClientPinResponse> for cbor::Value {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[cfg(feature = "fingerprint")]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct AuthenticatorBioEnrollmentResponse {
     pub modality: Option<u64>,
     pub fingerprint_kind: Option<u64>,
     pub max_capture_samples_required_for_enroll: Option<u64>,
-    pub max_template_friendly_name: Option<u64>,
     pub template_id: Option<Vec<u8>>,
-    pub last_enroll_sample_status: Option<u64>,
+    pub last_enroll_sample_status: Option<Ctap2EnrollFeedback>,
     pub remaining_samples: Option<u64>,
-    pub template_infos: Option<cbor::Value>,
+    pub template_infos: Option<Vec<TemplateInfo>>,
+    pub max_template_friendly_name: Option<u64>,
+}
+
+#[cfg(feature = "fingerprint")]
+impl From<AuthenticatorBioEnrollmentResponse> for cbor::Value {
+    fn from(bio_enrollment_response: AuthenticatorBioEnrollmentResponse) -> Self {
+        let AuthenticatorBioEnrollmentResponse {
+            modality,
+            fingerprint_kind,
+            max_capture_samples_required_for_enroll,
+            template_id,
+            last_enroll_sample_status,
+            remaining_samples,
+            template_infos,
+            max_template_friendly_name,
+        } = bio_enrollment_response;
+        cbor_map_options! {
+            0x01 => modality,
+            0x02 => fingerprint_kind,
+            0x03 => max_capture_samples_required_for_enroll,
+            0x04 => template_id,
+            0x05 => last_enroll_sample_status,
+            0x06 => remaining_samples,
+            0x07 => template_infos.map(|vec| cbor_array_vec!(vec)),
+            0x08 => max_template_friendly_name,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -292,21 +315,6 @@ pub struct AuthenticatorCredentialManagementResponse {
     pub total_credentials: Option<u64>,
     pub cred_protect: Option<CredentialProtectionPolicy>,
     pub large_blob_key: Option<Vec<u8>>,
-}
-
-impl From<AuthenticatorBioEnrollmentResponse> for cbor::Value {
-    fn from(bio_enrollment_response: AuthenticatorBioEnrollmentResponse) -> Self {
-        cbor_map_options! {
-            0x01 => bio_enrollment_response.modality,
-            0x02 => bio_enrollment_response.fingerprint_kind,
-            0x03 => bio_enrollment_response.max_capture_samples_required_for_enroll,
-            0x04 => bio_enrollment_response.template_id,
-            0x05 => bio_enrollment_response.last_enroll_sample_status,
-            0x06 => bio_enrollment_response.remaining_samples,
-            0x07 => bio_enrollment_response.template_infos,
-            0x08 => bio_enrollment_response.max_template_friendly_name,
-        }
-    }
 }
 
 impl From<AuthenticatorCredentialManagementResponse> for cbor::Value {
@@ -446,6 +454,8 @@ mod test {
             firmware_version: None,
             max_cred_blob_length: None,
             max_rp_ids_for_set_min_pin_length: None,
+            preferred_platform_uv_attempts: None,
+            uv_modality: None,
             certifications: None,
             remaining_discoverable_credentials: None,
         };
@@ -478,6 +488,8 @@ mod test {
             firmware_version: Some(0),
             max_cred_blob_length: Some(1024),
             max_rp_ids_for_set_min_pin_length: Some(8),
+            preferred_platform_uv_attempts: Some(1),
+            uv_modality: Some(1),
             certifications: Some(vec![(String::from("example-cert"), 1)]),
             remaining_discoverable_credentials: Some(150),
         };
@@ -500,6 +512,8 @@ mod test {
             0x0E => 0,
             0x0F => 1024,
             0x10 => 8,
+            0x11 => 1,
+            0x12 => 1,
             0x13 => cbor_map! {"example-cert" => 1},
             0x14 => 150,
         };
@@ -523,6 +537,7 @@ mod test {
             0x02 => vec![70],
             0x03 => 8,
             0x04 => false,
+            0x05 => 0,
         };
         assert_eq!(response_cbor, Some(expected_cbor));
     }
@@ -536,6 +551,49 @@ mod test {
     #[test]
     fn test_reset_into_cbor() {
         let response_cbor: Option<cbor::Value> = ResponseData::AuthenticatorReset.into();
+        assert_eq!(response_cbor, None);
+    }
+
+    #[test]
+    #[cfg(feature = "fingerprint")]
+    fn test_used_bio_enrollment_into_cbor() {
+        let template_info = TemplateInfo {
+            template_id: vec![1],
+            template_friendly_name: Some(String::from("Name")),
+        };
+        let bio_enrollment_response = AuthenticatorBioEnrollmentResponse {
+            modality: Some(1),
+            fingerprint_kind: Some(2),
+            max_capture_samples_required_for_enroll: Some(3),
+            template_id: Some(vec![4]),
+            last_enroll_sample_status: Some(Ctap2EnrollFeedback::FpTooFast),
+            remaining_samples: Some(6),
+            template_infos: Some(vec![template_info]),
+            max_template_friendly_name: Some(8),
+        };
+        let response_cbor: Option<cbor::Value> =
+            ResponseData::AuthenticatorBioEnrollment(Some(bio_enrollment_response)).into();
+        let expected_cbor = cbor_map_options! {
+            0x01 => 1,
+            0x02 => 2,
+            0x03 => 3,
+            0x04 => vec![4],
+            0x05 => 5,
+            0x06 => 6,
+            0x07 => cbor_array![cbor_map! {
+                0x01 => vec![1],
+                0x02 => "Name",
+            }],
+            0x08 => 8,
+        };
+        assert_eq!(response_cbor, Some(expected_cbor));
+    }
+
+    #[test]
+    #[cfg(feature = "fingerprint")]
+    fn test_empty_bio_enrollment_into_cbor() {
+        let response_cbor: Option<cbor::Value> =
+            ResponseData::AuthenticatorBioEnrollment(None).into();
         assert_eq!(response_cbor, None);
     }
 

--- a/libraries/opensk/src/ctap/response.rs
+++ b/libraries/opensk/src/ctap/response.rs
@@ -38,6 +38,8 @@ pub enum ResponseData {
     AuthenticatorLargeBlobs(Option<AuthenticatorLargeBlobsResponse>),
     #[cfg(feature = "config_command")]
     AuthenticatorConfig,
+
+    AuthenticatorBioEnrollment(Option<AuthenticatorBioEnrollmentResponse>),
 }
 
 impl From<ResponseData> for Option<cbor::Value> {
@@ -54,6 +56,8 @@ impl From<ResponseData> for Option<cbor::Value> {
             ResponseData::AuthenticatorLargeBlobs(data) => data.map(|d| d.into()),
             #[cfg(feature = "config_command")]
             ResponseData::AuthenticatorConfig => None,
+
+            ResponseData::AuthenticatorBioEnrollment(data) => data.map(|d| d.into()),
         }
     }
 }
@@ -143,6 +147,9 @@ pub struct AuthenticatorGetInfoResponse {
     // - 0x12: uvModality
     // Add them when your hardware supports any kind of user verification within
     // the boundary of the device, e.g. fingerprint or built-in keyboard.
+    pub preferred_platform_uv_attempts: Option<u64>,
+    pub uv_modality: Option<u64>,
+
     pub certifications: Option<Vec<(String, i64)>>,
     pub remaining_discoverable_credentials: Option<u64>,
     // - 0x15: vendorPrototypeConfigCommands missing as we don't support it.
@@ -167,6 +174,10 @@ impl From<AuthenticatorGetInfoResponse> for cbor::Value {
             firmware_version,
             max_cred_blob_length,
             max_rp_ids_for_set_min_pin_length,
+
+            preferred_platform_uv_attempts,
+            uv_modality,
+
             certifications,
             remaining_discoverable_credentials,
         } = get_info_response;
@@ -204,6 +215,8 @@ impl From<AuthenticatorGetInfoResponse> for cbor::Value {
             0x0E => firmware_version,
             0x0F => max_cred_blob_length,
             0x10 => max_rp_ids_for_set_min_pin_length,
+            0x11 => preferred_platform_uv_attempts,
+            0x12 => uv_modality,
             0x13 => certifications_cbor,
             0x14 => remaining_discoverable_credentials,
         }
@@ -216,7 +229,7 @@ pub struct AuthenticatorClientPinResponse {
     pub pin_uv_auth_token: Option<Vec<u8>>,
     pub retries: Option<u64>,
     pub power_cycle_state: Option<bool>,
-    // - 0x05: uvRetries missing as we don't support internal UV.
+    pub uv_retries: Option<u64>,
 }
 
 impl From<AuthenticatorClientPinResponse> for cbor::Value {
@@ -226,6 +239,7 @@ impl From<AuthenticatorClientPinResponse> for cbor::Value {
             pin_uv_auth_token,
             retries,
             power_cycle_state,
+            uv_retries,
         } = client_pin_response;
 
         cbor_map_options! {
@@ -233,8 +247,21 @@ impl From<AuthenticatorClientPinResponse> for cbor::Value {
             0x02 => pin_uv_auth_token,
             0x03 => retries,
             0x04 => power_cycle_state,
+            0x05 => uv_retries,
         }
     }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct AuthenticatorBioEnrollmentResponse {
+    pub modality: Option<u64>,
+    pub fingerprint_kind: Option<u64>,
+    pub max_capture_samples_required_for_enroll: Option<u64>,
+    pub max_template_friendly_name: Option<u64>,
+    pub template_id: Option<Vec<u8>>,
+    pub last_enroll_sample_status: Option<u64>,
+    pub remaining_samples: Option<u64>,
+    pub template_infos: Option<cbor::Value>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -265,6 +292,21 @@ pub struct AuthenticatorCredentialManagementResponse {
     pub total_credentials: Option<u64>,
     pub cred_protect: Option<CredentialProtectionPolicy>,
     pub large_blob_key: Option<Vec<u8>>,
+}
+
+impl From<AuthenticatorBioEnrollmentResponse> for cbor::Value {
+    fn from(bio_enrollment_response: AuthenticatorBioEnrollmentResponse) -> Self {
+        cbor_map_options! {
+            0x01 => bio_enrollment_response.modality,
+            0x02 => bio_enrollment_response.fingerprint_kind,
+            0x03 => bio_enrollment_response.max_capture_samples_required_for_enroll,
+            0x04 => bio_enrollment_response.template_id,
+            0x05 => bio_enrollment_response.last_enroll_sample_status,
+            0x06 => bio_enrollment_response.remaining_samples,
+            0x07 => bio_enrollment_response.template_infos,
+            0x08 => bio_enrollment_response.max_template_friendly_name,
+        }
+    }
 }
 
 impl From<AuthenticatorCredentialManagementResponse> for cbor::Value {
@@ -472,6 +514,7 @@ mod test {
             pin_uv_auth_token: Some(vec![70]),
             retries: Some(8),
             power_cycle_state: Some(false),
+            uv_retries: Some(0),
         };
         let response_cbor: Option<cbor::Value> =
             ResponseData::AuthenticatorClientPin(Some(client_pin_response)).into();

--- a/libraries/opensk/src/ctap/storage.rs
+++ b/libraries/opensk/src/ctap/storage.rs
@@ -204,6 +204,7 @@ pub fn reset_pin_retries(env: &mut impl Env) -> CtapResult<()> {
 }
 
 /// Returns the number of remaining UV retries.
+#[cfg(feature = "fingerprint")]
 pub fn uv_retries(env: &mut impl Env) -> CtapResult<u8> {
     Ok(env
         .customization()
@@ -212,11 +213,13 @@ pub fn uv_retries(env: &mut impl Env) -> CtapResult<u8> {
 }
 
 /// Decrements the number of remaining UV retries.
+#[cfg(feature = "fingerprint")]
 pub fn decr_uv_retries(env: &mut impl Env) -> CtapResult<()> {
     env.persist().incr_uv_fails()
 }
 
 /// Resets the number of remaining UV retries.
+#[cfg(feature = "fingerprint")]
 pub fn reset_uv_retries(env: &mut impl Env) -> CtapResult<()> {
     env.persist().reset_uv_retries()
 }
@@ -303,21 +306,6 @@ pub fn toggle_always_uv(env: &mut impl Env) -> CtapResult<()> {
         return Err(Ctap2StatusCode::CTAP2_ERR_OPERATION_DENIED);
     }
     env.persist().toggle_always_uv()
-}
-
-/// Store a Bio Enrollment friendly name for a given template_id.
-pub fn store_friendly_name<E: Env>(
-    env: &mut E,
-    template_id: u8,
-    friendly_name: &str,
-) -> CtapResult<()> {
-    env.persist()
-        .store_friendly_name(template_id, friendly_name)
-}
-
-/// Retrieve the Bio Enrollment friendly name for a given template_id.
-pub fn get_friendly_name<E: Env>(env: &mut E, template_id: u8) -> CtapResult<String> {
-    env.persist().get_friendly_name(template_id)
 }
 
 /// Iterator for credentials.
@@ -671,6 +659,35 @@ mod test {
         assert_eq!(
             pin_retries(&mut env),
             Ok(env.customization().max_pin_retries())
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "fingerprint")]
+    fn test_uv_retries() {
+        let mut env = TestEnv::default();
+
+        // The uv retries is initially at the maximum.
+        assert_eq!(
+            uv_retries(&mut env),
+            Ok(env.customization().max_uv_retries())
+        );
+
+        // Decrementing the uv retries decrements the uv retries.
+        for retries in (0..env.customization().max_uv_retries()).rev() {
+            decr_uv_retries(&mut env).unwrap();
+            assert_eq!(uv_retries(&mut env), Ok(retries));
+        }
+
+        // Decrementing the uv retries after zero does not modify the uv retries.
+        decr_uv_retries(&mut env).unwrap();
+        assert_eq!(uv_retries(&mut env), Ok(0));
+
+        // Resetting the uv retries resets the uv retries.
+        reset_uv_retries(&mut env).unwrap();
+        assert_eq!(
+            uv_retries(&mut env),
+            Ok(env.customization().max_uv_retries())
         );
     }
 

--- a/libraries/opensk/src/ctap/storage.rs
+++ b/libraries/opensk/src/ctap/storage.rs
@@ -203,6 +203,24 @@ pub fn reset_pin_retries(env: &mut impl Env) -> CtapResult<()> {
     env.persist().reset_pin_retries()
 }
 
+/// Returns the number of remaining UV retries.
+pub fn uv_retries(env: &mut impl Env) -> CtapResult<u8> {
+    Ok(env
+        .customization()
+        .max_uv_retries()
+        .saturating_sub(env.persist().uv_fails()?))
+}
+
+/// Decrements the number of remaining UV retries.
+pub fn decr_uv_retries(env: &mut impl Env) -> CtapResult<()> {
+    env.persist().incr_uv_fails()
+}
+
+/// Resets the number of remaining UV retries.
+pub fn reset_uv_retries(env: &mut impl Env) -> CtapResult<()> {
+    env.persist().reset_uv_retries()
+}
+
 /// Returns the minimum PIN length.
 pub fn min_pin_length(env: &mut impl Env) -> CtapResult<u8> {
     Ok(env
@@ -285,6 +303,21 @@ pub fn toggle_always_uv(env: &mut impl Env) -> CtapResult<()> {
         return Err(Ctap2StatusCode::CTAP2_ERR_OPERATION_DENIED);
     }
     env.persist().toggle_always_uv()
+}
+
+/// Store a Bio Enrollment friendly name for a given template_id.
+pub fn store_friendly_name<E: Env>(
+    env: &mut E,
+    template_id: u8,
+    friendly_name: &str,
+) -> CtapResult<()> {
+    env.persist()
+        .store_friendly_name(template_id, friendly_name)
+}
+
+/// Retrieve the Bio Enrollment friendly name for a given template_id.
+pub fn get_friendly_name<E: Env>(env: &mut E, template_id: u8) -> CtapResult<String> {
+    env.persist().get_friendly_name(template_id)
 }
 
 /// Iterator for credentials.

--- a/libraries/opensk/src/env/mod.rs
+++ b/libraries/opensk/src/env/mod.rs
@@ -18,6 +18,7 @@ use crate::api::crypto::ecdh::Ecdh;
 use crate::api::crypto::ecdsa::Ecdsa;
 use crate::api::crypto::Crypto;
 use crate::api::customization::Customization;
+use crate::api::fingerprint::Fingerprint;
 use crate::api::key_store::KeyStore;
 use crate::api::persist::Persist;
 use crate::api::rng::Rng;
@@ -49,12 +50,14 @@ pub trait Env {
     type HidConnection: HidConnection;
     type Clock: Clock;
     type Crypto: Crypto;
+    type Fingerprint: Fingerprint;
 
     fn rng(&mut self) -> &mut Self::Rng;
     fn user_presence(&mut self) -> &mut Self::UserPresence;
     fn persist(&mut self) -> &mut Self::Persist;
     fn key_store(&mut self) -> &mut Self::KeyStore;
     fn clock(&mut self) -> &mut Self::Clock;
+    fn fingerprint(&mut self) -> &mut Self::Fingerprint;
 
     /// Creates a write instance for debugging.
     ///

--- a/libraries/opensk/src/env/mod.rs
+++ b/libraries/opensk/src/env/mod.rs
@@ -18,6 +18,7 @@ use crate::api::crypto::ecdh::Ecdh;
 use crate::api::crypto::ecdsa::Ecdsa;
 use crate::api::crypto::Crypto;
 use crate::api::customization::Customization;
+#[cfg(feature = "fingerprint")]
 use crate::api::fingerprint::Fingerprint;
 use crate::api::key_store::KeyStore;
 use crate::api::persist::Persist;
@@ -50,6 +51,7 @@ pub trait Env {
     type HidConnection: HidConnection;
     type Clock: Clock;
     type Crypto: Crypto;
+    #[cfg(feature = "fingerprint")]
     type Fingerprint: Fingerprint;
 
     fn rng(&mut self) -> &mut Self::Rng;
@@ -57,6 +59,7 @@ pub trait Env {
     fn persist(&mut self) -> &mut Self::Persist;
     fn key_store(&mut self) -> &mut Self::KeyStore;
     fn clock(&mut self) -> &mut Self::Clock;
+    #[cfg(feature = "fingerprint")]
     fn fingerprint(&mut self) -> &mut Self::Fingerprint;
 
     /// Creates a write instance for debugging.

--- a/libraries/opensk/src/env/test/customization.rs
+++ b/libraries/opensk/src/env/test/customization.rs
@@ -35,6 +35,9 @@ pub struct TestCustomization {
     max_large_blob_array_size: usize,
     max_rp_ids_length: usize,
     max_supported_resident_keys: usize,
+    preferred_platform_uv_attempts: usize,
+    max_uv_retries: u8,
+    max_uv_attempts_for_internal_retries: u8,
 }
 
 impl TestCustomization {
@@ -126,6 +129,18 @@ impl Customization for TestCustomization {
     fn max_supported_resident_keys(&self) -> usize {
         self.max_supported_resident_keys
     }
+
+    fn preferred_platform_uv_attempts(&self) -> usize {
+        self.preferred_platform_uv_attempts
+    }
+
+    fn max_uv_retries(&self) -> u8 {
+        self.max_uv_retries
+    }
+
+    fn max_uv_attempts_for_internal_retries(&self) -> u8 {
+        self.max_uv_attempts_for_internal_retries
+    }
 }
 
 impl From<CustomizationImpl> for TestCustomization {
@@ -148,6 +163,9 @@ impl From<CustomizationImpl> for TestCustomization {
             max_large_blob_array_size,
             max_rp_ids_length,
             max_supported_resident_keys,
+            preferred_platform_uv_attempts,
+            max_uv_retries,
+            max_uv_attempts_for_internal_retries,
         } = c;
 
         let default_min_pin_length_rp_ids = default_min_pin_length_rp_ids
@@ -178,6 +196,9 @@ impl From<CustomizationImpl> for TestCustomization {
             max_large_blob_array_size,
             max_rp_ids_length,
             max_supported_resident_keys,
+            preferred_platform_uv_attempts,
+            max_uv_retries,
+            max_uv_attempts_for_internal_retries,
         }
     }
 }

--- a/libraries/opensk/src/env/test/customization.rs
+++ b/libraries/opensk/src/env/test/customization.rs
@@ -28,6 +28,12 @@ pub struct TestCustomization {
     enterprise_rp_id_list: Vec<String>,
     max_msg_size: usize,
     max_pin_retries: u8,
+    #[cfg(feature = "fingerprint")]
+    max_uv_attempts_for_internal_retries: u8,
+    #[cfg(feature = "fingerprint")]
+    max_uv_retries: u8,
+    #[cfg(feature = "fingerprint")]
+    preferred_platform_uv_attempts: usize,
     use_batch_attestation: bool,
     use_signature_counter: bool,
     max_cred_blob_length: usize,
@@ -35,9 +41,8 @@ pub struct TestCustomization {
     max_large_blob_array_size: usize,
     max_rp_ids_length: usize,
     max_supported_resident_keys: usize,
-    preferred_platform_uv_attempts: usize,
-    max_uv_retries: u8,
-    max_uv_attempts_for_internal_retries: u8,
+    #[cfg(feature = "fingerprint")]
+    max_template_friendly_name: usize,
 }
 
 impl TestCustomization {
@@ -102,6 +107,21 @@ impl Customization for TestCustomization {
         self.max_pin_retries
     }
 
+    #[cfg(feature = "fingerprint")]
+    fn max_uv_attempts_for_internal_retries(&self) -> u8 {
+        self.max_uv_attempts_for_internal_retries
+    }
+
+    #[cfg(feature = "fingerprint")]
+    fn max_uv_retries(&self) -> u8 {
+        self.max_uv_retries
+    }
+
+    #[cfg(feature = "fingerprint")]
+    fn preferred_platform_uv_attempts(&self) -> usize {
+        self.preferred_platform_uv_attempts
+    }
+
     fn use_batch_attestation(&self) -> bool {
         self.use_batch_attestation
     }
@@ -130,16 +150,9 @@ impl Customization for TestCustomization {
         self.max_supported_resident_keys
     }
 
-    fn preferred_platform_uv_attempts(&self) -> usize {
-        self.preferred_platform_uv_attempts
-    }
-
-    fn max_uv_retries(&self) -> u8 {
-        self.max_uv_retries
-    }
-
-    fn max_uv_attempts_for_internal_retries(&self) -> u8 {
-        self.max_uv_attempts_for_internal_retries
+    #[cfg(feature = "fingerprint")]
+    fn max_template_friendly_name(&self) -> usize {
+        self.max_template_friendly_name
     }
 }
 
@@ -156,6 +169,12 @@ impl From<CustomizationImpl> for TestCustomization {
             enterprise_rp_id_list,
             max_msg_size,
             max_pin_retries,
+            #[cfg(feature = "fingerprint")]
+            max_uv_attempts_for_internal_retries,
+            #[cfg(feature = "fingerprint")]
+            max_uv_retries,
+            #[cfg(feature = "fingerprint")]
+            preferred_platform_uv_attempts,
             use_batch_attestation,
             use_signature_counter,
             max_cred_blob_length,
@@ -163,9 +182,8 @@ impl From<CustomizationImpl> for TestCustomization {
             max_large_blob_array_size,
             max_rp_ids_length,
             max_supported_resident_keys,
-            preferred_platform_uv_attempts,
-            max_uv_retries,
-            max_uv_attempts_for_internal_retries,
+            #[cfg(feature = "fingerprint")]
+            max_template_friendly_name,
         } = c;
 
         let default_min_pin_length_rp_ids = default_min_pin_length_rp_ids
@@ -189,6 +207,12 @@ impl From<CustomizationImpl> for TestCustomization {
             enterprise_rp_id_list,
             max_msg_size,
             max_pin_retries,
+            #[cfg(feature = "fingerprint")]
+            max_uv_attempts_for_internal_retries,
+            #[cfg(feature = "fingerprint")]
+            max_uv_retries,
+            #[cfg(feature = "fingerprint")]
+            preferred_platform_uv_attempts,
             use_batch_attestation,
             use_signature_counter,
             max_cred_blob_length,
@@ -196,9 +220,8 @@ impl From<CustomizationImpl> for TestCustomization {
             max_large_blob_array_size,
             max_rp_ids_length,
             max_supported_resident_keys,
-            preferred_platform_uv_attempts,
-            max_uv_retries,
-            max_uv_attempts_for_internal_retries,
+            #[cfg(feature = "fingerprint")]
+            max_template_friendly_name,
         }
     }
 }

--- a/libraries/opensk/src/env/test/mod.rs
+++ b/libraries/opensk/src/env/test/mod.rs
@@ -16,6 +16,7 @@ use crate::api::clock::Clock;
 use crate::api::connection::{HidConnection, RecvStatus, UsbEndpoint};
 use crate::api::crypto::software_crypto::SoftwareCrypto;
 use crate::api::customization::DEFAULT_CUSTOMIZATION;
+use crate::api::fingerprint::{Fingerprint, FingerprintCaptureError, FingerprintCheckError};
 use crate::api::key_store;
 use crate::api::persist::{Persist, PersistIter};
 use crate::api::rng::Rng;
@@ -37,6 +38,7 @@ pub struct TestEnv {
     customization: TestCustomization,
     clock: TestClock,
     soft_reset: bool,
+    fingerprint: TestFingerprint,
 }
 
 pub type TestRng = StdRng;
@@ -88,6 +90,8 @@ impl Clock for TestClock {
 pub struct TestUserPresence {
     check: Box<dyn Fn() -> UserPresenceResult>,
 }
+
+pub struct TestFingerprint {}
 
 pub struct TestWrite;
 
@@ -155,6 +159,7 @@ impl Default for TestEnv {
         let store = Store::new(storage).ok().unwrap();
         let customization = DEFAULT_CUSTOMIZATION.into();
         let clock = TestClock::default();
+        let fingerprint = TestFingerprint {};
         TestEnv {
             rng,
             user_presence,
@@ -162,6 +167,7 @@ impl Default for TestEnv {
             customization,
             clock,
             soft_reset: false,
+            fingerprint,
         }
     }
 }
@@ -198,6 +204,42 @@ impl UserPresence for TestUserPresence {
     fn check_complete(&mut self) {}
 }
 
+impl Fingerprint for TestFingerprint {
+    fn get_enrollment_count_maximum(&self) -> u8 {
+        10
+    }
+
+    fn get_enrollment_count(&self) -> u8 {
+        0
+    }
+
+    fn prepare_enrollment(&self, _index: u8) {}
+
+    fn capture_sample(&self, _timeout: usize) -> Result<(), FingerprintCaptureError> {
+        Ok(())
+    }
+
+    fn commit_enrollment(&self) -> Result<(), ()> {
+        Ok(())
+    }
+
+    fn cancel_enrollment(&self) {}
+
+    fn get_enrollments(&self, _fingerlist: &mut [u8; 5]) {}
+
+    fn check_fingerprint_init(&mut self) {}
+
+    fn check_fingerprint(&self, _timeout: usize) -> Result<u8, FingerprintCheckError> {
+        Ok(0)
+    }
+
+    fn check_fingerprint_complete(&mut self) {}
+
+    fn delete_enrollment(&self, _index: u8) {}
+
+    fn setloglevel(&self, _level: u8) {}
+}
+
 impl key_store::Helper for TestEnv {}
 
 impl Env for TestEnv {
@@ -210,6 +252,7 @@ impl Env for TestEnv {
     type Customization = TestCustomization;
     type HidConnection = Self;
     type Crypto = SoftwareCrypto;
+    type Fingerprint = TestFingerprint;
 
     fn rng(&mut self) -> &mut Self::Rng {
         &mut self.rng
@@ -217,6 +260,10 @@ impl Env for TestEnv {
 
     fn user_presence(&mut self) -> &mut Self::UserPresence {
         &mut self.user_presence
+    }
+
+    fn fingerprint(&mut self) -> &mut Self::Fingerprint {
+        &mut self.fingerprint
     }
 
     fn persist(&mut self) -> &mut Self {

--- a/libraries/opensk/src/env/test/mod.rs
+++ b/libraries/opensk/src/env/test/mod.rs
@@ -16,7 +16,10 @@ use crate::api::clock::Clock;
 use crate::api::connection::{HidConnection, RecvStatus, UsbEndpoint};
 use crate::api::crypto::software_crypto::SoftwareCrypto;
 use crate::api::customization::DEFAULT_CUSTOMIZATION;
-use crate::api::fingerprint::{Fingerprint, FingerprintCaptureError, FingerprintCheckError};
+#[cfg(feature = "fingerprint")]
+use crate::api::fingerprint::{
+    Ctap2EnrollFeedback, Fingerprint, FingerprintCheckError, FingerprintKind,
+};
 use crate::api::key_store;
 use crate::api::persist::{Persist, PersistIter};
 use crate::api::rng::Rng;
@@ -38,6 +41,7 @@ pub struct TestEnv {
     customization: TestCustomization,
     clock: TestClock,
     soft_reset: bool,
+    #[cfg(feature = "fingerprint")]
     fingerprint: TestFingerprint,
 }
 
@@ -91,7 +95,13 @@ pub struct TestUserPresence {
     check: Box<dyn Fn() -> UserPresenceResult>,
 }
 
-pub struct TestFingerprint {}
+#[cfg(feature = "fingerprint")]
+#[derive(Debug, Default)]
+pub struct TestFingerprint {
+    // TODO more complete fake
+    template_ids: Vec<Vec<u8>>,
+    template_counter: usize,
+}
 
 pub struct TestWrite;
 
@@ -159,7 +169,8 @@ impl Default for TestEnv {
         let store = Store::new(storage).ok().unwrap();
         let customization = DEFAULT_CUSTOMIZATION.into();
         let clock = TestClock::default();
-        let fingerprint = TestFingerprint {};
+        #[cfg(feature = "fingerprint")]
+        let fingerprint = TestFingerprint::default();
         TestEnv {
             rng,
             user_presence,
@@ -167,6 +178,7 @@ impl Default for TestEnv {
             customization,
             clock,
             soft_reset: false,
+            #[cfg(feature = "fingerprint")]
             fingerprint,
         }
     }
@@ -204,40 +216,53 @@ impl UserPresence for TestUserPresence {
     fn check_complete(&mut self) {}
 }
 
+#[cfg(feature = "fingerprint")]
 impl Fingerprint for TestFingerprint {
-    fn get_enrollment_count_maximum(&self) -> u8 {
-        10
+    fn prepare_enrollment(&mut self) -> CtapResult<Vec<u8>> {
+        self.template_counter += 1;
+        let template_id = Vec::from(&self.template_counter.to_be_bytes());
+        self.template_ids.push(template_id.clone());
+        Ok(template_id)
     }
 
-    fn get_enrollment_count(&self) -> u8 {
-        0
+    fn capture_sample(
+        &mut self,
+        _template_id: &[u8],
+        _timeout_ms: Option<usize>,
+    ) -> CtapResult<(Ctap2EnrollFeedback, usize)> {
+        Ok((Ctap2EnrollFeedback::FpGood, 0))
     }
 
-    fn prepare_enrollment(&self, _index: u8) {}
-
-    fn capture_sample(&self, _timeout: usize) -> Result<(), FingerprintCaptureError> {
+    fn cancel_enrollment(&mut self) -> CtapResult<()> {
         Ok(())
     }
 
-    fn commit_enrollment(&self) -> Result<(), ()> {
+    fn remove_enrollment(&mut self, template_id: &[u8]) -> CtapResult<()> {
+        let index = self.template_ids.iter().position(|x| x == template_id);
+        if let Some(index) = index {
+            self.template_ids.remove(index);
+        }
         Ok(())
     }
-
-    fn cancel_enrollment(&self) {}
-
-    fn get_enrollments(&self, _fingerlist: &mut [u8; 5]) {}
 
     fn check_fingerprint_init(&mut self) {}
 
-    fn check_fingerprint(&self, _timeout: usize) -> Result<u8, FingerprintCheckError> {
-        Ok(0)
+    fn check_fingerprint(&mut self, _timeout_ms: usize) -> Result<(), FingerprintCheckError> {
+        if self.template_ids.is_empty() {
+            return Err(FingerprintCheckError::NoMatch);
+        }
+        Ok(())
     }
 
     fn check_fingerprint_complete(&mut self) {}
 
-    fn delete_enrollment(&self, _index: u8) {}
+    fn fingerprint_kind(&self) -> FingerprintKind {
+        FingerprintKind::Touch
+    }
 
-    fn setloglevel(&self, _level: u8) {}
+    fn max_capture_samples_required_for_enroll(&self) -> usize {
+        1
+    }
 }
 
 impl key_store::Helper for TestEnv {}
@@ -252,6 +277,7 @@ impl Env for TestEnv {
     type Customization = TestCustomization;
     type HidConnection = Self;
     type Crypto = SoftwareCrypto;
+    #[cfg(feature = "fingerprint")]
     type Fingerprint = TestFingerprint;
 
     fn rng(&mut self) -> &mut Self::Rng {
@@ -262,6 +288,7 @@ impl Env for TestEnv {
         &mut self.user_presence
     }
 
+    #[cfg(feature = "fingerprint")]
     fn fingerprint(&mut self) -> &mut Self::Fingerprint {
         &mut self.fingerprint
     }

--- a/run_desktop_tests.sh
+++ b/run_desktop_tests.sh
@@ -54,7 +54,7 @@ echo "Running Clippy lints..."
 cargo clippy --lib --tests --bins --benches --features std -- -D warnings
 cargo clippy --lib --tests --bins --benches --features std,"$MOST_FEATURES" -- -D warnings
 (cd libraries/opensk && cargo clippy --features std -- -D warnings)
-(cd libraries/opensk && cargo clippy --features std,config_command,debug_ctap,with_ctap1,vendor_hid,ed25519,fingerprint -- -D warnings)
+(cd libraries/opensk && cargo clippy --all-features -- -D warnings)
 (cd libraries/cbor && cargo clippy -- -D warnings)
 # Uncomment when persistent store is fixed:
 # (cd libraries/persistent_store && cargo clippy --features std -- -D warnings)

--- a/run_desktop_tests.sh
+++ b/run_desktop_tests.sh
@@ -17,7 +17,7 @@ set -ex
 
 ./fuzzing_setup.sh
 # Excludes std
-MOST_FEATURES=config_command,debug_allocations,debug_ctap,panic_console,verbose,with_ctap1,vendor_hid,ed25519
+MOST_FEATURES=config_command,debug_allocations,debug_ctap,panic_console,verbose,with_ctap1,vendor_hid,ed25519,fingerprint
 
 echo "Checking that OpenSK builds properly..."
 cargo check --release --target=thumbv7em-none-eabi
@@ -30,6 +30,7 @@ cargo check --release --target=thumbv7em-none-eabi --features with_ctap1
 cargo check --release --target=thumbv7em-none-eabi --features with_nfc
 cargo check --release --target=thumbv7em-none-eabi --features vendor_hid
 cargo check --release --target=thumbv7em-none-eabi --features ed25519
+cargo check --release --target=thumbv7em-none-eabi --features fingerprint
 cargo check --release --target=thumbv7em-none-eabi --features "$MOST_FEATURES"
 cargo check --release --target=thumbv7em-none-eabi --examples
 cargo check --release --target=thumbv7em-none-eabi --examples --features with_nfc

--- a/run_desktop_tests.sh
+++ b/run_desktop_tests.sh
@@ -54,7 +54,7 @@ echo "Running Clippy lints..."
 cargo clippy --lib --tests --bins --benches --features std -- -D warnings
 cargo clippy --lib --tests --bins --benches --features std,"$MOST_FEATURES" -- -D warnings
 (cd libraries/opensk && cargo clippy --features std -- -D warnings)
-(cd libraries/opensk && cargo clippy --features std,config_command,debug_ctap,with_ctap1,vendor_hid,ed25519 -- -D warnings)
+(cd libraries/opensk && cargo clippy --features std,config_command,debug_ctap,with_ctap1,vendor_hid,ed25519,fingerprint -- -D warnings)
 (cd libraries/cbor && cargo clippy -- -D warnings)
 # Uncomment when persistent store is fixed:
 # (cd libraries/persistent_store && cargo clippy --features std -- -D warnings)

--- a/src/env/tock/mod.rs
+++ b/src/env/tock/mod.rs
@@ -31,7 +31,10 @@ use opensk::api::clock::Clock;
 use opensk::api::connection::{HidConnection, RecvStatus, UsbEndpoint};
 use opensk::api::crypto::software_crypto::SoftwareCrypto;
 use opensk::api::customization::{CustomizationImpl, AAGUID_LENGTH, DEFAULT_CUSTOMIZATION};
-use opensk::api::fingerprint::{Fingerprint, FingerprintCaptureError, FingerprintCheckError};
+#[cfg(feature = "fingerprint")]
+use opensk::api::fingerprint::{
+    Ctap2EnrollFeedback, Fingerprint, FingerprintCheckError, FingerprintKind,
+};
 use opensk::api::key_store;
 use opensk::api::persist::{Persist, PersistIter};
 use opensk::api::rng::Rng;
@@ -338,44 +341,48 @@ where
     }
 }
 
+#[cfg(feature = "fingerprint")]
 impl<S, C> Fingerprint for TockEnv<S, C>
 where
     S: Syscalls,
     C: platform::subscribe::Config + platform::allow_ro::Config,
 {
-    fn get_enrollment_count_maximum(&self) -> u8 {
-        0
+    // This is a placeholder implementation, WIP.
+    fn prepare_enrollment(&mut self) -> CtapResult<Vec<u8>> {
+        Ok(Vec::new())
     }
 
-    fn get_enrollment_count(&self) -> u8 {
-        0
+    fn capture_sample(
+        &mut self,
+        _template_id: &[u8],
+        _timeout_ms: Option<usize>,
+    ) -> CtapResult<(Ctap2EnrollFeedback, usize)> {
+        Ok((Ctap2EnrollFeedback::FpGood, 0))
     }
 
-    fn prepare_enrollment(&self, _index: u8) {}
-
-    fn capture_sample(&self, _timeout_ms: usize) -> Result<(), FingerprintCaptureError> {
-        Err(FingerprintCaptureError::Other)
+    fn cancel_enrollment(&mut self) -> CtapResult<()> {
+        Ok(())
     }
 
-    fn commit_enrollment(&self) -> Result<(), ()> {
-        Err(())
+    fn remove_enrollment(&mut self, _template_id: &[u8]) -> CtapResult<()> {
+        Ok(())
     }
-
-    fn cancel_enrollment(&self) {}
-
-    fn get_enrollments(&self, _fingerlist: &mut [u8; 5]) {}
 
     fn check_fingerprint_init(&mut self) {}
 
-    fn check_fingerprint(&self, _timeout_ms: usize) -> Result<u8, FingerprintCheckError> {
-        Err(FingerprintCheckError::Other)
+    fn check_fingerprint(&mut self, _timeout_ms: usize) -> Result<(), FingerprintCheckError> {
+        Ok(())
     }
 
     fn check_fingerprint_complete(&mut self) {}
 
-    fn delete_enrollment(&self, _index: u8) {}
+    fn fingerprint_kind(&self) -> FingerprintKind {
+        FingerprintKind::Touch
+    }
 
-    fn setloglevel(&self, _level: u8) {}
+    fn max_capture_samples_required_for_enroll(&self) -> usize {
+        6
+    }
 }
 
 impl<S, C> key_store::Helper for TockEnv<S, C>
@@ -397,6 +404,7 @@ impl<S: Syscalls, C: platform::subscribe::Config + platform::allow_ro::Config> E
     type Customization = CustomizationImpl;
     type HidConnection = Self;
     type Crypto = SoftwareCrypto;
+    #[cfg(feature = "fingerprint")]
     type Fingerprint = Self;
 
     fn rng(&mut self) -> &mut Self::Rng {
@@ -407,6 +415,7 @@ impl<S: Syscalls, C: platform::subscribe::Config + platform::allow_ro::Config> E
         self
     }
 
+    #[cfg(feature = "fingerprint")]
     fn fingerprint(&mut self) -> &mut Self::Fingerprint {
         self
     }

--- a/src/env/tock/mod.rs
+++ b/src/env/tock/mod.rs
@@ -31,6 +31,7 @@ use opensk::api::clock::Clock;
 use opensk::api::connection::{HidConnection, RecvStatus, UsbEndpoint};
 use opensk::api::crypto::software_crypto::SoftwareCrypto;
 use opensk::api::customization::{CustomizationImpl, AAGUID_LENGTH, DEFAULT_CUSTOMIZATION};
+use opensk::api::fingerprint::{Fingerprint, FingerprintCaptureError, FingerprintCheckError};
 use opensk::api::key_store;
 use opensk::api::persist::{Persist, PersistIter};
 use opensk::api::rng::Rng;
@@ -337,6 +338,46 @@ where
     }
 }
 
+impl<S, C> Fingerprint for TockEnv<S, C>
+where
+    S: Syscalls,
+    C: platform::subscribe::Config + platform::allow_ro::Config,
+{
+    fn get_enrollment_count_maximum(&self) -> u8 {
+        0
+    }
+
+    fn get_enrollment_count(&self) -> u8 {
+        0
+    }
+
+    fn prepare_enrollment(&self, _index: u8) {}
+
+    fn capture_sample(&self, _timeout_ms: usize) -> Result<(), FingerprintCaptureError> {
+        Err(FingerprintCaptureError::Other)
+    }
+
+    fn commit_enrollment(&self) -> Result<(), ()> {
+        Err(())
+    }
+
+    fn cancel_enrollment(&self) {}
+
+    fn get_enrollments(&self, _fingerlist: &mut [u8; 5]) {}
+
+    fn check_fingerprint_init(&mut self) {}
+
+    fn check_fingerprint(&self, _timeout_ms: usize) -> Result<u8, FingerprintCheckError> {
+        Err(FingerprintCheckError::Other)
+    }
+
+    fn check_fingerprint_complete(&mut self) {}
+
+    fn delete_enrollment(&self, _index: u8) {}
+
+    fn setloglevel(&self, _level: u8) {}
+}
+
 impl<S, C> key_store::Helper for TockEnv<S, C>
 where
     S: Syscalls,
@@ -356,12 +397,17 @@ impl<S: Syscalls, C: platform::subscribe::Config + platform::allow_ro::Config> E
     type Customization = CustomizationImpl;
     type HidConnection = Self;
     type Crypto = SoftwareCrypto;
+    type Fingerprint = Self;
 
     fn rng(&mut self) -> &mut Self::Rng {
         &mut self.rng
     }
 
     fn user_presence(&mut self) -> &mut Self::UserPresence {
+        self
+    }
+
+    fn fingerprint(&mut self) -> &mut Self::Fingerprint {
         self
     }
 


### PR DESCRIPTION
Rebases and continues #718 .

The second commits adds the following missing features:

- PIN authentication of BioEnrollment subcommands that require it.
- A compile flag for all new features.
- Cleanup and generalization of the fingerprint API. (Example: `setloglevel` can be part of the `TockEnv` implementation, but shouldn't be included in the API.)
- A more useful fake implementation of the fingerprint API.
- Customization of Veridian's hardcoded numbers.
- Rollback of customizations that are specific to Veridian.
- Whether or not state is held is now left to the implementer of the fingerprint API. BioEnrollment is explicitly not a stateful command according to the specification.
- Don't ignore errors from hardware interaction, but forward them.
- Correct handling of UV retries: Reset everywhere necesary, and don't decrease the retry counter when asking for UV, but only when the user actually presented their finger.
- Removed magic numbers.
- Style matches existing code.
- CBOR parsing is more readable with new structs.
- Unit tests.
- Fixed all comments from the former PR.

Still missing:

- A more complete fake for testing.
- Tests for all subcommands.
- A working TockEnv implementation.

As is, the implementation is not usable on hardware.

Moves a lot of the code from the first commit around, so looking at these commits in isolation is harder than reviewing their sum.