### PR TITLE
Makes RustCrypto dependencies optional

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           toolchain: nightly
           command: test
-          args: --manifest-path libraries/opensk/Cargo.toml --features "std,with_ctap1,vendor_hid,ed25519" --no-fail-fast
+          args: --manifest-path libraries/opensk/Cargo.toml --features "std,with_ctap1,vendor_hid,software_crypto_ed25519" --no-fail-fast
         env:
           RUSTFLAGS: "-Cinstrument-coverage"
           LLVM_PROFILE_FILE: "opensk-%p-%m.profraw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ libtock_alarm = { path = "third_party/libtock-rs/apis/alarm" }
 libtock_console = { path = "third_party/libtock-rs/apis/console" }
 libtock_leds = { path = "third_party/libtock-rs/apis/leds" }
 lang_items = { path = "third_party/lang-items" }
-opensk = { path = "libraries/opensk", default-features = false }
 sk-cbor = { path = "libraries/cbor" }
 persistent_store = { path = "libraries/persistent_store" }
 libtock_unittest = { path = "third_party/libtock-rs/unittest", optional = true }
@@ -36,6 +35,11 @@ version = "0.13.0"
 default-features = false
 features = ["ecdsa"]
 
+[dependencies.opensk]
+path = "libraries/opensk"
+default-features = false
+features = ["software_crypto"]
+
 [features]
 config_command = ["opensk/config_command"]
 debug_allocations = ["lang_items/debug_allocations"]
@@ -46,7 +50,7 @@ verbose = ["debug_ctap", "libtock_drivers/verbose_usb"]
 with_ctap1 = ["opensk/with_ctap1"]
 with_nfc = ["libtock_drivers/with_nfc"]
 vendor_hid = ["opensk/vendor_hid"]
-ed25519 = ["opensk/ed25519"]
+ed25519 = ["opensk/software_crypto_ed25519"]
 fingerprint = ["opensk/fingerprint"]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ features = ["ecdsa"]
 [dependencies.opensk]
 path = "libraries/opensk"
 default-features = false
-features = ["software_crypto"]
+features = ["persistent_store", "software_crypto"]
 
 [features]
 config_command = ["opensk/config_command"]

--- a/libraries/opensk/Cargo.toml
+++ b/libraries/opensk/Cargo.toml
@@ -19,29 +19,32 @@ arrayref = "0.3.6"
 subtle = { version = "2.2", default-features = false, features = ["nightly"] }
 arbitrary = { version = "0.4.7", features = ["derive"], optional = true }
 ed25519-compact = { version = "1", default-features = false, optional = true }
-rand_core = "0.6.4"
+rand_core = { version = "0.6.4", optional = true }
 rand = { version = "0.8.5", default-features = false, optional = true }
-sha2 = { version = "0.10.6", default-features = false }
-hmac = { version = "0.12.1", default-features = false }
-hkdf = { version = "0.12.3", default-features = false }
-aes = { version = "0.8.2", default-features = false }
-cbc = { version = "0.1.2", default-features = false }
+sha2 = { version = "0.10.6", default-features = false, optional = true }
+hmac = { version = "0.12.1", default-features = false, optional = true }
+hkdf = { version = "0.12.3", default-features = false, optional = true }
+aes = { version = "0.8.2", default-features = false, optional = true }
+cbc = { version = "0.1.2", default-features = false, optional = true }
 zeroize = { version = "1.5.7", features = ["derive"] }
 
 [dependencies.p256]
 version = "0.13.0"
 default-features = false
 features = ["alloc", "ecdh", "ecdsa"]
+optional = true
 
 [features]
 default = ["config_command", "with_ctap1"]
 config_command = []
 debug_ctap = []
-std = ["persistent_store/std", "rand/std_rng", "config_command"]
+std = ["persistent_store/std", "rand/std_rng", "config_command", "software_crypto"]
 with_ctap1 = []
 vendor_hid = []
 fuzz = ["arbitrary", "std"]
-ed25519 = ["ed25519-compact"]
+software_crypto = ["rand_core", "rand", "sha2", "hmac", "hkdf", "aes", "cbc", "p256"]
+ed25519 = []
+software_crypto_ed25519 = ["software_crypto", "ed25519", "ed25519-compact"]
 fingerprint = []
 
 [dev-dependencies]

