### PR TITLE
ECDSA private key wrapping responsibility into Env

### DIFF
--- a/libraries/opensk/src/api/crypto/ecdsa.rs
+++ b/libraries/opensk/src/api/crypto/ecdsa.rs
@@ -31,9 +31,6 @@ pub trait SecretKey: Sized {
     /// Generates a new random secret key.
     fn random(rng: &mut impl Rng) -> Self;
 
-    /// Creates a signing key from its representation in bytes.
-    fn from_slice(bytes: &[u8; EC_FIELD_SIZE]) -> Option<Self>;
-
     /// Computes the corresponding public key for this private key.
     fn public_key(&self) -> Self::PublicKey;
 
@@ -42,8 +39,20 @@ pub trait SecretKey: Sized {
     /// For hashing, SHA256 is used implicitly.
     fn sign(&self, message: &[u8]) -> Self::Signature;
 
-    /// Writes the signing key bytes into the passed in parameter.
-    fn to_slice(&self, bytes: &mut [u8; EC_FIELD_SIZE]);
+    /// Returns the wrapped signing key.
+    ///
+    /// If you have access to a hardware module that securly wraps key material, the returned data
+    /// should not allow reconstructing the private key outside of the cryptography hardware.
+    ///
+    /// If you return the plain private key bytes, the key material is not exposed outside of the
+    /// security key. However, the data is present in plain text in memory and storage, and will
+    /// not be zeroized immediately after usage.
+    fn export(&self) -> Vec<u8>;
+
+    /// Creates a signing key from its wrapped representation.
+    ///
+    /// Returns None if the given bytes do not represent a wrapped secret key.
+    fn import(bytes: &[u8]) -> Option<Self>;
 }
 
 /// ECDSA verifying key.

--- a/libraries/opensk/src/api/crypto/ecdsa.rs
+++ b/libraries/opensk/src/api/crypto/ecdsa.rs
@@ -41,6 +41,9 @@ pub trait SecretKey: Sized {
 
     /// Returns the wrapped signing key.
     ///
+    /// The returned representation needs to be deterministic. If you call this function twice for
+    /// the same private key, the return value has to stay the same.
+    ///
     /// If you have access to a hardware module that securly wraps key material, the returned data
     /// should not allow reconstructing the private key outside of the cryptography hardware.
     ///

--- a/libraries/opensk/src/api/crypto/mod.rs
+++ b/libraries/opensk/src/api/crypto/mod.rs
@@ -125,15 +125,13 @@ mod test {
     }
 
     #[test]
-    fn test_ecdsa_secret_key_from_to_slice() {
+    fn test_ecdsa_secret_key_wrap_unwrap() {
         let mut env = TestEnv::default();
         let first_key = SoftwareEcdsaSecretKey::random(env.rng());
-        let mut key_bytes = [0; EC_FIELD_SIZE];
-        first_key.to_slice(&mut key_bytes);
-        let second_key = SoftwareEcdsaSecretKey::from_slice(&key_bytes).unwrap();
-        let mut new_bytes = [0; EC_FIELD_SIZE];
-        second_key.to_slice(&mut new_bytes);
-        assert_eq!(key_bytes, new_bytes);
+        let wrapped = first_key.export();
+        let second_key = SoftwareEcdsaSecretKey::import(&wrapped).unwrap();
+        let wrapped_again = second_key.export();
+        assert_eq!(wrapped, wrapped_again);
     }
 
     #[test]

--- a/libraries/opensk/src/api/crypto/mod.rs
+++ b/libraries/opensk/src/api/crypto/mod.rs
@@ -125,7 +125,16 @@ mod test {
     }
 
     #[test]
-    fn test_ecdsa_secret_key_wrap_unwrap() {
+    fn test_ecdsa_secret_key_deterministic_export() {
+        let mut env = TestEnv::default();
+        let key = SoftwareEcdsaSecretKey::random(env.rng());
+        let wrapped1 = key.export();
+        let wrapped2 = key.export();
+        assert_eq!(wrapped1, wrapped2);
+    }
+
+    #[test]
+    fn test_ecdsa_secret_key_export_import() {
         let mut env = TestEnv::default();
         let first_key = SoftwareEcdsaSecretKey::random(env.rng());
         let wrapped = first_key.export();

--- a/libraries/opensk/src/api/crypto/rust_crypto.rs
+++ b/libraries/opensk/src/api/crypto/rust_crypto.rs
@@ -141,11 +141,6 @@ impl ecdsa::SecretKey for SoftwareEcdsaSecretKey {
         SoftwareEcdsaSecretKey { signing_key }
     }
 
-    fn from_slice(bytes: &[u8; EC_FIELD_SIZE]) -> Option<Self> {
-        let signing_key = SigningKey::from_slice(bytes).ok()?;
-        Some(SoftwareEcdsaSecretKey { signing_key })
-    }
-
     fn public_key(&self) -> Self::PublicKey {
         let verifying_key = VerifyingKey::from(&self.signing_key);
         SoftwareEcdsaPublicKey { verifying_key }
@@ -156,8 +151,13 @@ impl ecdsa::SecretKey for SoftwareEcdsaSecretKey {
         SoftwareEcdsaSignature { signature }
     }
 
-    fn to_slice(&self, bytes: &mut [u8; EC_FIELD_SIZE]) {
-        bytes.copy_from_slice(&self.signing_key.to_bytes());
+    fn export(&self) -> Vec<u8> {
+        self.signing_key.to_bytes().to_vec()
+    }
+
+    fn import(bytes: &[u8]) -> Option<Self> {
+        let signing_key = SigningKey::from_slice(bytes).ok()?;
+        Some(SoftwareEcdsaSecretKey { signing_key })
     }
 }
 

--- a/libraries/opensk/src/api/key_store.rs
+++ b/libraries/opensk/src/api/key_store.rs
@@ -70,14 +70,6 @@ pub trait KeyStore {
     /// This function should be a no-op if the key store is already initialized.
     fn init(&mut self) -> Result<(), Error>;
 
-    /// Key to wrap (secret) data.
-    ///
-    /// Useful for encrypting data before
-    /// - writing it to persistent storage,
-    /// - CBOR encoding it,
-    /// - doing anything that does not support [`Secret`].
-    fn wrap_key<E: Env>(&mut self) -> Result<AesKey<E>, Error>;
-
     /// Encodes a credential as a binary string.
     ///
     /// The output is encrypted and authenticated. Since the wrapped credentials are passed to the
@@ -127,10 +119,6 @@ pub trait Helper: Env {}
 impl<T: Helper> KeyStore for T {
     fn init(&mut self) -> Result<(), Error> {
         Ok(())
-    }
-
-    fn wrap_key<E: Env>(&mut self) -> Result<AesKey<E>, Error> {
-        Ok(AesKey::<E>::new(&get_master_keys(self)?.encryption))
     }
 
     /// Encrypts the given credential source data into a credential ID.
@@ -363,9 +351,8 @@ mod test {
         signature_algorithm: SignatureAlgorithm,
     ) -> CredentialSource {
         let private_key = PrivateKey::new(env, signature_algorithm);
-        let wrapped_private_key = private_key.to_cbor(env).unwrap();
         CredentialSource {
-            wrapped_private_key,
+            wrapped_private_key: private_key.to_cbor(),
             rp_id_hash: [0x55; 32],
             cred_protect_policy: Some(CredentialProtectionPolicy::UserVerificationOptional),
             cred_blob: Some(vec![0xAA; 32]),
@@ -388,15 +375,6 @@ mod test {
             &cred_random_with_uv
         );
 
-        // Same for wrap key.
-        let wrap_key = env.key_store().wrap_key::<TestEnv>().unwrap();
-        let mut test_block = [0x33; 16];
-        wrap_key.encrypt_block(&mut test_block);
-        let new_wrap_key = env.key_store().wrap_key::<TestEnv>().unwrap();
-        let mut new_test_block = [0x33; 16];
-        new_wrap_key.encrypt_block(&mut new_test_block);
-        assert_eq!(&new_test_block, &test_block);
-
         assert_eq!(crate::ctap::reset(&mut env), Ok(()));
         assert_ne!(
             &env.key_store().cred_random(false).unwrap(),
@@ -406,10 +384,6 @@ mod test {
             &env.key_store().cred_random(true).unwrap(),
             &cred_random_with_uv
         );
-        let new_wrap_key = env.key_store().wrap_key::<TestEnv>().unwrap();
-        let mut new_test_block = [0x33; 16];
-        new_wrap_key.encrypt_block(&mut new_test_block);
-        assert_ne!(&new_test_block, &test_block);
     }
 
     #[test]

--- a/libraries/opensk/src/api/persist.rs
+++ b/libraries/opensk/src/api/persist.rs
@@ -14,7 +14,7 @@
 
 mod keys;
 
-use crate::api::crypto::EC_FIELD_SIZE;
+use crate::ctap::data_formats::{extract_byte_string, extract_map, ok_or_missing};
 #[cfg(feature = "fingerprint")]
 use crate::ctap::fingerprint::TemplateInfo;
 use crate::ctap::secret::Secret;
@@ -31,8 +31,8 @@ use core::cmp;
 use core::convert::TryFrom;
 #[cfg(test)]
 use enum_iterator::IntoEnumIterator;
-#[cfg(feature = "fingerprint")]
 use sk_cbor as cbor;
+use sk_cbor::destructure_cbor_map;
 
 pub type PersistIter<'a> = Box<dyn Iterator<Item = CtapResult<usize>> + 'a>;
 pub type PersistCredentialIter<'a> = Box<dyn Iterator<Item = CtapResult<(usize, Vec<u8>)>> + 'a>;
@@ -543,18 +543,15 @@ pub trait Persist {
                 return Ok(None);
             }
         }
-        let private_key = self.find(keys::ATTESTATION_PRIVATE_KEY)?;
+        let wrapped_private_key = self.find(keys::ATTESTATION_PRIVATE_KEY)?;
         let certificate = self.find(keys::ATTESTATION_CERTIFICATE)?;
-        let (private_key, certificate) = match (private_key, certificate) {
+        let (wrapped_private_key, certificate) = match (wrapped_private_key, certificate) {
             (Some(x), Some(y)) => (x, y),
             (None, None) => return Ok(None),
             _ => return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR),
         };
-        if private_key.len() != EC_FIELD_SIZE {
-            return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
-        }
         Ok(Some(Attestation {
-            private_key: Secret::from_exposed_secret(*array_ref![private_key, 0, EC_FIELD_SIZE]),
+            wrapped_private_key,
             certificate,
         }))
     }
@@ -578,8 +575,11 @@ pub trait Persist {
                 self.remove(keys::ATTESTATION_ID)?;
             }
             Some(attestation) => {
-                self.insert(keys::ATTESTATION_PRIVATE_KEY, &attestation.private_key[..])?;
-                self.insert(keys::ATTESTATION_CERTIFICATE, &attestation.certificate[..])?;
+                self.insert(
+                    keys::ATTESTATION_PRIVATE_KEY,
+                    &attestation.wrapped_private_key,
+                )?;
+                self.insert(keys::ATTESTATION_CERTIFICATE, &attestation.certificate)?;
                 self.insert(keys::ATTESTATION_ID, &[id as u8])?;
             }
         }
@@ -622,11 +622,32 @@ impl TryFrom<u8> for AttestationId {
     }
 }
 
-#[cfg_attr(feature = "std", derive(Debug, PartialEq, Eq))]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Attestation {
-    /// ECDSA private key (big-endian).
-    pub private_key: Secret<[u8; EC_FIELD_SIZE]>,
+    /// ECDSA private key, wrapping is implementation specific.
+    ///
+    /// The wrapping needs to work together with your `ecdsa::SecretKey` implementation.
+    pub wrapped_private_key: Vec<u8>,
     pub certificate: Vec<u8>,
+}
+
+impl TryFrom<cbor::Value> for Attestation {
+    type Error = Ctap2StatusCode;
+
+    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
+        destructure_cbor_map! {
+            let {
+                0x01 => certificate,
+                0x02 => wrapped_private_key,
+            } = extract_map(cbor_value)?;
+        }
+        let certificate = extract_byte_string(ok_or_missing(certificate)?)?;
+        let wrapped_private_key = extract_byte_string(ok_or_missing(wrapped_private_key)?)?;
+        Ok(Attestation {
+            wrapped_private_key,
+            certificate,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -636,6 +657,7 @@ mod test {
     use crate::api::rng::Rng;
     use crate::env::test::TestEnv;
     use crate::env::Env;
+    use sk_cbor::cbor_map;
 
     #[test]
     fn test_max_large_blob_array_size() {
@@ -778,5 +800,19 @@ mod test {
         );
         assert_eq!(persist.remove_template_id(&[0x00]), Ok(()));
         assert_eq!(persist.get_friendly_name(&[0x00]).unwrap(), None);
+    }
+
+    #[test]
+    fn test_from_cbor_attestation() {
+        let cbor_value = cbor_map! {
+            0x01 => vec![0xCC],
+            0x02 => vec![0x55],
+        };
+        let returned_attestation = Attestation::try_from(cbor_value).unwrap();
+        let expected_attestation = Attestation {
+            wrapped_private_key: vec![0x55],
+            certificate: vec![0xCC],
+        };
+        assert_eq!(returned_attestation, expected_attestation);
     }
 }

--- a/libraries/opensk/src/api/private_key.rs
+++ b/libraries/opensk/src/api/private_key.rs
@@ -13,19 +13,14 @@
 // limitations under the License.
 
 use crate::api::crypto::ecdsa::{SecretKey as _, Signature};
-#[cfg(test)]
-use crate::api::crypto::EC_FIELD_SIZE;
-use crate::api::key_store::KeyStore;
-use crate::ctap::crypto_wrapper::{aes256_cbc_decrypt, aes256_cbc_encrypt};
 use crate::ctap::data_formats::{extract_array, extract_byte_string, CoseKey, SignatureAlgorithm};
+#[cfg(feature = "ed25519")]
 use crate::ctap::secret::Secret;
 use crate::ctap::status_code::{Ctap2StatusCode, CtapResult};
-use crate::env::{AesKey, EcdsaSk, Env};
+use crate::env::{EcdsaSk, Env};
 use alloc::vec;
 use alloc::vec::Vec;
 use core::convert::TryFrom;
-#[cfg(feature = "ed25519")]
-use core::ops::Deref;
 #[cfg(feature = "ed25519")]
 use rand_core::RngCore;
 use sk_cbor as cbor;
@@ -43,9 +38,7 @@ impl<E: Env> Clone for PrivateKey<E> {
     fn clone(&self) -> Self {
         match self {
             PrivateKey::Ecdsa(key) => {
-                let mut key_bytes = [0; EC_FIELD_SIZE];
-                key.to_slice(&mut key_bytes);
-                PrivateKey::Ecdsa(EcdsaSk::<E>::from_slice(&key_bytes).unwrap())
+                PrivateKey::Ecdsa(EcdsaSk::<E>::import(&key.export()).unwrap())
             }
             #[cfg(feature = "ed25519")]
             PrivateKey::Ed25519(key) => Self::Ed25519(*key),
@@ -58,15 +51,10 @@ impl<E: Env> Clone for PrivateKey<E> {
 impl<E: Env> PartialEq for PrivateKey<E> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (PrivateKey::Ecdsa(key1), PrivateKey::Ecdsa(key2)) => {
-                let mut bytes1 = [0; EC_FIELD_SIZE];
-                key1.to_slice(&mut bytes1);
-                let mut bytes2 = [0; EC_FIELD_SIZE];
-                key2.to_slice(&mut bytes2);
-                bytes1 == bytes2
-            }
+            (PrivateKey::Ecdsa(key1), PrivateKey::Ecdsa(key2)) => key1.export() == key2.export(),
             #[cfg(feature = "ed25519")]
             (PrivateKey::Ed25519(key1), PrivateKey::Ed25519(key2)) => key1 == key2,
+            #[cfg(feature = "ed25519")]
             _ => false,
         }
     }
@@ -94,12 +82,6 @@ impl<E: Env> PrivateKey<E> {
     /// Creates a new ecdsa private key.
     pub fn new_ecdsa(env: &mut E) -> PrivateKey<E> {
         Self::new(env, SignatureAlgorithm::Es256)
-    }
-
-    /// Helper function that creates a private key of type ECDSA.
-    fn new_ecdsa_from_bytes(bytes: &[u8]) -> Option<Self> {
-        let bytes = <&[u8; 32]>::try_from(bytes).ok()?;
-        EcdsaSk::<E>::from_slice(bytes).map(|k| PrivateKey::Ecdsa(k))
     }
 
     /// Helper function that creates a private key of type Ed25519.
@@ -140,43 +122,34 @@ impl<E: Env> PrivateKey<E> {
     }
 
     /// Writes the key bytes.
-    pub fn to_bytes(&self) -> Secret<[u8]> {
-        let mut bytes = Secret::new(32);
+    pub fn export(&self) -> Vec<u8> {
         match self {
-            PrivateKey::Ecdsa(key) => {
-                let mut array_bytes: Secret<[u8; 32]> = Secret::default();
-                key.to_slice(&mut array_bytes);
-                bytes.copy_from_slice(&array_bytes[..]);
-            }
+            PrivateKey::Ecdsa(key) => key.export(),
             #[cfg(feature = "ed25519")]
-            PrivateKey::Ed25519(ed25519_key) => bytes.copy_from_slice(ed25519_key.seed().deref()),
+            PrivateKey::Ed25519(ed25519_key) => ed25519_key.seed().to_vec(),
         }
-        bytes
     }
 
     /// Encodes the private key into a CBOR array with type information.
-    pub fn to_cbor(&self, env: &mut E) -> CtapResult<cbor::Value> {
-        let bytes = self.to_bytes();
-        let wrap_key = env.key_store().wrap_key::<E>()?;
-        let wrapped_bytes = aes256_cbc_encrypt::<E>(env.rng(), &wrap_key, &bytes, true)?;
-        Ok(cbor_array![
+    pub fn to_cbor(&self) -> cbor::Value {
+        cbor_array![
             cbor_int!(self.signature_algorithm() as i64),
-            cbor_bytes!(wrapped_bytes),
-        ])
+            cbor_bytes!(self.export()),
+        ]
     }
 
-    pub fn from_cbor(wrap_key: &AesKey<E>, cbor_value: cbor::Value) -> CtapResult<Self> {
+    pub fn from_cbor(cbor_value: cbor::Value) -> CtapResult<Self> {
         let mut array = extract_array(cbor_value)?;
         if array.len() != 2 {
             return Err(Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR);
         }
         let wrapped_bytes = extract_byte_string(array.pop().unwrap())?;
-        let key_bytes = aes256_cbc_decrypt::<E>(wrap_key, &wrapped_bytes, true)?;
         match SignatureAlgorithm::try_from(array.pop().unwrap())? {
-            SignatureAlgorithm::Es256 => PrivateKey::<E>::new_ecdsa_from_bytes(&key_bytes)
+            SignatureAlgorithm::Es256 => EcdsaSk::<E>::import(&wrapped_bytes)
+                .map(|k| PrivateKey::Ecdsa(k))
                 .ok_or(Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR),
             #[cfg(feature = "ed25519")]
-            SignatureAlgorithm::Eddsa => PrivateKey::<E>::new_ed25519_from_bytes(&key_bytes)
+            SignatureAlgorithm::Eddsa => PrivateKey::<E>::new_ed25519_from_bytes(&wrapped_bytes)
                 .ok_or(Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR),
             _ => Err(Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR),
         }
@@ -186,15 +159,16 @@ impl<E: Env> PrivateKey<E> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::api::key_store::KeyStore;
     use crate::env::test::TestEnv;
 
     #[test]
-    fn test_new_ecdsa_from_bytes() {
+    fn test_new_ecdsa_wrap_unwrap() {
         let mut env = TestEnv::default();
-        let private_key = PrivateKey::<TestEnv>::new(&mut env, SignatureAlgorithm::Es256);
-        let key_bytes = private_key.to_bytes();
-        assert!(PrivateKey::<TestEnv>::new_ecdsa_from_bytes(&key_bytes) == Some(private_key));
+        let private_key = PrivateKey::<TestEnv>::new_ecdsa(&mut env);
+        let key_bytes = private_key.export();
+        let ecdsa_key = EcdsaSk::<TestEnv>::import(&key_bytes).unwrap();
+        let reconstructed = PrivateKey::<TestEnv>::Ecdsa(ecdsa_key);
+        assert!(private_key == reconstructed);
     }
 
     #[test]
@@ -202,16 +176,8 @@ mod test {
     fn test_new_ed25519_from_bytes() {
         let mut env = TestEnv::default();
         let private_key = PrivateKey::<TestEnv>::new(&mut env, SignatureAlgorithm::Eddsa);
-        let key_bytes = private_key.to_bytes();
+        let key_bytes = private_key.export();
         assert!(PrivateKey::<TestEnv>::new_ed25519_from_bytes(&key_bytes) == Some(private_key));
-    }
-
-    #[test]
-    fn test_new_ecdsa_from_bytes_wrong_length() {
-        assert!(PrivateKey::<TestEnv>::new_ecdsa_from_bytes(&[0x55; 16]).is_none());
-        assert!(PrivateKey::<TestEnv>::new_ecdsa_from_bytes(&[0x55; 31]).is_none());
-        assert!(PrivateKey::<TestEnv>::new_ecdsa_from_bytes(&[0x55; 33]).is_none());
-        assert!(PrivateKey::<TestEnv>::new_ecdsa_from_bytes(&[0x55; 64]).is_none());
     }
 
     #[test]
@@ -264,10 +230,9 @@ mod test {
 
     fn test_private_key_from_to_cbor(signature_algorithm: SignatureAlgorithm) {
         let mut env = TestEnv::default();
-        let wrap_key = env.key_store().wrap_key::<TestEnv>().unwrap();
         let private_key = PrivateKey::<TestEnv>::new(&mut env, signature_algorithm);
-        let cbor = private_key.to_cbor(&mut env).unwrap();
-        assert!(PrivateKey::<TestEnv>::from_cbor(&wrap_key, cbor) == Ok(private_key));
+        let cbor = private_key.to_cbor();
+        assert!(PrivateKey::<TestEnv>::from_cbor(cbor) == Ok(private_key));
     }
 
     #[test]
@@ -282,8 +247,6 @@ mod test {
     }
 
     fn test_private_key_from_bad_cbor(signature_algorithm: SignatureAlgorithm) {
-        let mut env = TestEnv::default();
-        let wrap_key = env.key_store().wrap_key::<TestEnv>().unwrap();
         let cbor = cbor_array![
             cbor_int!(signature_algorithm as i64),
             cbor_bytes!(vec![0x88; 32]),
@@ -291,8 +254,7 @@ mod test {
             cbor_int!(0),
         ];
         assert!(
-            PrivateKey::<TestEnv>::from_cbor(&wrap_key, cbor)
-                == Err(Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR),
+            PrivateKey::<TestEnv>::from_cbor(cbor) == Err(Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR)
         );
     }
 
@@ -309,16 +271,13 @@ mod test {
 
     #[test]
     fn test_private_key_from_bad_cbor_unsupported_algo() {
-        let mut env = TestEnv::default();
-        let wrap_key = env.key_store().wrap_key::<TestEnv>().unwrap();
         let cbor = cbor_array![
             // This algorithms doesn't exist.
             cbor_int!(-1),
             cbor_bytes!(vec![0x88; 32]),
         ];
         assert!(
-            PrivateKey::<TestEnv>::from_cbor(&wrap_key, cbor)
-                == Err(Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR),
+            PrivateKey::<TestEnv>::from_cbor(cbor) == Err(Ctap2StatusCode::CTAP2_ERR_INVALID_CBOR)
         );
     }
 }

--- a/libraries/opensk/src/ctap/credential_management.rs
+++ b/libraries/opensk/src/ctap/credential_management.rs
@@ -24,7 +24,6 @@ use super::status_code::Ctap2StatusCode;
 use super::{Channel, StatefulCommand, StatefulPermission};
 use crate::api::crypto::sha256::Sha256;
 use crate::api::customization::Customization;
-use crate::api::key_store::KeyStore;
 use crate::api::private_key::PrivateKey;
 use crate::ctap::data_formats::CredentialProtectionPolicy;
 use crate::ctap::status_code::CtapResult;
@@ -96,8 +95,7 @@ fn enumerate_credentials_response<E: Env>(
         key_id: credential_id,
         transports: None, // You can set USB as a hint here.
     };
-    let wrap_key = env.key_store().wrap_key::<E>()?;
-    let private_key = PrivateKey::<E>::from_cbor(&wrap_key, wrapped_private_key)?;
+    let private_key = PrivateKey::<E>::from_cbor(wrapped_private_key)?;
     let public_key = private_key.get_pub_key()?;
     let cred_protect = cred_protect_policy
         .or(env.customization().default_cred_protect())
@@ -376,11 +374,10 @@ mod test {
 
     fn create_credential_source(env: &mut TestEnv) -> PublicKeyCredentialSource {
         let private_key = PrivateKey::new_ecdsa(env);
-        let wrapped_private_key = private_key.to_cbor(env).unwrap();
         PublicKeyCredentialSource {
             key_type: PublicKeyCredentialType::PublicKey,
             credential_id: env.rng().gen_uniform_u8x32().to_vec(),
-            wrapped_private_key,
+            wrapped_private_key: private_key.to_cbor(),
             rp_id: String::from("example.com"),
             user_handle: vec![0x01],
             user_display_name: Some("display_name".to_string()),

--- a/libraries/opensk/src/ctap/ctap1.rs
+++ b/libraries/opensk/src/ctap/ctap1.rs
@@ -297,7 +297,8 @@ impl Ctap1Command {
         signature_data.extend(key_handle);
         signature_data.extend_from_slice(&user_pk);
 
-        let attestation_key = EcdsaSk::<E>::import(&wrapped_private_key).unwrap();
+        let attestation_key = EcdsaSk::<E>::import(&wrapped_private_key)
+            .ok_or(Ctap1StatusCode::SW_INTERNAL_EXCEPTION)?;
         let signature = attestation_key.sign(&signature_data);
 
         response.extend(signature.to_der());

--- a/libraries/opensk/src/ctap/ctap1.rs
+++ b/libraries/opensk/src/ctap/ctap1.rs
@@ -256,9 +256,7 @@ impl Ctap1Command {
         let sk = EcdsaSk::<E>::random(env.rng());
         let pk = sk.public_key();
         let private_key = PrivateKey::<E>::Ecdsa(sk);
-        let wrapped_private_key = private_key
-            .to_cbor(env)
-            .map_err(|_| Ctap1StatusCode::SW_INTERNAL_EXCEPTION)?;
+        let wrapped_private_key = private_key.to_cbor();
         let credential_source = CredentialSource {
             wrapped_private_key,
             rp_id_hash: application,
@@ -275,7 +273,7 @@ impl Ctap1Command {
         }
 
         let Attestation {
-            private_key,
+            wrapped_private_key,
             certificate,
         } = env
             .persist()
@@ -299,7 +297,7 @@ impl Ctap1Command {
         signature_data.extend(key_handle);
         signature_data.extend_from_slice(&user_pk);
 
-        let attestation_key = EcdsaSk::<E>::from_slice(&private_key).unwrap();
+        let attestation_key = EcdsaSk::<E>::import(&wrapped_private_key).unwrap();
         let signature = attestation_key.sign(&signature_data);
 
         response.extend(signature.to_der());
@@ -348,13 +346,8 @@ impl Ctap1Command {
             )
             .map_err(|_| Ctap1StatusCode::SW_WRONG_DATA)?;
         signature_data.extend(&challenge);
-        let wrap_key = env
-            .key_store()
-            .wrap_key::<E>()
+        let private_key = PrivateKey::<E>::from_cbor(credential_source.wrapped_private_key)
             .map_err(|_| Ctap1StatusCode::SW_INTERNAL_EXCEPTION)?;
-        let private_key =
-            PrivateKey::<E>::from_cbor(&wrap_key, credential_source.wrapped_private_key)
-                .map_err(|_| Ctap1StatusCode::SW_INTERNAL_EXCEPTION)?;
         let signature = private_key
             .sign_and_encode(&signature_data)
             .map_err(|_| Ctap1StatusCode::SW_INTERNAL_EXCEPTION)?;
@@ -367,13 +360,12 @@ impl Ctap1Command {
 
 #[cfg(test)]
 mod test {
-    use super::super::data_formats::{CredentialProtectionPolicy, SignatureAlgorithm};
+    use super::super::data_formats::CredentialProtectionPolicy;
     use super::super::TOUCH_TIMEOUT_MS;
     use super::*;
     use crate::api::crypto::sha256::Sha256;
     use crate::api::customization::Customization;
     use crate::api::key_store::CBOR_CREDENTIAL_ID_SIZE;
-    use crate::ctap::secret::Secret;
     use crate::ctap::storage;
     use crate::env::test::TestEnv;
     use crate::env::Sha;
@@ -418,7 +410,7 @@ mod test {
     /// Creates an example wrapped credential and RP ID hash.
     fn create_wrapped_credential(env: &mut TestEnv) -> (Vec<u8>, [u8; 32]) {
         let private_key = PrivateKey::new_ecdsa(env);
-        let wrapped_private_key = private_key.to_cbor(env).unwrap();
+        let wrapped_private_key = private_key.to_cbor();
         let rp_id_hash = Sha::<TestEnv>::digest(b"example.com");
         let credential_source = CredentialSource {
             wrapped_private_key,
@@ -462,7 +454,7 @@ mod test {
         assert_eq!(response, Err(Ctap1StatusCode::SW_INTERNAL_EXCEPTION));
 
         let attestation = Attestation {
-            private_key: Secret::from_exposed_secret([0x41; 32]),
+            wrapped_private_key: vec![0x41; 32],
             certificate: vec![0x99; 100],
         };
         env.persist()
@@ -726,7 +718,7 @@ mod test {
         let mut ctap_state = CtapState::new(&mut env);
 
         let private_key = PrivateKey::new_ecdsa(&mut env);
-        let wrapped_private_key = private_key.to_cbor(&mut env).unwrap();
+        let wrapped_private_key = private_key.to_cbor();
         let rp_id_hash = Sha::<TestEnv>::digest(b"example.com");
         let credential_source = CredentialSource {
             wrapped_private_key,

--- a/libraries/opensk/src/ctap/data_formats.rs
+++ b/libraries/opensk/src/ctap/data_formats.rs
@@ -2070,11 +2070,10 @@ mod test {
     fn test_credential_source_cbor_round_trip() {
         let mut env = TestEnv::default();
         let private_key = PrivateKey::new_ecdsa(&mut env);
-        let wrapped_private_key = private_key.to_cbor(&mut env).unwrap();
         let credential = PublicKeyCredentialSource {
             key_type: PublicKeyCredentialType::PublicKey,
             credential_id: env.rng().gen_uniform_u8x32().to_vec(),
-            wrapped_private_key,
+            wrapped_private_key: private_key.to_cbor(),
             rp_id: "example.com".to_string(),
             user_handle: b"foo".to_vec(),
             user_display_name: None,

--- a/libraries/opensk/src/ctap/mod.rs
+++ b/libraries/opensk/src/ctap/mod.rs
@@ -917,7 +917,7 @@ impl<E: Env> CtapState<E> {
             let credential_source = PublicKeyCredentialSource {
                 key_type: PublicKeyCredentialType::PublicKey,
                 credential_id: random_id.clone(),
-                wrapped_private_key: private_key.to_cbor(env)?,
+                wrapped_private_key: private_key.to_cbor(),
                 rp_id,
                 user_handle: user.user_id,
                 // This input is user provided, so we crop it to 64 byte for storage.
@@ -940,7 +940,7 @@ impl<E: Env> CtapState<E> {
             random_id
         } else {
             let credential_source = CredentialSource {
-                wrapped_private_key: private_key.to_cbor(env)?,
+                wrapped_private_key: private_key.to_cbor(),
                 rp_id_hash,
                 cred_protect_policy,
                 cred_blob,
@@ -994,13 +994,13 @@ impl<E: Env> CtapState<E> {
         let (signature, x5c) = match attestation_id {
             Some(id) => {
                 let Attestation {
-                    private_key,
+                    wrapped_private_key,
                     certificate,
                 } = env
                     .persist()
                     .get_attestation(id)?
                     .ok_or(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)?;
-                let attestation_key = EcdsaSk::<E>::from_slice(&private_key).unwrap();
+                let attestation_key = EcdsaSk::<E>::import(&wrapped_private_key).unwrap();
                 (
                     attestation_key.sign(&signature_data).to_der(),
                     Some(vec![certificate]),
@@ -1034,7 +1034,7 @@ impl<E: Env> CtapState<E> {
         private_key: &PrivateKey<E>,
         has_uv: bool,
     ) -> CtapResult<Secret<[u8; HASH_SIZE]>> {
-        let private_key_bytes = private_key.to_bytes();
+        let private_key_bytes = private_key.export();
         let salt = array_ref!(private_key_bytes, 0, 32);
         let key = env.key_store().cred_random(has_uv)?;
         let mut output = Secret::default();
@@ -1059,8 +1059,7 @@ impl<E: Env> CtapState<E> {
             has_uv,
         } = assertion_input;
 
-        let wrap_key = env.key_store().wrap_key::<E>()?;
-        let private_key = PrivateKey::from_cbor(&wrap_key, credential.wrapped_private_key)?;
+        let private_key = PrivateKey::from_cbor(credential.wrapped_private_key)?;
         // Process extensions.
         if extensions.hmac_secret.is_some() || extensions.cred_blob {
             let encrypted_output = if let Some(hmac_secret_input) = extensions.hmac_secret {
@@ -1820,7 +1819,7 @@ mod test {
     fn test_process_make_credential_credential_excluded() {
         let mut env = TestEnv::default();
         let excluded_private_key = PrivateKey::new_ecdsa(&mut env);
-        let wrapped_private_key = excluded_private_key.to_cbor(&mut env).unwrap();
+        let wrapped_private_key = excluded_private_key.to_cbor();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         let excluded_credential_id = vec![0x01, 0x23, 0x45, 0x67];
@@ -2656,7 +2655,7 @@ mod test {
     fn test_resident_process_get_assertion_with_cred_protect() {
         let mut env = TestEnv::default();
         let private_key = PrivateKey::new_ecdsa(&mut env);
-        let wrapped_private_key = private_key.to_cbor(&mut env).unwrap();
+        let wrapped_private_key = private_key.to_cbor();
         let credential_id = env.rng().gen_uniform_u8x32().to_vec();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
@@ -2832,7 +2831,7 @@ mod test {
     fn test_process_get_assertion_with_cred_blob() {
         let mut env = TestEnv::default();
         let private_key = PrivateKey::new_ecdsa(&mut env);
-        let wrapped_private_key = private_key.to_cbor(&mut env).unwrap();
+        let wrapped_private_key = private_key.to_cbor();
         let credential_id = env.rng().gen_uniform_u8x32().to_vec();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
@@ -2952,7 +2951,7 @@ mod test {
     fn test_process_get_assertion_with_large_blob_key() {
         let mut env = TestEnv::default();
         let private_key = PrivateKey::new_ecdsa(&mut env);
-        let wrapped_private_key = private_key.to_cbor(&mut env).unwrap();
+        let wrapped_private_key = private_key.to_cbor();
         let credential_id = env.rng().gen_uniform_u8x32().to_vec();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
@@ -3227,7 +3226,7 @@ mod test {
     fn test_process_reset() {
         let mut env = TestEnv::default();
         let private_key = PrivateKey::new_ecdsa(&mut env);
-        let wrapped_private_key = private_key.to_cbor(&mut env).unwrap();
+        let wrapped_private_key = private_key.to_cbor();
         let mut ctap_state = CtapState::<TestEnv>::new(&mut env);
 
         let credential_id = vec![0x01, 0x23, 0x45, 0x67];
@@ -3396,7 +3395,7 @@ mod test {
         );
 
         let private_key = PrivateKey::new_ecdsa(&mut env);
-        let wrapped_private_key = private_key.to_cbor(&mut env).unwrap();
+        let wrapped_private_key = private_key.to_cbor();
         let credential_source = PublicKeyCredentialSource {
             key_type: PublicKeyCredentialType::PublicKey,
             credential_id: env.rng().gen_uniform_u8x32().to_vec(),

--- a/libraries/opensk/src/ctap/mod.rs
+++ b/libraries/opensk/src/ctap/mod.rs
@@ -1000,7 +1000,8 @@ impl<E: Env> CtapState<E> {
                     .persist()
                     .get_attestation(id)?
                     .ok_or(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)?;
-                let attestation_key = EcdsaSk::<E>::import(&wrapped_private_key).unwrap();
+                let attestation_key = EcdsaSk::<E>::import(&wrapped_private_key)
+                    .ok_or(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)?;
                 (
                     attestation_key.sign(&signature_data).to_der(),
                     Some(vec![certificate]),
@@ -1034,11 +1035,10 @@ impl<E: Env> CtapState<E> {
         private_key: &PrivateKey<E>,
         has_uv: bool,
     ) -> CtapResult<Secret<[u8; HASH_SIZE]>> {
-        let private_key_bytes = private_key.export();
-        let salt = array_ref!(private_key_bytes, 0, 32);
+        let salt = Sha::<E>::digest(&private_key.export());
         let key = env.key_store().cred_random(has_uv)?;
         let mut output = Secret::default();
-        Hkdf::<E>::hkdf_256(&*key, salt, b"credRandom", &mut output);
+        Hkdf::<E>::hkdf_256(&*key, &salt, b"credRandom", &mut output);
         Ok(output)
     }
 

--- a/libraries/opensk/src/ctap/storage.rs
+++ b/libraries/opensk/src/ctap/storage.rs
@@ -395,7 +395,6 @@ mod test {
         CredentialProtectionPolicy, PublicKeyCredentialSource, PublicKeyCredentialType,
     };
     use crate::ctap::reset;
-    use crate::ctap::secret::Secret;
     use crate::env::test::TestEnv;
 
     fn create_credential_source(
@@ -404,11 +403,10 @@ mod test {
         user_handle: Vec<u8>,
     ) -> PublicKeyCredentialSource {
         let private_key = PrivateKey::new_ecdsa(env);
-        let wrapped_private_key = private_key.to_cbor(env).unwrap();
         PublicKeyCredentialSource {
             key_type: PublicKeyCredentialType::PublicKey,
             credential_id: env.rng().gen_uniform_u8x32().to_vec(),
-            wrapped_private_key,
+            wrapped_private_key: private_key.to_cbor(),
             rp_id: String::from(rp_id),
             user_handle,
             user_display_name: None,
@@ -688,7 +686,7 @@ mod test {
 
         // Make sure the persistent keys are initialized to dummy values.
         let dummy_attestation = Attestation {
-            private_key: Secret::from_exposed_secret([0x41; 32]),
+            wrapped_private_key: vec![0x41; 32],
             certificate: vec![0xdd; 20],
         };
         env.persist()
@@ -745,7 +743,7 @@ mod test {
         let mut env = TestEnv::default();
 
         let dummy_attestation = Attestation {
-            private_key: Secret::from_exposed_secret([0x41; 32]),
+            wrapped_private_key: vec![0x41; 32],
             certificate: vec![0xdd; 20],
         };
         env.persist()
@@ -782,11 +780,10 @@ mod test {
     fn test_serialize_deserialize_credential() {
         let mut env = TestEnv::default();
         let private_key = PrivateKey::new_ecdsa(&mut env);
-        let wrapped_private_key = private_key.to_cbor(&mut env).unwrap();
         let credential = PublicKeyCredentialSource {
             key_type: PublicKeyCredentialType::PublicKey,
             credential_id: env.rng().gen_uniform_u8x32().to_vec(),
-            wrapped_private_key,
+            wrapped_private_key: private_key.to_cbor(),
             rp_id: String::from("example.com"),
             user_handle: vec![0x00],
             user_display_name: Some(String::from("Display Name")),

--- a/libraries/opensk/src/test_helpers/mod.rs
+++ b/libraries/opensk/src/test_helpers/mod.rs
@@ -15,7 +15,6 @@
 use crate::api::persist::{Attestation, AttestationId, Persist};
 use crate::ctap::command::{AuthenticatorConfigParameters, Command};
 use crate::ctap::data_formats::ConfigSubCommand;
-use crate::ctap::secret::Secret;
 use crate::ctap::status_code::CtapResult;
 use crate::ctap::{Channel, CtapState};
 use crate::env::Env;
@@ -29,7 +28,7 @@ pub fn enable_enterprise_attestation<E: Env>(
     env: &mut E,
 ) -> CtapResult<Attestation> {
     let attestation = Attestation {
-        private_key: Secret::from_exposed_secret([0x41; 32]),
+        wrapped_private_key: vec![0x41; 32],
         certificate: vec![0xdd; 20],
     };
     env.persist()

--- a/src/env/tock/commands.rs
+++ b/src/env/tock/commands.rs
@@ -15,7 +15,6 @@
 use super::TockEnv;
 use alloc::vec;
 use alloc::vec::Vec;
-use arrayref::array_ref;
 use core::convert::TryFrom;
 use libtock_platform::Syscalls;
 use opensk::api::crypto::sha256::Sha256;
@@ -28,7 +27,6 @@ use opensk::ctap::check_user_presence;
 use opensk::ctap::data_formats::{
     extract_bool, extract_byte_string, extract_map, extract_unsigned, ok_or_missing,
 };
-use opensk::ctap::secret::Secret;
 use opensk::ctap::status_code::{Ctap2StatusCode, CtapResult};
 use opensk::ctap::{cbor_read, cbor_write, Channel};
 use opensk::env::{Env, Sha};
@@ -117,12 +115,7 @@ fn process_vendor_configure<
             // We don't overwrite the attestation if it's already set. We don't return any error
             // to not leak information.
             if current_attestation.is_none() {
-                let attestation = Attestation {
-                    private_key: Secret::from_exposed_secret(data.private_key),
-                    certificate: data.certificate,
-                };
-                env.persist()
-                    .set_attestation(attestation_id, Some(&attestation))?;
+                env.persist().set_attestation(attestation_id, Some(&data))?;
             }
             VendorConfigureResponse {
                 cert_programmed: true,
@@ -180,39 +173,10 @@ fn process_vendor_upgrade_info<
     })
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct AttestationMaterial {
-    pub certificate: Vec<u8>,
-    pub private_key: [u8; EC_FIELD_SIZE],
-}
-
-impl TryFrom<cbor::Value> for AttestationMaterial {
-    type Error = Ctap2StatusCode;
-
-    fn try_from(cbor_value: cbor::Value) -> CtapResult<Self> {
-        destructure_cbor_map! {
-            let {
-                0x01 => certificate,
-                0x02 => private_key,
-            } = extract_map(cbor_value)?;
-        }
-        let certificate = extract_byte_string(ok_or_missing(certificate)?)?;
-        let private_key = extract_byte_string(ok_or_missing(private_key)?)?;
-        if private_key.len() != EC_FIELD_SIZE {
-            return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
-        }
-        let private_key = array_ref!(private_key, 0, EC_FIELD_SIZE);
-        Ok(AttestationMaterial {
-            certificate,
-            private_key: *private_key,
-        })
-    }
-}
-
 #[derive(Debug, PartialEq, Eq)]
 pub struct VendorConfigureParameters {
     pub lockdown: bool,
-    pub attestation_material: Option<AttestationMaterial>,
+    pub attestation_material: Option<Attestation>,
 }
 
 impl TryFrom<cbor::Value> for VendorConfigureParameters {
@@ -227,8 +191,14 @@ impl TryFrom<cbor::Value> for VendorConfigureParameters {
         }
         let lockdown = lockdown.map_or(Ok(false), extract_bool)?;
         let attestation_material = attestation_material
-            .map(AttestationMaterial::try_from)
+            .map(Attestation::try_from)
             .transpose()?;
+        // In this implementation, we expect the plain private key bytes.
+        if let Some(attestation) = &attestation_material {
+            if attestation.wrapped_private_key.len() != EC_FIELD_SIZE {
+                return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
+            }
+        }
         Ok(VendorConfigureParameters {
             lockdown,
             attestation_material,
@@ -398,9 +368,9 @@ mod test {
             VendorConfigureParameters::try_from(cbor_value),
             Ok(VendorConfigureParameters {
                 lockdown: false,
-                attestation_material: Some(AttestationMaterial {
+                attestation_material: Some(Attestation {
+                    wrapped_private_key: dummy_pkey.to_vec(),
                     certificate: dummy_cert.to_vec(),
-                    private_key: dummy_pkey
                 }),
             })
         );
@@ -496,15 +466,15 @@ mod test {
         );
 
         // Inject dummy values
-        let dummy_key = [0x41u8; EC_FIELD_SIZE];
-        let dummy_cert = [0xddu8; 20];
+        let dummy_key = vec![0x41u8; EC_FIELD_SIZE];
+        let dummy_cert = vec![0xddu8; 20];
         let response = process_vendor_configure(
             &mut env,
             VendorConfigureParameters {
                 lockdown: false,
-                attestation_material: Some(AttestationMaterial {
-                    certificate: dummy_cert.to_vec(),
-                    private_key: dummy_key,
+                attestation_material: Some(Attestation {
+                    wrapped_private_key: dummy_key.clone(),
+                    certificate: dummy_cert.clone(),
                 }),
             },
             DUMMY_CHANNEL,
@@ -519,20 +489,20 @@ mod test {
         assert_eq!(
             env.persist().get_attestation(AttestationId::Batch),
             Ok(Some(Attestation {
-                private_key: Secret::from_exposed_secret(dummy_key),
-                certificate: dummy_cert.to_vec(),
+                wrapped_private_key: dummy_key.clone(),
+                certificate: dummy_cert.clone(),
             }))
         );
 
         // Try to inject other dummy values and check that initial values are retained.
-        let other_dummy_key = [0x44u8; EC_FIELD_SIZE];
+        let other_dummy_key = vec![0x44u8; EC_FIELD_SIZE];
         let response = process_vendor_configure(
             &mut env,
             VendorConfigureParameters {
                 lockdown: false,
-                attestation_material: Some(AttestationMaterial {
-                    certificate: dummy_cert.to_vec(),
-                    private_key: other_dummy_key,
+                attestation_material: Some(Attestation {
+                    wrapped_private_key: other_dummy_key,
+                    certificate: dummy_cert.clone(),
                 }),
             },
             DUMMY_CHANNEL,
@@ -547,8 +517,8 @@ mod test {
         assert_eq!(
             env.persist().get_attestation(AttestationId::Batch),
             Ok(Some(Attestation {
-                private_key: Secret::from_exposed_secret(dummy_key),
-                certificate: dummy_cert.to_vec(),
+                wrapped_private_key: dummy_key,
+                certificate: dummy_cert,
             }))
         );
 


### PR DESCRIPTION
This change is backwards incompatible. If you flash this firmware onto an OpenSK with existing registrations, they will not work. This includes all of resident keys, server-side keys and CTAP1 keys.

Before, we had a `key_wrap` function in `KeyStore` that, by default, uses a symmetric key to encrypt ECDSA private keys for storage.

However, hardware cryptography users may not want to expose the private key to OpenSK at all. Therefore, the ECDSA API has to change to not assume the existance of `to_slice`, but merely a function to export and re-import it, where we receive a wrapping of unknown length.

We also remove `wrap_key` in `KeyStore`, since this was the imperfect in-library solution for the problem. Since the symmetric `wrap_key` was stored in plaintext on flash, it didn't give the same security guarantees as hardware can. Instead, if you want to secure plain text storage of private key material, you have to implement your own measure.

This does not affect the security of private keys exported through any CTAP API. This is only about local attackers with physical access to the device.