### PR TITLE
Makes `PrivateKey` take actual private keys

### DIFF
--- a/libraries/opensk/src/api/key_store.rs
+++ b/libraries/opensk/src/api/key_store.rs
@@ -16,7 +16,6 @@ use crate::api::crypto::aes256::Aes256;
 use crate::api::crypto::hmac256::Hmac256;
 use crate::api::crypto::HASH_SIZE;
 use crate::api::persist::Persist;
-use crate::api::private_key::PrivateKey;
 use crate::ctap::crypto_wrapper::{aes256_cbc_decrypt, aes256_cbc_encrypt};
 use crate::ctap::data_formats::CredentialProtectionPolicy;
 use crate::ctap::secret::Secret;
@@ -44,7 +43,7 @@ const MAX_PADDING_LENGTH: u8 = 0xBF;
 #[derive(Clone, Debug)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct CredentialSource {
-    pub private_key: PrivateKey,
+    pub wrapped_private_key: cbor::Value,
     pub rp_id_hash: [u8; 32],
     pub cred_protect_policy: Option<CredentialProtectionPolicy>,
     pub cred_blob: Option<Vec<u8>>,
@@ -140,13 +139,8 @@ impl<T: Helper> KeyStore for T {
     /// stored server-side, this information is already available (unencrypted).
     fn wrap_credential(&mut self, credential: CredentialSource) -> Result<Vec<u8>, Error> {
         let mut payload = Vec::new();
-        let wrap_key = self.wrap_key::<T>()?;
-        let private_key_cbor = credential
-            .private_key
-            .to_cbor::<T>(self.rng(), &wrap_key)
-            .map_err(|_| Error)?;
         let cbor = cbor_map_options! {
-          CredentialSourceField::PrivateKey => private_key_cbor,
+          CredentialSourceField::PrivateKey => credential.wrapped_private_key,
           CredentialSourceField::RpIdHash => credential.rp_id_hash,
           CredentialSourceField::CredProtectPolicy => credential.cred_protect_policy,
           CredentialSourceField::CredBlob => credential.cred_blob,
@@ -205,7 +199,6 @@ impl<T: Helper> KeyStore for T {
                     return Ok(None);
                 }
                 decrypt_cbor_credential_id::<T>(
-                    self,
                     &master_keys.encryption,
                     &bytes[1..hmac_message_size],
                 )?
@@ -309,7 +302,6 @@ fn remove_padding(data: &[u8]) -> Result<&[u8], Error> {
 }
 
 fn decrypt_cbor_credential_id<E: Env>(
-    env: &mut E,
     encryption_key_bytes: &[u8; 32],
     bytes: &[u8],
 ) -> Result<Option<CredentialSource>, Error> {
@@ -320,17 +312,14 @@ fn decrypt_cbor_credential_id<E: Env>(
     let cbor_credential_source = cbor_read(unpadded).map_err(|_| Error)?;
     destructure_cbor_map! {
       let {
-          CredentialSourceField::PrivateKey => private_key,
+          CredentialSourceField::PrivateKey => wrapped_private_key,
           CredentialSourceField::RpIdHash => rp_id_hash,
           CredentialSourceField::CredProtectPolicy => cred_protect_policy,
           CredentialSourceField::CredBlob => cred_blob,
       } = extract_map(cbor_credential_source)?;
     }
-    Ok(match (private_key, rp_id_hash) {
-        (Some(private_key), Some(rp_id_hash)) => {
-            let wrap_key = env.key_store().wrap_key::<E>()?;
-            let private_key =
-                PrivateKey::from_cbor::<E>(&wrap_key, private_key).map_err(|_| Error)?;
+    Ok(match (wrapped_private_key, rp_id_hash) {
+        (Some(wrapped_private_key), Some(rp_id_hash)) => {
             let rp_id_hash = extract_byte_string(rp_id_hash)?;
             if rp_id_hash.len() != 32 {
                 return Err(Error);
@@ -341,7 +330,7 @@ fn decrypt_cbor_credential_id<E: Env>(
                 .map_err(|_| Error)?;
             let cred_blob = cred_blob.map(extract_byte_string).transpose()?;
             Some(CredentialSource {
-                private_key,
+                wrapped_private_key,
                 rp_id_hash: rp_id_hash.try_into().unwrap(),
                 cred_protect_policy,
                 cred_blob,
@@ -363,10 +352,25 @@ fn extract_map(cbor_value: cbor::Value) -> Result<Vec<(cbor::Value, cbor::Value)
 mod test {
     use super::*;
     use crate::api::customization::Customization;
+    use crate::api::private_key::PrivateKey;
     use crate::ctap::data_formats::SignatureAlgorithm;
     use crate::env::test::TestEnv;
 
     const UNSUPPORTED_CREDENTIAL_ID_VERSION: u8 = 0x80;
+
+    fn generate_credential_source(
+        env: &mut TestEnv,
+        signature_algorithm: SignatureAlgorithm,
+    ) -> CredentialSource {
+        let private_key = PrivateKey::new(env, signature_algorithm);
+        let wrapped_private_key = private_key.to_cbor(env).unwrap();
+        CredentialSource {
+            wrapped_private_key,
+            rp_id_hash: [0x55; 32],
+            cred_protect_policy: Some(CredentialProtectionPolicy::UserVerificationOptional),
+            cred_blob: Some(vec![0xAA; 32]),
+        }
+    }
 
     #[test]
     fn test_key_store() {
@@ -422,13 +426,7 @@ mod test {
 
     fn test_wrap_unwrap_credential(signature_algorithm: SignatureAlgorithm) {
         let mut env = TestEnv::default();
-        let private_key = PrivateKey::new(&mut env, signature_algorithm);
-        let credential_source = CredentialSource {
-            private_key,
-            rp_id_hash: [0x55; 32],
-            cred_protect_policy: Some(CredentialProtectionPolicy::UserVerificationOptional),
-            cred_blob: Some(vec![0xAA; 32]),
-        };
+        let credential_source = generate_credential_source(&mut env, signature_algorithm);
         let credential_id = env
             .key_store()
             .wrap_credential(credential_source.clone())
@@ -454,13 +452,7 @@ mod test {
 
     fn test_wrap_unwrap_credential_bad_version(signature_algorithm: SignatureAlgorithm) {
         let mut env = TestEnv::default();
-        let private_key = PrivateKey::new(&mut env, signature_algorithm);
-        let credential_source = CredentialSource {
-            private_key,
-            rp_id_hash: [0x55; 32],
-            cred_protect_policy: Some(CredentialProtectionPolicy::UserVerificationOptional),
-            cred_blob: Some(vec![0xAA; 32]),
-        };
+        let credential_source = generate_credential_source(&mut env, signature_algorithm);
         let mut credential_id = env.key_store().wrap_credential(credential_source).unwrap();
         credential_id[0] = UNSUPPORTED_CREDENTIAL_ID_VERSION;
         // Override the HMAC to pass the check.
@@ -488,13 +480,7 @@ mod test {
 
     fn test_wrap_unwrap_credential_bad_hmac(signature_algorithm: SignatureAlgorithm) {
         let mut env = TestEnv::default();
-        let private_key = PrivateKey::new(&mut env, signature_algorithm);
-        let credential_source = CredentialSource {
-            private_key,
-            rp_id_hash: [0x55; 32],
-            cred_protect_policy: Some(CredentialProtectionPolicy::UserVerificationOptional),
-            cred_blob: Some(vec![0xAA; 32]),
-        };
+        let credential_source = generate_credential_source(&mut env, signature_algorithm);
         let mut credential_id = env.key_store().wrap_credential(credential_source).unwrap();
         let hmac_byte_index = credential_id.len() - 1;
         credential_id[hmac_byte_index] ^= 0x01;
@@ -517,13 +503,7 @@ mod test {
 
     fn test_wrap_unwrap_credential_missing_blocks(signature_algorithm: SignatureAlgorithm) {
         let mut env = TestEnv::default();
-        let private_key = PrivateKey::new(&mut env, signature_algorithm);
-        let credential_source = CredentialSource {
-            private_key,
-            rp_id_hash: [0x55; 32],
-            cred_protect_policy: Some(CredentialProtectionPolicy::UserVerificationOptional),
-            cred_blob: Some(vec![0xAA; 32]),
-        };
+        let credential_source = generate_credential_source(&mut env, signature_algorithm);
         let credential_id = env.key_store().wrap_credential(credential_source).unwrap();
         for length in (1..CBOR_CREDENTIAL_ID_SIZE).step_by(16) {
             let unwrapped = env
@@ -547,13 +527,7 @@ mod test {
     #[test]
     fn test_wrap_credential_size() {
         let mut env = TestEnv::default();
-        let private_key = PrivateKey::new(&mut env, SignatureAlgorithm::Es256);
-        let credential_source = CredentialSource {
-            private_key,
-            rp_id_hash: [0x55; 32],
-            cred_protect_policy: Some(CredentialProtectionPolicy::UserVerificationOptional),
-            cred_blob: Some(vec![0xAA; 32]),
-        };
+        let credential_source = generate_credential_source(&mut env, SignatureAlgorithm::Es256);
         let credential_id = env.key_store().wrap_credential(credential_source).unwrap();
         assert_eq!(credential_id.len(), CBOR_CREDENTIAL_ID_SIZE);
     }
@@ -563,13 +537,8 @@ mod test {
         // The CBOR encoding length is variadic and depends on size of fields. Ensure that contents
         // still fit into the padded size when we use maximum length entries.
         let mut env = TestEnv::default();
-        let private_key = PrivateKey::new(&mut env, SignatureAlgorithm::Es256);
-        let credential_source = CredentialSource {
-            private_key,
-            rp_id_hash: [0x55; 32],
-            cred_protect_policy: Some(CredentialProtectionPolicy::UserVerificationOptional),
-            cred_blob: Some(vec![0xAA; env.customization().max_cred_blob_length()]),
-        };
+        let mut credential_source = generate_credential_source(&mut env, SignatureAlgorithm::Es256);
+        credential_source.cred_blob = Some(vec![0xAA; env.customization().max_cred_blob_length()]);
         let credential_id = env.key_store().wrap_credential(credential_source);
         assert!(credential_id.is_ok());
     }

--- a/libraries/opensk/src/api/private_key.rs
+++ b/libraries/opensk/src/api/private_key.rs
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 use crate::api::crypto::ecdsa::{SecretKey as _, Signature};
+#[cfg(test)]
+use crate::api::crypto::EC_FIELD_SIZE;
+use crate::api::key_store::KeyStore;
 use crate::ctap::crypto_wrapper::{aes256_cbc_decrypt, aes256_cbc_encrypt};
 use crate::ctap::data_formats::{extract_array, extract_byte_string, CoseKey, SignatureAlgorithm};
 use crate::ctap::secret::Secret;
@@ -21,38 +24,62 @@ use crate::env::{AesKey, EcdsaSk, Env};
 use alloc::vec;
 use alloc::vec::Vec;
 use core::convert::TryFrom;
-use core::ops::Deref;
-#[cfg(feature = "ed25519")]
-use core::ops::DerefMut;
+use core::ops::{Deref, DerefMut};
 #[cfg(feature = "ed25519")]
 use rand_core::RngCore;
 use sk_cbor as cbor;
 use sk_cbor::{cbor_array, cbor_bytes, cbor_int};
 
 /// An asymmetric private key that can sign messages.
-#[derive(Clone, Debug)]
-// We shouldn't compare private keys in prod without constant-time operations.
-#[cfg_attr(test, derive(PartialEq, Eq))]
-pub enum PrivateKey {
-    // We store the key bytes instead of the env type. They can be converted into each other.
-    Ecdsa(Secret<[u8; 32]>),
+pub enum PrivateKey<E: Env> {
+    Ecdsa(EcdsaSk<E>),
     #[cfg(feature = "ed25519")]
     Ed25519(ed25519_compact::SecretKey),
 }
 
-impl PrivateKey {
+#[cfg(test)]
+impl<E: Env> Clone for PrivateKey<E> {
+    fn clone(&self) -> Self {
+        match self {
+            PrivateKey::Ecdsa(key) => {
+                let mut key_bytes = [0; EC_FIELD_SIZE];
+                key.to_slice(&mut key_bytes);
+                PrivateKey::Ecdsa(EcdsaSk::<E>::from_slice(&key_bytes).unwrap())
+            }
+            #[cfg(feature = "ed25519")]
+            PrivateKey::Ed25519(key) => Self::Ed25519(*key),
+        }
+    }
+}
+
+// We shouldn't compare private keys in prod without constant-time operations.
+#[cfg(test)]
+impl<E: Env> PartialEq for PrivateKey<E> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (PrivateKey::Ecdsa(key1), PrivateKey::Ecdsa(key2)) => {
+                let mut bytes1 = [0; EC_FIELD_SIZE];
+                key1.to_slice(&mut bytes1);
+                let mut bytes2 = [0; EC_FIELD_SIZE];
+                key2.to_slice(&mut bytes2);
+                bytes1 == bytes2
+            }
+            #[cfg(feature = "ed25519")]
+            (PrivateKey::Ed25519(key1), PrivateKey::Ed25519(key2)) => key1 == key2,
+            _ => false,
+        }
+    }
+}
+
+impl<E: Env> PrivateKey<E> {
     /// Creates a new private key for the given algorithm.
     ///
     /// # Panics
     ///
     /// Panics if the algorithm is [`SignatureAlgorithm::Unknown`].
-    pub fn new<E: Env>(env: &mut E, alg: SignatureAlgorithm) -> Self {
+    pub fn new(env: &mut E, alg: SignatureAlgorithm) -> Self {
         match alg {
-            SignatureAlgorithm::Es256 => {
-                let mut bytes: Secret<[u8; 32]> = Secret::default();
-                EcdsaSk::<E>::random(env.rng()).to_slice(&mut bytes);
-                PrivateKey::Ecdsa(bytes)
-            }
+            SignatureAlgorithm::Es256 => Self::Ecdsa(EcdsaSk::<E>::random(env.rng())),
             #[cfg(feature = "ed25519")]
             SignatureAlgorithm::Eddsa => {
                 let mut bytes: Secret<[u8; 32]> = Secret::default();
@@ -64,18 +91,14 @@ impl PrivateKey {
     }
 
     /// Creates a new ecdsa private key.
-    pub fn new_ecdsa(env: &mut impl Env) -> PrivateKey {
+    pub fn new_ecdsa(env: &mut E) -> PrivateKey<E> {
         Self::new(env, SignatureAlgorithm::Es256)
     }
 
     /// Helper function that creates a private key of type ECDSA.
-    pub fn new_ecdsa_from_bytes(bytes: &[u8]) -> Option<Self> {
-        if bytes.len() != 32 {
-            return None;
-        }
-        let mut seed: Secret<[u8; 32]> = Secret::default();
-        seed.copy_from_slice(bytes);
-        Some(PrivateKey::Ecdsa(seed))
+    fn new_ecdsa_from_bytes(bytes: &[u8]) -> Option<Self> {
+        let bytes = <&[u8; 32]>::try_from(bytes).ok()?;
+        EcdsaSk::<E>::from_slice(bytes).map(|k| PrivateKey::Ecdsa(k))
     }
 
     /// Helper function that creates a private key of type Ed25519.
@@ -88,30 +111,19 @@ impl PrivateKey {
         Some(Self::Ed25519(ed25519_compact::KeyPair::from_seed(seed).sk))
     }
 
-    /// Returns the ECDSA private key.
-    pub fn ecdsa_key<E: Env>(&self) -> CtapResult<EcdsaSk<E>> {
-        match self {
-            PrivateKey::Ecdsa(bytes) => ecdsa_key_from_bytes::<E>(bytes),
-            #[allow(unreachable_patterns)]
-            _ => Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR),
-        }
-    }
-
     /// Returns the corresponding public key.
-    pub fn get_pub_key<E: Env>(&self) -> CtapResult<CoseKey> {
+    pub fn get_pub_key(&self) -> CtapResult<CoseKey> {
         Ok(match self {
-            PrivateKey::Ecdsa(bytes) => {
-                CoseKey::from_ecdsa_public_key(ecdsa_key_from_bytes::<E>(bytes)?.public_key())
-            }
+            PrivateKey::Ecdsa(key) => CoseKey::from_ecdsa_public_key(key.public_key()),
             #[cfg(feature = "ed25519")]
             PrivateKey::Ed25519(ed25519_key) => CoseKey::from(ed25519_key.public_key()),
         })
     }
 
     /// Returns the encoded signature for a given message.
-    pub fn sign_and_encode<E: Env>(&self, message: &[u8]) -> CtapResult<Vec<u8>> {
+    pub fn sign_and_encode(&self, message: &[u8]) -> CtapResult<Vec<u8>> {
         Ok(match self {
-            PrivateKey::Ecdsa(bytes) => ecdsa_key_from_bytes::<E>(bytes)?.sign(message).to_der(),
+            PrivateKey::Ecdsa(key) => key.sign(message).to_der(),
             #[cfg(feature = "ed25519")]
             PrivateKey::Ed25519(ed25519_key) => ed25519_key.sign(message, None).to_vec(),
         })
@@ -130,27 +142,29 @@ impl PrivateKey {
     pub fn to_bytes(&self) -> Secret<[u8]> {
         let mut bytes = Secret::new(32);
         match self {
-            PrivateKey::Ecdsa(key_bytes) => bytes.copy_from_slice(key_bytes.deref()),
+            PrivateKey::Ecdsa(key) => {
+                let mut array_bytes: Secret<[u8; 32]> = Secret::default();
+                key.to_slice(array_bytes.deref_mut());
+                bytes.copy_from_slice(array_bytes.deref())
+            }
             #[cfg(feature = "ed25519")]
             PrivateKey::Ed25519(ed25519_key) => bytes.copy_from_slice(ed25519_key.seed().deref()),
         }
         bytes
     }
 
-    pub fn to_cbor<E: Env>(
-        &self,
-        rng: &mut E::Rng,
-        wrap_key: &AesKey<E>,
-    ) -> CtapResult<cbor::Value> {
+    /// Encodes the private key into a CBOR array with type information.
+    pub fn to_cbor(&self, env: &mut E) -> CtapResult<cbor::Value> {
         let bytes = self.to_bytes();
-        let wrapped_bytes = aes256_cbc_encrypt::<E>(rng, wrap_key, &bytes, true)?;
+        let wrap_key = env.key_store().wrap_key::<E>()?;
+        let wrapped_bytes = aes256_cbc_encrypt::<E>(env.rng(), &wrap_key, &bytes, true)?;
         Ok(cbor_array![
             cbor_int!(self.signature_algorithm() as i64),
             cbor_bytes!(wrapped_bytes),
         ])
     }
 
-    pub fn from_cbor<E: Env>(wrap_key: &AesKey<E>, cbor_value: cbor::Value) -> CtapResult<Self> {
+    pub fn from_cbor(wrap_key: &AesKey<E>, cbor_value: cbor::Value) -> CtapResult<Self> {
         let mut array = extract_array(cbor_value)?;
         if array.len() != 2 {
             return Err(Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR);
@@ -158,18 +172,14 @@ impl PrivateKey {
         let wrapped_bytes = extract_byte_string(array.pop().unwrap())?;
         let key_bytes = aes256_cbc_decrypt::<E>(wrap_key, &wrapped_bytes, true)?;
         match SignatureAlgorithm::try_from(array.pop().unwrap())? {
-            SignatureAlgorithm::Es256 => PrivateKey::new_ecdsa_from_bytes(&key_bytes)
+            SignatureAlgorithm::Es256 => PrivateKey::<E>::new_ecdsa_from_bytes(&key_bytes)
                 .ok_or(Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR),
             #[cfg(feature = "ed25519")]
-            SignatureAlgorithm::Eddsa => PrivateKey::new_ed25519_from_bytes(&key_bytes)
+            SignatureAlgorithm::Eddsa => PrivateKey::<E>::new_ed25519_from_bytes(&key_bytes)
                 .ok_or(Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR),
             _ => Err(Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR),
         }
     }
-}
-
-fn ecdsa_key_from_bytes<E: Env>(bytes: &[u8; 32]) -> CtapResult<EcdsaSk<E>> {
-    EcdsaSk::<E>::from_slice(bytes).ok_or(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)
 }
 
 #[cfg(test)]
@@ -181,51 +191,45 @@ mod test {
     #[test]
     fn test_new_ecdsa_from_bytes() {
         let mut env = TestEnv::default();
-        let private_key = PrivateKey::new(&mut env, SignatureAlgorithm::Es256);
+        let private_key = PrivateKey::<TestEnv>::new(&mut env, SignatureAlgorithm::Es256);
         let key_bytes = private_key.to_bytes();
-        assert_eq!(
-            PrivateKey::new_ecdsa_from_bytes(&key_bytes),
-            Some(private_key)
-        );
+        assert!(PrivateKey::<TestEnv>::new_ecdsa_from_bytes(&key_bytes) == Some(private_key));
     }
 
     #[test]
     #[cfg(feature = "ed25519")]
     fn test_new_ed25519_from_bytes() {
         let mut env = TestEnv::default();
-        let private_key = PrivateKey::new(&mut env, SignatureAlgorithm::Eddsa);
+        let private_key = PrivateKey::<TestEnv>::new(&mut env, SignatureAlgorithm::Eddsa);
         let key_bytes = private_key.to_bytes();
-        assert_eq!(
-            PrivateKey::new_ed25519_from_bytes(&key_bytes),
-            Some(private_key)
-        );
+        assert!(PrivateKey::<TestEnv>::new_ed25519_from_bytes(&key_bytes) == Some(private_key));
     }
 
     #[test]
     fn test_new_ecdsa_from_bytes_wrong_length() {
-        assert_eq!(PrivateKey::new_ecdsa_from_bytes(&[0x55; 16]), None);
-        assert_eq!(PrivateKey::new_ecdsa_from_bytes(&[0x55; 31]), None);
-        assert_eq!(PrivateKey::new_ecdsa_from_bytes(&[0x55; 33]), None);
-        assert_eq!(PrivateKey::new_ecdsa_from_bytes(&[0x55; 64]), None);
+        assert!(PrivateKey::<TestEnv>::new_ecdsa_from_bytes(&[0x55; 16]).is_none());
+        assert!(PrivateKey::<TestEnv>::new_ecdsa_from_bytes(&[0x55; 31]).is_none());
+        assert!(PrivateKey::<TestEnv>::new_ecdsa_from_bytes(&[0x55; 33]).is_none());
+        assert!(PrivateKey::<TestEnv>::new_ecdsa_from_bytes(&[0x55; 64]).is_none());
     }
 
     #[test]
     #[cfg(feature = "ed25519")]
     fn test_new_ed25519_from_bytes_wrong_length() {
-        assert_eq!(PrivateKey::new_ed25519_from_bytes(&[0x55; 16]), None);
-        assert_eq!(PrivateKey::new_ed25519_from_bytes(&[0x55; 31]), None);
-        assert_eq!(PrivateKey::new_ed25519_from_bytes(&[0x55; 33]), None);
-        assert_eq!(PrivateKey::new_ed25519_from_bytes(&[0x55; 64]), None);
+        assert!(PrivateKey::<TestEnv>::new_ed25519_from_bytes(&[0x55; 16]).is_none());
+        assert!(PrivateKey::<TestEnv>::new_ed25519_from_bytes(&[0x55; 31]).is_none());
+        assert!(PrivateKey::<TestEnv>::new_ed25519_from_bytes(&[0x55; 33]).is_none());
+        assert!(PrivateKey::<TestEnv>::new_ed25519_from_bytes(&[0x55; 64]).is_none());
     }
 
     #[test]
     fn test_private_key_get_pub_key() {
         let mut env = TestEnv::default();
-        let private_key = PrivateKey::new_ecdsa(&mut env);
-        let ecdsa_key = private_key.ecdsa_key::<TestEnv>().unwrap();
+        let ecdsa_key = EcdsaSk::<TestEnv>::random(env.rng());
         let public_key = ecdsa_key.public_key();
+        let private_key = PrivateKey::<TestEnv>::Ecdsa(ecdsa_key);
         assert_eq!(
-            private_key.get_pub_key::<TestEnv>(),
+            private_key.get_pub_key(),
             Ok(CoseKey::from_ecdsa_public_key(public_key))
         );
     }
@@ -234,18 +238,15 @@ mod test {
     fn test_private_key_sign_and_encode() {
         let mut env = TestEnv::default();
         let message = [0x5A; 32];
-        let private_key = PrivateKey::new_ecdsa(&mut env);
-        let ecdsa_key = private_key.ecdsa_key::<TestEnv>().unwrap();
+        let ecdsa_key = EcdsaSk::<TestEnv>::random(env.rng());
         let signature = ecdsa_key.sign(&message).to_der();
-        assert_eq!(
-            private_key.sign_and_encode::<TestEnv>(&message),
-            Ok(signature)
-        );
+        let private_key = PrivateKey::<TestEnv>::Ecdsa(ecdsa_key);
+        assert_eq!(private_key.sign_and_encode(&message), Ok(signature));
     }
 
     fn test_private_key_signature_algorithm(signature_algorithm: SignatureAlgorithm) {
         let mut env = TestEnv::default();
-        let private_key = PrivateKey::new(&mut env, signature_algorithm);
+        let private_key = PrivateKey::<TestEnv>::new(&mut env, signature_algorithm);
         assert_eq!(private_key.signature_algorithm(), signature_algorithm);
     }
 
@@ -263,14 +264,9 @@ mod test {
     fn test_private_key_from_to_cbor(signature_algorithm: SignatureAlgorithm) {
         let mut env = TestEnv::default();
         let wrap_key = env.key_store().wrap_key::<TestEnv>().unwrap();
-        let private_key = PrivateKey::new(&mut env, signature_algorithm);
-        let cbor = private_key
-            .to_cbor::<TestEnv>(env.rng(), &wrap_key)
-            .unwrap();
-        assert_eq!(
-            PrivateKey::from_cbor::<TestEnv>(&wrap_key, cbor),
-            Ok(private_key)
-        );
+        let private_key = PrivateKey::<TestEnv>::new(&mut env, signature_algorithm);
+        let cbor = private_key.to_cbor(&mut env).unwrap();
+        assert!(PrivateKey::<TestEnv>::from_cbor(&wrap_key, cbor) == Ok(private_key));
     }
 
     #[test]
@@ -293,9 +289,9 @@ mod test {
             // The array is too long.
             cbor_int!(0),
         ];
-        assert_eq!(
-            PrivateKey::from_cbor::<TestEnv>(&wrap_key, cbor),
-            Err(Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR),
+        assert!(
+            PrivateKey::<TestEnv>::from_cbor(&wrap_key, cbor)
+                == Err(Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR),
         );
     }
 
@@ -319,9 +315,9 @@ mod test {
             cbor_int!(-1),
             cbor_bytes!(vec![0x88; 32]),
         ];
-        assert_eq!(
-            PrivateKey::from_cbor::<TestEnv>(&wrap_key, cbor),
-            Err(Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR),
+        assert!(
+            PrivateKey::<TestEnv>::from_cbor(&wrap_key, cbor)
+                == Err(Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR),
         );
     }
 }

--- a/libraries/opensk/src/api/private_key.rs
+++ b/libraries/opensk/src/api/private_key.rs
@@ -24,7 +24,8 @@ use crate::env::{AesKey, EcdsaSk, Env};
 use alloc::vec;
 use alloc::vec::Vec;
 use core::convert::TryFrom;
-use core::ops::{Deref, DerefMut};
+#[cfg(feature = "ed25519")]
+use core::ops::Deref;
 #[cfg(feature = "ed25519")]
 use rand_core::RngCore;
 use sk_cbor as cbor;
@@ -83,7 +84,7 @@ impl<E: Env> PrivateKey<E> {
             #[cfg(feature = "ed25519")]
             SignatureAlgorithm::Eddsa => {
                 let mut bytes: Secret<[u8; 32]> = Secret::default();
-                env.rng().fill_bytes(bytes.deref_mut());
+                env.rng().fill_bytes(&mut bytes[..]);
                 Self::new_ed25519_from_bytes(&*bytes).unwrap()
             }
             SignatureAlgorithm::Unknown => unreachable!(),
@@ -144,8 +145,8 @@ impl<E: Env> PrivateKey<E> {
         match self {
             PrivateKey::Ecdsa(key) => {
                 let mut array_bytes: Secret<[u8; 32]> = Secret::default();
-                key.to_slice(array_bytes.deref_mut());
-                bytes.copy_from_slice(array_bytes.deref())
+                key.to_slice(&mut array_bytes);
+                bytes.copy_from_slice(&array_bytes[..]);
             }
             #[cfg(feature = "ed25519")]
             PrivateKey::Ed25519(ed25519_key) => bytes.copy_from_slice(ed25519_key.seed().deref()),

--- a/libraries/opensk/src/api/private_key.rs
+++ b/libraries/opensk/src/api/private_key.rs
@@ -103,7 +103,7 @@ impl<E: Env> PrivateKey<E> {
 
     /// Helper function that creates a private key of type Ed25519.
     #[cfg(feature = "ed25519")]
-    pub fn new_ed25519_from_bytes(bytes: &[u8]) -> Option<Self> {
+    fn new_ed25519_from_bytes(bytes: &[u8]) -> Option<Self> {
         if bytes.len() != 32 {
             return None;
         }

--- a/libraries/opensk/src/ctap/credential_management.rs
+++ b/libraries/opensk/src/ctap/credential_management.rs
@@ -24,6 +24,8 @@ use super::status_code::Ctap2StatusCode;
 use super::{Channel, StatefulCommand, StatefulPermission};
 use crate::api::crypto::sha256::Sha256;
 use crate::api::customization::Customization;
+use crate::api::key_store::KeyStore;
+use crate::api::private_key::PrivateKey;
 use crate::ctap::data_formats::CredentialProtectionPolicy;
 use crate::ctap::status_code::CtapResult;
 use crate::ctap::storage;
@@ -72,7 +74,7 @@ fn enumerate_credentials_response<E: Env>(
     let PublicKeyCredentialSource {
         key_type,
         credential_id,
-        private_key,
+        wrapped_private_key,
         rp_id: _,
         user_handle,
         user_display_name,
@@ -94,7 +96,9 @@ fn enumerate_credentials_response<E: Env>(
         key_id: credential_id,
         transports: None, // You can set USB as a hint here.
     };
-    let public_key = private_key.get_pub_key::<E>()?;
+    let wrap_key = env.key_store().wrap_key::<E>()?;
+    let private_key = PrivateKey::<E>::from_cbor(&wrap_key, wrapped_private_key)?;
+    let public_key = private_key.get_pub_key()?;
     let cred_protect = cred_protect_policy
         .or(env.customization().default_cred_protect())
         .or(Some(CredentialProtectionPolicy::UserVerificationOptional));
@@ -372,10 +376,11 @@ mod test {
 
     fn create_credential_source(env: &mut TestEnv) -> PublicKeyCredentialSource {
         let private_key = PrivateKey::new_ecdsa(env);
+        let wrapped_private_key = private_key.to_cbor(env).unwrap();
         PublicKeyCredentialSource {
             key_type: PublicKeyCredentialType::PublicKey,
             credential_id: env.rng().gen_uniform_u8x32().to_vec(),
-            private_key,
+            wrapped_private_key,
             rp_id: String::from("example.com"),
             user_handle: vec![0x01],
             user_display_name: Some("display_name".to_string()),

--- a/libraries/opensk/src/ctap/ctap1.rs
+++ b/libraries/opensk/src/ctap/ctap1.rs
@@ -417,7 +417,7 @@ mod test {
 
     /// Creates an example wrapped credential and RP ID hash.
     fn create_wrapped_credential(env: &mut TestEnv) -> (Vec<u8>, [u8; 32]) {
-        let private_key = PrivateKey::new(env, SignatureAlgorithm::Es256);
+        let private_key = PrivateKey::new_ecdsa(env);
         let wrapped_private_key = private_key.to_cbor(env).unwrap();
         let rp_id_hash = Sha::<TestEnv>::digest(b"example.com");
         let credential_source = CredentialSource {
@@ -725,7 +725,7 @@ mod test {
             .set(|| panic!("Unexpected user presence check in CTAP1"));
         let mut ctap_state = CtapState::new(&mut env);
 
-        let private_key = PrivateKey::new(&mut env, SignatureAlgorithm::Es256);
+        let private_key = PrivateKey::new_ecdsa(&mut env);
         let wrapped_private_key = private_key.to_cbor(&mut env).unwrap();
         let rp_id_hash = Sha::<TestEnv>::digest(b"example.com");
         let credential_source = CredentialSource {

--- a/libraries/opensk/src/ctap/ctap1.rs
+++ b/libraries/opensk/src/ctap/ctap1.rs
@@ -253,13 +253,14 @@ impl Ctap1Command {
         challenge: [u8; 32],
         application: [u8; 32],
     ) -> Result<Vec<u8>, Ctap1StatusCode> {
-        let private_key = PrivateKey::new_ecdsa(env);
-        let sk = private_key
-            .ecdsa_key::<E>()
-            .map_err(|_| Ctap1StatusCode::SW_INTERNAL_EXCEPTION)?;
+        let sk = EcdsaSk::<E>::random(env.rng());
         let pk = sk.public_key();
+        let private_key = PrivateKey::<E>::Ecdsa(sk);
+        let wrapped_private_key = private_key
+            .to_cbor(env)
+            .map_err(|_| Ctap1StatusCode::SW_INTERNAL_EXCEPTION)?;
         let credential_source = CredentialSource {
-            private_key,
+            wrapped_private_key,
             rp_id_hash: application,
             cred_protect_policy: None,
             cred_blob: None,
@@ -347,9 +348,15 @@ impl Ctap1Command {
             )
             .map_err(|_| Ctap1StatusCode::SW_WRONG_DATA)?;
         signature_data.extend(&challenge);
-        let signature = credential_source
-            .private_key
-            .sign_and_encode::<E>(&signature_data)
+        let wrap_key = env
+            .key_store()
+            .wrap_key::<E>()
+            .map_err(|_| Ctap1StatusCode::SW_INTERNAL_EXCEPTION)?;
+        let private_key =
+            PrivateKey::<E>::from_cbor(&wrap_key, credential_source.wrapped_private_key)
+                .map_err(|_| Ctap1StatusCode::SW_INTERNAL_EXCEPTION)?;
+        let signature = private_key
+            .sign_and_encode(&signature_data)
             .map_err(|_| Ctap1StatusCode::SW_INTERNAL_EXCEPTION)?;
 
         let mut response = signature_data[application.len()..application.len() + 5].to_vec();
@@ -411,9 +418,10 @@ mod test {
     /// Creates an example wrapped credential and RP ID hash.
     fn create_wrapped_credential(env: &mut TestEnv) -> (Vec<u8>, [u8; 32]) {
         let private_key = PrivateKey::new(env, SignatureAlgorithm::Es256);
+        let wrapped_private_key = private_key.to_cbor(env).unwrap();
         let rp_id_hash = Sha::<TestEnv>::digest(b"example.com");
         let credential_source = CredentialSource {
-            private_key,
+            wrapped_private_key,
             rp_id_hash,
             cred_protect_policy: None,
             cred_blob: None,
@@ -718,9 +726,10 @@ mod test {
         let mut ctap_state = CtapState::new(&mut env);
 
         let private_key = PrivateKey::new(&mut env, SignatureAlgorithm::Es256);
+        let wrapped_private_key = private_key.to_cbor(&mut env).unwrap();
         let rp_id_hash = Sha::<TestEnv>::digest(b"example.com");
         let credential_source = CredentialSource {
-            private_key,
+            wrapped_private_key,
             rp_id_hash,
             cred_protect_policy: Some(CredentialProtectionPolicy::UserVerificationRequired),
             cred_blob: None,

--- a/libraries/opensk/src/ctap/data_formats.rs
+++ b/libraries/opensk/src/ctap/data_formats.rs
@@ -14,9 +14,7 @@
 
 use super::status_code::Ctap2StatusCode;
 use crate::api::crypto::{ecdh, ecdsa, EC_FIELD_SIZE};
-use crate::api::private_key::PrivateKey;
 use crate::ctap::status_code::CtapResult;
-use crate::env::{AesKey, Env};
 use alloc::string::String;
 use alloc::vec::Vec;
 #[cfg(feature = "fuzz")]
@@ -587,7 +585,7 @@ impl TryFrom<cbor::Value> for CredentialProtectionPolicy {
 pub struct PublicKeyCredentialSource {
     pub key_type: PublicKeyCredentialType,
     pub credential_id: Vec<u8>,
-    pub private_key: PrivateKey,
+    pub wrapped_private_key: cbor::Value,
     pub rp_id: String,
     pub user_handle: Vec<u8>, // not optional, but nullable
     pub user_display_name: Option<String>,
@@ -633,28 +631,12 @@ impl PublicKeyCredentialSource {
             || self.cred_protect_policy
                 == Some(CredentialProtectionPolicy::UserVerificationOptional)
     }
+}
 
-    pub fn to_cbor<E: Env>(
-        self,
-        rng: &mut E::Rng,
-        wrap_key: &AesKey<E>,
-    ) -> CtapResult<cbor::Value> {
-        Ok(cbor_map_options! {
-            PublicKeyCredentialSourceField::CredentialId => Some(self.credential_id),
-            PublicKeyCredentialSourceField::RpId => Some(self.rp_id),
-            PublicKeyCredentialSourceField::UserHandle => Some(self.user_handle),
-            PublicKeyCredentialSourceField::UserDisplayName => self.user_display_name,
-            PublicKeyCredentialSourceField::CredProtectPolicy => self.cred_protect_policy,
-            PublicKeyCredentialSourceField::CreationOrder => self.creation_order,
-            PublicKeyCredentialSourceField::UserName => self.user_name,
-            PublicKeyCredentialSourceField::UserIcon => self.user_icon,
-            PublicKeyCredentialSourceField::CredBlob => self.cred_blob,
-            PublicKeyCredentialSourceField::LargeBlobKey => self.large_blob_key,
-            PublicKeyCredentialSourceField::PrivateKey => self.private_key.to_cbor::<E>(rng, wrap_key)?,
-        })
-    }
+impl TryFrom<cbor::Value> for PublicKeyCredentialSource {
+    type Error = Ctap2StatusCode;
 
-    pub fn from_cbor<E: Env>(wrap_key: &AesKey<E>, cbor_value: cbor::Value) -> CtapResult<Self> {
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
         destructure_cbor_map! {
             let {
                 PublicKeyCredentialSourceField::CredentialId => credential_id,
@@ -667,7 +649,7 @@ impl PublicKeyCredentialSource {
                 PublicKeyCredentialSourceField::UserIcon => user_icon,
                 PublicKeyCredentialSourceField::CredBlob => cred_blob,
                 PublicKeyCredentialSourceField::LargeBlobKey => large_blob_key,
-                PublicKeyCredentialSourceField::PrivateKey => private_key,
+                PublicKeyCredentialSourceField::PrivateKey => wrapped_private_key,
             } = extract_map(cbor_value)?;
         }
 
@@ -683,7 +665,7 @@ impl PublicKeyCredentialSource {
         let user_icon = user_icon.map(extract_text_string).transpose()?;
         let cred_blob = cred_blob.map(extract_byte_string).transpose()?;
         let large_blob_key = large_blob_key.map(extract_byte_string).transpose()?;
-        let private_key = PrivateKey::from_cbor::<E>(wrap_key, ok_or_missing(private_key)?)?;
+        let wrapped_private_key = ok_or_missing(wrapped_private_key)?;
 
         // We don't return whether there were unknown fields in the CBOR value. This means that
         // deserialization is not injective. In particular deserialization is only an inverse of
@@ -698,7 +680,7 @@ impl PublicKeyCredentialSource {
         Ok(PublicKeyCredentialSource {
             key_type: PublicKeyCredentialType::PublicKey,
             credential_id,
-            private_key,
+            wrapped_private_key,
             rp_id,
             user_handle,
             user_display_name,
@@ -709,6 +691,24 @@ impl PublicKeyCredentialSource {
             cred_blob,
             large_blob_key,
         })
+    }
+}
+
+impl From<PublicKeyCredentialSource> for cbor::Value {
+    fn from(cred: PublicKeyCredentialSource) -> Self {
+        cbor_map_options! {
+            PublicKeyCredentialSourceField::CredentialId => Some(cred.credential_id),
+            PublicKeyCredentialSourceField::RpId => Some(cred.rp_id),
+            PublicKeyCredentialSourceField::UserHandle => Some(cred.user_handle),
+            PublicKeyCredentialSourceField::UserDisplayName => cred.user_display_name,
+            PublicKeyCredentialSourceField::CredProtectPolicy => cred.cred_protect_policy,
+            PublicKeyCredentialSourceField::CreationOrder => cred.creation_order,
+            PublicKeyCredentialSourceField::UserName => cred.user_name,
+            PublicKeyCredentialSourceField::UserIcon => cred.user_icon,
+            PublicKeyCredentialSourceField::CredBlob => cred.cred_blob,
+            PublicKeyCredentialSourceField::LargeBlobKey => cred.large_blob_key,
+            PublicKeyCredentialSourceField::PrivateKey => cred.wrapped_private_key,
+        }
     }
 }
 
@@ -1195,7 +1195,7 @@ mod test {
     use super::*;
     use crate::api::crypto::ecdh::PublicKey as _;
     use crate::api::crypto::ecdsa::PublicKey as _;
-    use crate::api::key_store::KeyStore;
+    use crate::api::private_key::PrivateKey;
     use crate::api::rng::Rng;
     use crate::env::test::TestEnv;
     use crate::env::{EcdhPk, EcdsaPk, Env};
@@ -2069,12 +2069,12 @@ mod test {
     #[test]
     fn test_credential_source_cbor_round_trip() {
         let mut env = TestEnv::default();
-        let wrap_key = env.key_store().wrap_key::<TestEnv>().unwrap();
         let private_key = PrivateKey::new_ecdsa(&mut env);
+        let wrapped_private_key = private_key.to_cbor(&mut env).unwrap();
         let credential = PublicKeyCredentialSource {
             key_type: PublicKeyCredentialType::PublicKey,
             credential_id: env.rng().gen_uniform_u8x32().to_vec(),
-            private_key,
+            wrapped_private_key,
             rp_id: "example.com".to_string(),
             user_handle: b"foo".to_vec(),
             user_display_name: None,
@@ -2085,13 +2085,8 @@ mod test {
             cred_blob: None,
             large_blob_key: None,
         };
-
-        let cbor_value = credential
-            .clone()
-            .to_cbor::<TestEnv>(env.rng(), &wrap_key)
-            .unwrap();
         assert_eq!(
-            PublicKeyCredentialSource::from_cbor::<TestEnv>(&wrap_key, cbor_value),
+            PublicKeyCredentialSource::try_from(cbor::Value::from(credential.clone())),
             Ok(credential.clone())
         );
 
@@ -2099,13 +2094,8 @@ mod test {
             user_display_name: Some("Display Name".to_string()),
             ..credential
         };
-
-        let cbor_value = credential
-            .clone()
-            .to_cbor::<TestEnv>(env.rng(), &wrap_key)
-            .unwrap();
         assert_eq!(
-            PublicKeyCredentialSource::from_cbor::<TestEnv>(&wrap_key, cbor_value),
+            PublicKeyCredentialSource::try_from(cbor::Value::from(credential.clone())),
             Ok(credential.clone())
         );
 
@@ -2113,13 +2103,8 @@ mod test {
             cred_protect_policy: Some(CredentialProtectionPolicy::UserVerificationOptional),
             ..credential
         };
-
-        let cbor_value = credential
-            .clone()
-            .to_cbor::<TestEnv>(env.rng(), &wrap_key)
-            .unwrap();
         assert_eq!(
-            PublicKeyCredentialSource::from_cbor::<TestEnv>(&wrap_key, cbor_value),
+            PublicKeyCredentialSource::try_from(cbor::Value::from(credential.clone())),
             Ok(credential.clone())
         );
 
@@ -2127,13 +2112,8 @@ mod test {
             user_name: Some("name".to_string()),
             ..credential
         };
-
-        let cbor_value = credential
-            .clone()
-            .to_cbor::<TestEnv>(env.rng(), &wrap_key)
-            .unwrap();
         assert_eq!(
-            PublicKeyCredentialSource::from_cbor::<TestEnv>(&wrap_key, cbor_value),
+            PublicKeyCredentialSource::try_from(cbor::Value::from(credential.clone())),
             Ok(credential.clone())
         );
 
@@ -2141,13 +2121,8 @@ mod test {
             user_icon: Some("icon".to_string()),
             ..credential
         };
-
-        let cbor_value = credential
-            .clone()
-            .to_cbor::<TestEnv>(env.rng(), &wrap_key)
-            .unwrap();
         assert_eq!(
-            PublicKeyCredentialSource::from_cbor::<TestEnv>(&wrap_key, cbor_value),
+            PublicKeyCredentialSource::try_from(cbor::Value::from(credential.clone())),
             Ok(credential.clone())
         );
 
@@ -2155,13 +2130,8 @@ mod test {
             cred_blob: Some(vec![0xCB]),
             ..credential
         };
-
-        let cbor_value = credential
-            .clone()
-            .to_cbor::<TestEnv>(env.rng(), &wrap_key)
-            .unwrap();
         assert_eq!(
-            PublicKeyCredentialSource::from_cbor::<TestEnv>(&wrap_key, cbor_value),
+            PublicKeyCredentialSource::try_from(cbor::Value::from(credential.clone())),
             Ok(credential.clone())
         );
 
@@ -2169,29 +2139,16 @@ mod test {
             large_blob_key: Some(vec![0x1B]),
             ..credential
         };
-
-        let cbor_value = credential
-            .clone()
-            .to_cbor::<TestEnv>(env.rng(), &wrap_key)
-            .unwrap();
         assert_eq!(
-            PublicKeyCredentialSource::from_cbor::<TestEnv>(&wrap_key, cbor_value),
+            PublicKeyCredentialSource::try_from(cbor::Value::from(credential.clone())),
             Ok(credential)
         );
     }
 
     #[test]
     fn test_credential_source_invalid_cbor() {
-        let mut env = TestEnv::default();
-        let wrap_key = env.key_store().wrap_key::<TestEnv>().unwrap();
-        assert!(PublicKeyCredentialSource::from_cbor::<TestEnv>(&wrap_key, cbor_false!()).is_err());
-        assert!(
-            PublicKeyCredentialSource::from_cbor::<TestEnv>(&wrap_key, cbor_array!(false)).is_err()
-        );
-        assert!(PublicKeyCredentialSource::from_cbor::<TestEnv>(
-            &wrap_key,
-            cbor_array!(b"foo".to_vec())
-        )
-        .is_err());
+        assert!(PublicKeyCredentialSource::try_from(cbor_false!()).is_err());
+        assert!(PublicKeyCredentialSource::try_from(cbor_array!(false)).is_err());
+        assert!(PublicKeyCredentialSource::try_from(cbor_array!(b"foo".to_vec())).is_err());
     }
 }

--- a/libraries/opensk/src/ctap/mod.rs
+++ b/libraries/opensk/src/ctap/mod.rs
@@ -236,7 +236,7 @@ fn to_public_source(
     PublicKeyCredentialSource {
         key_type: PublicKeyCredentialType::PublicKey,
         credential_id,
-        private_key: credential_source.private_key,
+        wrapped_private_key: credential_source.wrapped_private_key,
         rp_id: String::new(),
         user_handle: Vec::new(),
         user_display_name: None,
@@ -917,7 +917,7 @@ impl<E: Env> CtapState<E> {
             let credential_source = PublicKeyCredentialSource {
                 key_type: PublicKeyCredentialType::PublicKey,
                 credential_id: random_id.clone(),
-                private_key: private_key.clone(),
+                wrapped_private_key: private_key.to_cbor(env)?,
                 rp_id,
                 user_handle: user.user_id,
                 // This input is user provided, so we crop it to 64 byte for storage.
@@ -940,7 +940,7 @@ impl<E: Env> CtapState<E> {
             random_id
         } else {
             let credential_source = CredentialSource {
-                private_key: private_key.clone(),
+                wrapped_private_key: private_key.to_cbor(env)?,
                 rp_id_hash,
                 cred_protect_policy,
                 cred_blob,
@@ -958,7 +958,7 @@ impl<E: Env> CtapState<E> {
         }
         auth_data.extend(vec![0x00, credential_id.len() as u8]);
         auth_data.extend(&credential_id);
-        let public_cose_key = private_key.get_pub_key::<E>()?;
+        let public_cose_key = private_key.get_pub_key()?;
         cbor_write(cbor::Value::from(public_cose_key), &mut auth_data)?;
         if has_extension_output {
             let hmac_secret_output = if extensions.hmac_secret {
@@ -1006,7 +1006,7 @@ impl<E: Env> CtapState<E> {
                     Some(vec![certificate]),
                 )
             }
-            None => (private_key.sign_and_encode::<E>(&signature_data)?, None),
+            None => (private_key.sign_and_encode(&signature_data)?, None),
         };
         let attestation_statement = PackedAttestationStatement {
             alg: SignatureAlgorithm::Es256 as i64,
@@ -1031,7 +1031,7 @@ impl<E: Env> CtapState<E> {
     fn generate_cred_random(
         &mut self,
         env: &mut E,
-        private_key: &PrivateKey,
+        private_key: &PrivateKey<E>,
         has_uv: bool,
     ) -> CtapResult<Secret<[u8; HASH_SIZE]>> {
         let private_key_bytes = private_key.to_bytes();
@@ -1059,11 +1059,12 @@ impl<E: Env> CtapState<E> {
             has_uv,
         } = assertion_input;
 
+        let wrap_key = env.key_store().wrap_key::<E>()?;
+        let private_key = PrivateKey::from_cbor(&wrap_key, credential.wrapped_private_key)?;
         // Process extensions.
         if extensions.hmac_secret.is_some() || extensions.cred_blob {
             let encrypted_output = if let Some(hmac_secret_input) = extensions.hmac_secret {
-                let cred_random =
-                    self.generate_cred_random(env, &credential.private_key, has_uv)?;
+                let cred_random = self.generate_cred_random(env, &private_key, has_uv)?;
                 Some(
                     self.client_pin
                         .process_hmac_secret(env, hmac_secret_input, &cred_random)?,
@@ -1090,9 +1091,7 @@ impl<E: Env> CtapState<E> {
 
         let mut signature_data = auth_data.clone();
         signature_data.extend(client_data_hash);
-        let signature = credential
-            .private_key
-            .sign_and_encode::<E>(&signature_data)?;
+        let signature = private_key.sign_and_encode(&signature_data)?;
 
         let cred_desc = PublicKeyCredentialDescriptor {
             key_type: PublicKeyCredentialType::PublicKey,
@@ -1821,6 +1820,7 @@ mod test {
     fn test_process_make_credential_credential_excluded() {
         let mut env = TestEnv::default();
         let excluded_private_key = PrivateKey::new_ecdsa(&mut env);
+        let wrapped_private_key = excluded_private_key.to_cbor(&mut env).unwrap();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         let excluded_credential_id = vec![0x01, 0x23, 0x45, 0x67];
@@ -1829,7 +1829,7 @@ mod test {
         let excluded_credential_source = PublicKeyCredentialSource {
             key_type: PublicKeyCredentialType::PublicKey,
             credential_id: excluded_credential_id,
-            private_key: excluded_private_key,
+            wrapped_private_key,
             rp_id: String::from("example.com"),
             user_handle: vec![],
             user_display_name: None,
@@ -2656,6 +2656,7 @@ mod test {
     fn test_resident_process_get_assertion_with_cred_protect() {
         let mut env = TestEnv::default();
         let private_key = PrivateKey::new_ecdsa(&mut env);
+        let wrapped_private_key = private_key.to_cbor(&mut env).unwrap();
         let credential_id = env.rng().gen_uniform_u8x32().to_vec();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
@@ -2667,7 +2668,7 @@ mod test {
         let credential = PublicKeyCredentialSource {
             key_type: PublicKeyCredentialType::PublicKey,
             credential_id: credential_id.clone(),
-            private_key: private_key.clone(),
+            wrapped_private_key: wrapped_private_key.clone(),
             rp_id: String::from("example.com"),
             user_handle: vec![0x1D],
             user_display_name: None,
@@ -2721,7 +2722,7 @@ mod test {
         let credential = PublicKeyCredentialSource {
             key_type: PublicKeyCredentialType::PublicKey,
             credential_id,
-            private_key,
+            wrapped_private_key,
             rp_id: String::from("example.com"),
             user_handle: vec![0x1D],
             user_display_name: None,
@@ -2831,13 +2832,14 @@ mod test {
     fn test_process_get_assertion_with_cred_blob() {
         let mut env = TestEnv::default();
         let private_key = PrivateKey::new_ecdsa(&mut env);
+        let wrapped_private_key = private_key.to_cbor(&mut env).unwrap();
         let credential_id = env.rng().gen_uniform_u8x32().to_vec();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         let credential = PublicKeyCredentialSource {
             key_type: PublicKeyCredentialType::PublicKey,
             credential_id,
-            private_key,
+            wrapped_private_key,
             rp_id: String::from("example.com"),
             user_handle: vec![0x1D],
             user_display_name: None,
@@ -2950,13 +2952,14 @@ mod test {
     fn test_process_get_assertion_with_large_blob_key() {
         let mut env = TestEnv::default();
         let private_key = PrivateKey::new_ecdsa(&mut env);
+        let wrapped_private_key = private_key.to_cbor(&mut env).unwrap();
         let credential_id = env.rng().gen_uniform_u8x32().to_vec();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         let credential = PublicKeyCredentialSource {
             key_type: PublicKeyCredentialType::PublicKey,
             credential_id,
-            private_key,
+            wrapped_private_key,
             rp_id: String::from("example.com"),
             user_handle: vec![0x1D],
             user_display_name: None,
@@ -3224,13 +3227,14 @@ mod test {
     fn test_process_reset() {
         let mut env = TestEnv::default();
         let private_key = PrivateKey::new_ecdsa(&mut env);
+        let wrapped_private_key = private_key.to_cbor(&mut env).unwrap();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         let credential_id = vec![0x01, 0x23, 0x45, 0x67];
         let credential_source = PublicKeyCredentialSource {
             key_type: PublicKeyCredentialType::PublicKey,
             credential_id,
-            private_key,
+            wrapped_private_key,
             rp_id: String::from("example.com"),
             user_handle: vec![],
             user_display_name: None,
@@ -3392,10 +3396,11 @@ mod test {
         );
 
         let private_key = PrivateKey::new_ecdsa(&mut env);
+        let wrapped_private_key = private_key.to_cbor(&mut env).unwrap();
         let credential_source = PublicKeyCredentialSource {
             key_type: PublicKeyCredentialType::PublicKey,
             credential_id: env.rng().gen_uniform_u8x32().to_vec(),
-            private_key,
+            wrapped_private_key,
             rp_id: String::from("example.com"),
             user_handle: vec![0x01],
             user_display_name: Some("display_name".to_string()),

--- a/libraries/opensk/src/ctap/storage.rs
+++ b/libraries/opensk/src/ctap/storage.rs
@@ -19,9 +19,10 @@ use crate::ctap::data_formats::{
     extract_array, extract_text_string, PublicKeyCredentialSource, PublicKeyCredentialUserEntity,
 };
 use crate::ctap::status_code::{Ctap2StatusCode, CtapResult};
-use crate::env::{AesKey, Env};
+use crate::env::Env;
 use alloc::string::String;
 use alloc::vec::Vec;
+use core::convert::TryFrom;
 #[cfg(feature = "config_command")]
 use sk_cbor::cbor_array_vec;
 
@@ -39,8 +40,7 @@ pub fn init(env: &mut impl Env) -> CtapResult<()> {
 /// Returns `CTAP2_ERR_VENDOR_INTERNAL_ERROR` if the key does not hold a valid credential.
 pub fn get_credential<E: Env>(env: &mut E, key: usize) -> CtapResult<PublicKeyCredentialSource> {
     let credential_entry = env.persist().credential_bytes(key)?;
-    let wrap_key = env.key_store().wrap_key::<E>()?;
-    deserialize_credential::<E>(&wrap_key, &credential_entry)
+    deserialize_credential(&credential_entry)
         .ok_or(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)
 }
 
@@ -118,8 +118,7 @@ pub fn store_credential<E: Env>(
         // This is an existing credential being updated, we reuse its key.
         Some(x) => x,
     };
-    let wrap_key = env.key_store().wrap_key::<E>()?;
-    let value = serialize_credential::<E>(env, &wrap_key, new_credential)?;
+    let value = serialize_credential(new_credential)?;
     env.persist().write_credential_bytes(key, &value)?;
     Ok(())
 }
@@ -148,8 +147,7 @@ pub fn update_credential<E: Env>(
     credential.user_name = user.user_name;
     credential.user_display_name = user.user_display_name;
     credential.user_icon = user.user_icon;
-    let wrap_key = env.key_store().wrap_key::<E>()?;
-    let value = serialize_credential::<E>(env, &wrap_key, credential)?;
+    let value = serialize_credential(credential)?;
     env.persist().write_credential_bytes(key, &value)
 }
 
@@ -172,7 +170,7 @@ pub fn remaining_credentials(env: &mut impl Env) -> CtapResult<usize> {
 pub fn iter_credentials<'a, E: Env>(
     env: &'a mut E,
     result: &'a mut CtapResult<()>,
-) -> Result<IterCredentials<'a, E>, Ctap2StatusCode> {
+) -> Result<IterCredentials<'a>, Ctap2StatusCode> {
     IterCredentials::new(env, result)
 }
 
@@ -309,10 +307,7 @@ pub fn toggle_always_uv(env: &mut impl Env) -> CtapResult<()> {
 }
 
 /// Iterator for credentials.
-pub struct IterCredentials<'a, E: Env> {
-    /// The key store for credential unwrapping.
-    wrap_key: AesKey<E>,
-
+pub struct IterCredentials<'a> {
     /// The store iterator.
     iter: PersistCredentialIter<'a>,
 
@@ -323,16 +318,11 @@ pub struct IterCredentials<'a, E: Env> {
     result: &'a mut CtapResult<()>,
 }
 
-impl<'a, E: Env> IterCredentials<'a, E> {
+impl<'a> IterCredentials<'a> {
     /// Creates a credential iterator.
-    fn new(env: &'a mut E, result: &'a mut CtapResult<()>) -> CtapResult<Self> {
-        let wrap_key = env.key_store().wrap_key::<E>()?;
+    fn new<E: Env>(env: &'a mut E, result: &'a mut CtapResult<()>) -> CtapResult<Self> {
         let iter = env.persist().iter_credentials()?;
-        Ok(IterCredentials {
-            wrap_key,
-            iter,
-            result,
-        })
+        Ok(IterCredentials { iter, result })
     }
 
     /// Marks the iteration as failed if the content is absent.
@@ -348,7 +338,7 @@ impl<'a, E: Env> IterCredentials<'a, E> {
     }
 }
 
-impl<'a, E: Env> Iterator for IterCredentials<'a, E> {
+impl<'a> Iterator for IterCredentials<'a> {
     type Item = (usize, PublicKeyCredentialSource);
 
     fn next(&mut self) -> Option<(usize, PublicKeyCredentialSource)> {
@@ -357,29 +347,22 @@ impl<'a, E: Env> Iterator for IterCredentials<'a, E> {
         }
         let next = self.iter.next()?;
         let (key, value) = self.unwrap(next.ok())?;
-        let deserialized = deserialize_credential::<E>(&self.wrap_key, &value);
+        let deserialized = deserialize_credential(&value);
         let credential = self.unwrap(deserialized)?;
         Some((key, credential))
     }
 }
 
 /// Deserializes a credential from storage representation.
-fn deserialize_credential<E: Env>(
-    wrap_key: &AesKey<E>,
-    data: &[u8],
-) -> Option<PublicKeyCredentialSource> {
+fn deserialize_credential(data: &[u8]) -> Option<PublicKeyCredentialSource> {
     let cbor = super::cbor_read(data).ok()?;
-    PublicKeyCredentialSource::from_cbor::<E>(wrap_key, cbor).ok()
+    PublicKeyCredentialSource::try_from(cbor).ok()
 }
 
 /// Serializes a credential to storage representation.
-fn serialize_credential<E: Env>(
-    env: &mut E,
-    wrap_key: &AesKey<E>,
-    credential: PublicKeyCredentialSource,
-) -> CtapResult<Vec<u8>> {
+fn serialize_credential(credential: PublicKeyCredentialSource) -> CtapResult<Vec<u8>> {
     let mut data = Vec::new();
-    super::cbor_write(credential.to_cbor::<E>(env.rng(), wrap_key)?, &mut data)?;
+    super::cbor_write(credential.into(), &mut data)?;
     Ok(data)
 }
 
@@ -421,10 +404,11 @@ mod test {
         user_handle: Vec<u8>,
     ) -> PublicKeyCredentialSource {
         let private_key = PrivateKey::new_ecdsa(env);
+        let wrapped_private_key = private_key.to_cbor(env).unwrap();
         PublicKeyCredentialSource {
             key_type: PublicKeyCredentialType::PublicKey,
             credential_id: env.rng().gen_uniform_u8x32().to_vec(),
-            private_key,
+            wrapped_private_key,
             rp_id: String::from(rp_id),
             user_handle,
             user_display_name: None,
@@ -610,7 +594,7 @@ mod test {
         let credential_source0 = create_credential_source(&mut env, "example.com", vec![0x00]);
         let credential_source1 = create_credential_source(&mut env, "example.com", vec![0x01]);
         let id0 = credential_source0.credential_id.clone();
-        let key0 = credential_source0.private_key.clone();
+        let key0 = credential_source0.wrapped_private_key.clone();
         assert!(store_credential(&mut env, credential_source0).is_ok());
         assert!(store_credential(&mut env, credential_source1).is_ok());
 
@@ -620,7 +604,7 @@ mod test {
         let expected_credential = PublicKeyCredentialSource {
             key_type: PublicKeyCredentialType::PublicKey,
             credential_id: id0,
-            private_key: key0,
+            wrapped_private_key: key0,
             rp_id: String::from("example.com"),
             user_handle: vec![0x00],
             user_display_name: None,
@@ -797,12 +781,12 @@ mod test {
     #[test]
     fn test_serialize_deserialize_credential() {
         let mut env = TestEnv::default();
-        let wrap_key = env.key_store().wrap_key::<TestEnv>().unwrap();
         let private_key = PrivateKey::new_ecdsa(&mut env);
+        let wrapped_private_key = private_key.to_cbor(&mut env).unwrap();
         let credential = PublicKeyCredentialSource {
             key_type: PublicKeyCredentialType::PublicKey,
             credential_id: env.rng().gen_uniform_u8x32().to_vec(),
-            private_key,
+            wrapped_private_key,
             rp_id: String::from("example.com"),
             user_handle: vec![0x00],
             user_display_name: Some(String::from("Display Name")),
@@ -813,9 +797,8 @@ mod test {
             cred_blob: Some(vec![0xCB]),
             large_blob_key: Some(vec![0x1B]),
         };
-        let serialized =
-            serialize_credential::<TestEnv>(&mut env, &wrap_key, credential.clone()).unwrap();
-        let reconstructed = deserialize_credential::<TestEnv>(&wrap_key, &serialized).unwrap();
+        let serialized = serialize_credential(credential.clone()).unwrap();
+        let reconstructed = deserialize_credential(&serialized).unwrap();
         assert_eq!(credential, reconstructed);
     }
 


### PR DESCRIPTION
Before, it would store their seed bytes in a `Secret`. While zeroization helps with some attacks, we didn't leave it to the cryptography implementation to further protect the information.

This introduces a new `Env` type dependency in `PrivateKey`. Instead of forwarding it to both types that store `PrivateKey`, namely `CredentialSource` and `PublicKeyCredentialSource`, we make them hold a wrapped version of that private key. This has several advantages:

- We now iterate over stored credentials and filter them more easily without having to decrypt the private key material.
- Private keys wrapping moved out of high level data types, and closer to the cryptographic implementation.

The latter is useful for removing `to_slice` in `SecretKey`, and replacing it with a more generic `wrap`, so that private key material does not have to leave hardware cryptography.

The second goal this PR prepares for is to move Ed25519 into `Env`'s crypto API.