--- a/libraries/opensk/Cargo.toml
+++ b/libraries/opensk/Cargo.toml
@@ -13,13 +13,13 @@ rust-version = "1.66"
 
 [dependencies]
 sk-cbor = { path = "../cbor" }
-persistent_store = { path = "../persistent_store" }
+persistent_store = { path = "../persistent_store", optional = true }
 byteorder = { version = "1", default-features = false }
 arrayref = "0.3.6"
 subtle = { version = "2.2", default-features = false, features = ["nightly"] }
 arbitrary = { version = "0.4.7", features = ["derive"], optional = true }
 ed25519-compact = { version = "1", default-features = false, optional = true }
-rand_core = { version = "0.6.4", optional = true }
+rand_core = "0.6.4"
 rand = { version = "0.8.5", default-features = false, optional = true }
 sha2 = { version = "0.10.6", default-features = false, optional = true }
 hmac = { version = "0.12.1", default-features = false, optional = true }
@@ -38,11 +38,11 @@ optional = true
 default = ["config_command", "with_ctap1"]
 config_command = []
 debug_ctap = []
-std = ["persistent_store/std", "rand/std_rng", "config_command", "software_crypto"]
+std = ["persistent_store/std", "rand?/std_rng", "config_command", "software_crypto"]
 with_ctap1 = []
 vendor_hid = []
 fuzz = ["arbitrary", "std"]
-software_crypto = ["rand_core", "rand", "sha2", "hmac", "hkdf", "aes", "cbc", "p256"]
+software_crypto = ["rand", "sha2", "hmac", "hkdf", "aes", "cbc", "p256"]
 ed25519 = []
 software_crypto_ed25519 = ["software_crypto", "ed25519", "ed25519-compact"]
 fingerprint = []

--- a/libraries/opensk/src/api/crypto/mod.rs
+++ b/libraries/opensk/src/api/crypto/mod.rs
@@ -15,7 +15,9 @@
 pub mod aes256;
 pub mod ec_signing;
 pub mod ecdh;
+#[cfg(feature = "software_crypto")]
 pub mod rust_crypto;
+#[cfg(feature = "software_crypto")]
 pub use rust_crypto as software_crypto;
 pub mod hkdf256;
 pub mod hmac256;

--- a/libraries/opensk/src/ctap/status_code.rs
+++ b/libraries/opensk/src/ctap/status_code.rs
@@ -109,6 +109,7 @@ impl From<Ctap2StatusCode> for key_store::Error {
     }
 }
 
+#[cfg(feature = "persistent_store")]
 impl From<persistent_store::StoreError> for Ctap2StatusCode {
     fn from(error: persistent_store::StoreError) -> Ctap2StatusCode {
         use persistent_store::StoreError;

--- a/run_desktop_tests.sh
+++ b/run_desktop_tests.sh
@@ -20,6 +20,8 @@ set -ex
 MOST_FEATURES=config_command,debug_allocations,debug_ctap,panic_console,verbose,with_ctap1,vendor_hid,ed25519,fingerprint
 
 echo "Checking that OpenSK builds properly..."
+cargo check --release --manifest-path libraries/opensk/Cargo.toml
+cargo check --release --target=thumbv7em-none-eabi --manifest-path libraries/opensk/Cargo.toml
 cargo check --release --target=thumbv7em-none-eabi
 cargo check --release --target=thumbv7em-none-eabi --features config_command
 cargo check --release --target=thumbv7em-none-eabi --features debug_allocations
@@ -73,7 +75,7 @@ cargo build --release --target=thumbv7em-none-eabi --features config_command,wit
 
 echo "Running OpenSK library unit tests..."
 cd libraries/opensk
-cargo test --features std
+cargo test --no-default-features --features std
 cargo test --features std,config_command,with_ctap1
 cargo test --all-features
 cd ../..


### PR DESCRIPTION
The new `software_crypto` feature allows us to only turn on RustCrypto when we need it. There is a special feature for ed25519 now so that its dependency only needs to be used when a user wants software cryptography AND this particular algorithm.
