### PR TITLE
Changes the Env API to late choice of template ID

### DIFF
--- a/libraries/opensk/src/api/fingerprint.rs
+++ b/libraries/opensk/src/api/fingerprint.rs
@@ -72,10 +72,6 @@ pub trait Fingerprint {
     ) -> CtapResult<(Ctap2EnrollFeedback, usize, Option<Vec<u8>>)>;
 
     /// Cancel a fingerprint enrollment.
-    ///
-    /// Returns the newly assigned hardware template ID. This is not to be
-    /// confused with FIDO's template ID that the CTAP command returns when we
-    /// being enrollment.
     fn cancel_enrollment(&mut self) -> CtapResult<()>;
 
     /// Delete the fingerprint matching the given template ID.

--- a/libraries/opensk/src/api/fingerprint.rs
+++ b/libraries/opensk/src/api/fingerprint.rs
@@ -45,9 +45,7 @@ impl From<Ctap2EnrollFeedback> for cbor::Value {
 
 pub trait Fingerprint {
     /// Starts the fingerprint enrollment process.
-    ///
-    /// Returns the newly assigned template ID.
-    fn prepare_enrollment(&mut self) -> CtapResult<Vec<u8>>;
+    fn prepare_enrollment(&mut self) -> CtapResult<()>;
 
     /// Captures a fingerprint image.
     ///
@@ -56,16 +54,28 @@ pub trait Fingerprint {
     /// `prepare_enrollment` must be called first.
     /// A returned `Ctap2StatusCode` indicates an unexpected failure processing
     /// the command.
-    /// The `Ctap2EnrollFeedback` contains expected errors from the fingerprint
-    /// capture process.
-    /// Also returns the expected number of remaining samples.
+    ///
+    /// This function returns:
+    /// - The `Ctap2EnrollFeedback` contains expected errors from the
+    /// fingerprint capture process.
+    /// - The expected number of remaining samples.
+    /// If the sensor finished template creation, return a hardware ID for this
+    /// template. This ID is different from the FIDO template ID, but they are
+    /// mapped to each other in OpenSK. This should happen exactly when the
+    /// returned number of `remainingSamples` is 0.
+    ///
+    /// There is always only one fingerprint enrollment in progress, and the
+    /// capture implicitly refers to that.
     fn capture_sample(
         &mut self,
-        template_id: &[u8],
         timeout_ms: Option<usize>,
-    ) -> CtapResult<(Ctap2EnrollFeedback, usize)>;
+    ) -> CtapResult<(Ctap2EnrollFeedback, usize, Option<Vec<u8>>)>;
 
     /// Cancel a fingerprint enrollment.
+    ///
+    /// Returns the newly assigned hardware template ID. This is not to be
+    /// confused with FIDO's template ID that the CTAP command returns when we
+    /// being enrollment.
     fn cancel_enrollment(&mut self) -> CtapResult<()>;
 
     /// Delete the fingerprint matching the given template ID.

--- a/libraries/opensk/src/ctap/client_pin.rs
+++ b/libraries/opensk/src/ctap/client_pin.rs
@@ -700,8 +700,6 @@ mod test {
     use super::super::pin_protocol::authenticate_pin_uv_auth_token;
     use super::*;
     use crate::api::crypto::HASH_SIZE;
-    #[cfg(feature = "fingerprint")]
-    use crate::api::fingerprint::Fingerprint;
     use crate::env::test::TestEnv;
     use crate::env::EcdhSk;
     use alloc::vec;
@@ -1181,8 +1179,7 @@ mod test {
             .unwrap();
         let mut env = TestEnv::default();
         set_standard_pin(&mut env);
-        let template_id = env.fingerprint().prepare_enrollment().unwrap();
-        let _ = env.fingerprint().capture_sample(&template_id, Some(30_000));
+        assert!(env.create_fingerprint().is_ok());
 
         let response = client_pin
             .process_command(&mut env, params.clone(), DUMMY_CHANNEL)

--- a/libraries/opensk/src/ctap/fingerprint.rs
+++ b/libraries/opensk/src/ctap/fingerprint.rs
@@ -23,6 +23,8 @@ use super::{send_packets, storage, Channel, CtapHid, KeepaliveStatus};
 use crate::api::customization::Customization;
 use crate::api::fingerprint::{Fingerprint, FingerprintCheckError};
 use crate::api::persist::Persist;
+use crate::api::rng::Rng;
+use crate::ctap::cbor_write;
 use crate::env::Env;
 use crate::Transport;
 use alloc::string::String;
@@ -38,6 +40,63 @@ const MODALITY: u64 = 1;
 const UV_TIMEOUT_MS: usize = 30000;
 /// Wait time for a fingerprint sensor response per iteration.
 const FINGERPRINT_TIMEOUT_MS: usize = 500;
+
+/// Captures all generated template IDs in the enrollment process.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct EnrollmentStatus {
+    temporary_id: Option<Vec<u8>>,
+    hardware_id: Option<Vec<u8>>,
+}
+
+impl EnrollmentStatus {
+    /// Resets the enrollment status.
+    pub fn clear(&mut self) {
+        self.temporary_id = None;
+        self.hardware_id = None;
+    }
+
+    /// Returns the fingerprint sensor's template ID choice.
+    pub fn internal_id(&self) -> Option<Vec<u8>> {
+        self.hardware_id.clone()
+    }
+
+    /// Returns the preferred choice for the template ID returned to CTAP.
+    pub fn external_id(&self) -> Option<Vec<u8>> {
+        self.temporary_id.clone().or(self.hardware_id.clone())
+    }
+
+    /// Checks whether the incoming template ID form CTAP is plausible.
+    pub fn check_template_id(&self, template_id: &[u8]) -> bool {
+        if let Some(existing_id) = &self.temporary_id {
+            existing_id == template_id
+        } else if let Some(existing_id) = &self.hardware_id {
+            existing_id == template_id
+        } else {
+            false
+        }
+    }
+
+    /// Sets a temporary ID if none exist yet, or returns an error.
+    pub fn insert_temporary_id(&mut self, template_id: &[u8]) -> CtapResult<()> {
+        if self.temporary_id.is_some() || self.hardware_id.is_some() {
+            return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
+        }
+        self.temporary_id = Some(template_id.to_vec());
+        Ok(())
+    }
+
+    /// Sets a hardware ID, if consistent with the status so far.
+    pub fn insert_hardware_id(&mut self, template_id: &[u8]) -> CtapResult<()> {
+        if let Some(existing_id) = &self.hardware_id {
+            if existing_id != template_id {
+                return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
+            }
+        } else {
+            self.hardware_id = Some(template_id.to_vec());
+        }
+        Ok(())
+    }
+}
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct TemplateInfo {
@@ -145,16 +204,25 @@ fn check_fingerprint_loop<E: Env>(
     Err(Ctap2StatusCode::CTAP2_ERR_USER_ACTION_TIMEOUT)
 }
 
+/// Logic for the enrollBegin subcommand.
 fn enroll_begin<E: Env>(
     env: &mut E,
     sub_command_params: Option<BioEnrollmentSubCommandParams>,
+    enrollment_status: &mut EnrollmentStatus,
 ) -> CtapResult<ResponseData> {
-    let template_id = env.fingerprint().prepare_enrollment()?;
+    enrollment_status.clear();
+    env.fingerprint().prepare_enrollment()?;
     let timeout_ms = sub_command_params.and_then(|p| p.timeout_milliseconds);
-    let (sample_status, remaining_samples) =
-        env.fingerprint().capture_sample(&template_id, timeout_ms)?;
+    let (sample_status, remaining_samples, hardware_id) =
+        env.fingerprint().capture_sample(timeout_ms)?;
+    // We need to remember if this is a fake ID or hardware ID to overwrite it later.
+    if let Some(template_id) = hardware_id {
+        enrollment_status.insert_hardware_id(&template_id)?;
+    } else {
+        enrollment_status.insert_temporary_id(&env.rng().gen_uniform_u8x32())?;
+    }
     let response = AuthenticatorBioEnrollmentResponse {
-        template_id: Some(template_id),
+        template_id: enrollment_status.external_id(),
         last_enroll_sample_status: Some(sample_status),
         remaining_samples: Some(remaining_samples as u64),
         ..Default::default()
@@ -162,16 +230,30 @@ fn enroll_begin<E: Env>(
     Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
 }
 
+/// Logic for the enrollCaptureNextSample subcommand.
 fn enroll_capture_next_sample<E: Env>(
     env: &mut E,
     sub_command_params: BioEnrollmentSubCommandParams,
+    enrollment_status: &mut EnrollmentStatus,
 ) -> CtapResult<ResponseData> {
-    let template_id = ok_or_missing(sub_command_params.template_id)?;
+    let external_id = ok_or_missing(sub_command_params.template_id)?;
+    if !enrollment_status.check_template_id(&external_id) {
+        // CTAP does not specify what to do in this case.
+        return Err(Ctap2StatusCode::CTAP1_ERR_INVALID_PARAMETER);
+    }
     let timeout_ms = sub_command_params.timeout_milliseconds;
-    let (sample_status, remaining_samples) =
-        env.fingerprint().capture_sample(&template_id, timeout_ms)?;
+    let (sample_status, remaining_samples, hardware_id) =
+        env.fingerprint().capture_sample(timeout_ms)?;
+    if let Some(template_id) = hardware_id {
+        enrollment_status.insert_hardware_id(&template_id)?;
+    }
     if remaining_samples == 0 {
-        env.persist().store_template_id(template_id)?;
+        if let Some(template_id) = enrollment_status.internal_id() {
+            env.persist().store_template_id(template_id)?;
+        } else {
+            return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
+        }
+        enrollment_status.clear();
     }
     let response = AuthenticatorBioEnrollmentResponse {
         last_enroll_sample_status: Some(sample_status),
@@ -181,11 +263,17 @@ fn enroll_capture_next_sample<E: Env>(
     Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
 }
 
-fn cancel_current_enrollment<E: Env>(env: &mut E) -> CtapResult<ResponseData> {
+/// Logic for the cancelCurrentEnrollment subcommand.
+fn cancel_current_enrollment<E: Env>(
+    env: &mut E,
+    enrollment_status: &mut EnrollmentStatus,
+) -> CtapResult<ResponseData> {
+    enrollment_status.clear();
     env.fingerprint().cancel_enrollment()?;
     Ok(ResponseData::AuthenticatorBioEnrollment(None))
 }
 
+/// Logic for the enumerateEnrollments subcommand.
 fn enumerate_enrollments<E: Env>(env: &mut E) -> CtapResult<ResponseData> {
     let template_infos = env.persist().template_infos()?;
     if template_infos.is_empty() {
@@ -198,6 +286,7 @@ fn enumerate_enrollments<E: Env>(env: &mut E) -> CtapResult<ResponseData> {
     Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
 }
 
+/// Logic for the setFriendlyName subcommand.
 fn set_friendly_name<E: Env>(
     env: &mut E,
     sub_command_params: BioEnrollmentSubCommandParams,
@@ -212,6 +301,7 @@ fn set_friendly_name<E: Env>(
     Ok(ResponseData::AuthenticatorBioEnrollment(None))
 }
 
+/// Logic for the removeEnrollment subcommand.
 fn remove_enrollment<E: Env>(
     env: &mut E,
     sub_command_params: BioEnrollmentSubCommandParams,
@@ -223,6 +313,7 @@ fn remove_enrollment<E: Env>(
     Ok(ResponseData::AuthenticatorBioEnrollment(None))
 }
 
+/// Logic for the getFingerprintSensorInfo subcommand.
 fn get_fingerprint_sensor_info<E: Env>(env: &mut E) -> CtapResult<ResponseData> {
     let response = AuthenticatorBioEnrollmentResponse {
         modality: Some(MODALITY),
@@ -236,10 +327,12 @@ fn get_fingerprint_sensor_info<E: Env>(env: &mut E) -> CtapResult<ResponseData> 
     Ok(ResponseData::AuthenticatorBioEnrollment(Some(response)))
 }
 
+/// Handles the authenticatorBioEnrollment command.
 pub fn process_bio_enrollment<E: Env>(
     env: &mut E,
     client_pin: &mut ClientPin<E>,
     params: AuthenticatorBioEnrollmentParameters,
+    enrollment_status: &mut EnrollmentStatus,
 ) -> CtapResult<ResponseData> {
     // Enforcing modaility is not explicitly mentioned in the specification.
     // https://github.com/fido-alliance/fido-2-specs/issues/1673
@@ -253,7 +346,7 @@ pub fn process_bio_enrollment<E: Env>(
     // Some subcommands don't need parameters or authentication.
     match params.sub_command {
         Some(BioEnrollmentSubCommand::CancelCurrentEnrollment) => {
-            return cancel_current_enrollment(env);
+            return cancel_current_enrollment(env, enrollment_status);
         }
         Some(BioEnrollmentSubCommand::GetFingerprintSensorInfo) => {
             return get_fingerprint_sensor_info(env);
@@ -279,7 +372,7 @@ pub fn process_bio_enrollment<E: Env>(
         .ok_or(Ctap2StatusCode::CTAP2_ERR_MISSING_PARAMETER)?;
     let mut command_data = vec![MODALITY as u8, sub_command as u8];
     if let Some(sub_command_params) = params.sub_command_params.clone() {
-        super::cbor_write(sub_command_params.into(), &mut command_data)?;
+        cbor_write(sub_command_params.into(), &mut command_data)?;
     }
     client_pin.verify_pin_uv_auth_token(&command_data, &pin_uv_auth_param, pin_uv_auth_protocol)?;
     client_pin.has_permission(PinPermission::BioEnrollment)?;
@@ -287,10 +380,14 @@ pub fn process_bio_enrollment<E: Env>(
     match sub_command {
         // Since the subcommand parameter map can be empty, the whole map might be missing.
         // In CTAP, the parameter is not marked as optional, but Chrome omits it when empty.
-        BioEnrollmentSubCommand::EnrollBegin => enroll_begin(env, params.sub_command_params),
-        BioEnrollmentSubCommand::EnrollCaptureNextSample => {
-            enroll_capture_next_sample(env, ok_or_missing(params.sub_command_params)?)
+        BioEnrollmentSubCommand::EnrollBegin => {
+            enroll_begin(env, params.sub_command_params, enrollment_status)
         }
+        BioEnrollmentSubCommand::EnrollCaptureNextSample => enroll_capture_next_sample(
+            env,
+            ok_or_missing(params.sub_command_params)?,
+            enrollment_status,
+        ),
         BioEnrollmentSubCommand::EnumerateEnrollments => enumerate_enrollments(env),
         BioEnrollmentSubCommand::SetFriendlyName => {
             set_friendly_name(env, ok_or_missing(params.sub_command_params)?)
@@ -314,23 +411,10 @@ mod test {
 
     const DUMMY_CHANNEL: Channel = Channel::MainHid([0x12, 0x34, 0x56, 0x78]);
 
-    fn create_fingerprint(env: &mut TestEnv) -> Vec<u8> {
-        let template_id = env.fingerprint().prepare_enrollment().unwrap();
-        while env
-            .fingerprint()
-            .capture_sample(&template_id, Some(30_000))
-            .unwrap()
-            .1
-            > 0
-        {}
-        assert_eq!(env.persist().store_template_id(template_id.clone()), Ok(()));
-        template_id
-    }
-
     #[test]
     fn test_perform_built_in_uv() {
         let mut env = TestEnv::default();
-        create_fingerprint(&mut env);
+        assert!(env.create_fingerprint().is_ok());
         assert_eq!(perform_built_in_uv(&mut env, DUMMY_CHANNEL, true), Ok(()));
         assert_eq!(perform_built_in_uv(&mut env, DUMMY_CHANNEL, false), Ok(()));
     }
@@ -379,7 +463,7 @@ mod test {
     }
 
     #[test]
-    fn test_enumerate_enrollments() {
+    fn test_modality() {
         let mut env = TestEnv::default();
         let key_agreement_key = EcdhSk::<TestEnv>::random(env.rng());
         let pin_uv_auth_token = [0x55; 32];
@@ -390,39 +474,213 @@ mod test {
             pin_uv_auth_token,
             pin_uv_auth_protocol,
         );
-        env.persist().set_pin(&[0x88; 16], 4).unwrap();
 
-        let sub_command = BioEnrollmentSubCommand::EnumerateEnrollments;
-        let command_data = vec![MODALITY as u8, sub_command as u8];
-        let pin_uv_auth_param =
-            authenticate_pin_uv_auth_token(&pin_uv_auth_token, &command_data, pin_uv_auth_protocol);
         let params = AuthenticatorBioEnrollmentParameters {
-            modality: Some(MODALITY),
-            sub_command: Some(sub_command),
+            modality: None,
+            sub_command: None,
             sub_command_params: None,
-            pin_uv_auth_protocol: Some(pin_uv_auth_protocol),
-            pin_uv_auth_param: Some(pin_uv_auth_param),
-            get_modality: None,
+            pin_uv_auth_protocol: None,
+            pin_uv_auth_param: None,
+            get_modality: Some(true),
         };
-        let response = process_bio_enrollment(&mut env, &mut client_pin, params.clone());
-        assert_eq!(response, Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION));
-
-        let template_id = create_fingerprint(&mut env);
-        let response = process_bio_enrollment(&mut env, &mut client_pin, params);
+        let response = process_bio_enrollment(
+            &mut env,
+            &mut client_pin,
+            params,
+            &mut EnrollmentStatus::default(),
+        );
         match response.unwrap() {
             ResponseData::AuthenticatorBioEnrollment(Some(response)) => {
-                assert!(response.modality.is_none());
-                assert!(response.fingerprint_kind.is_none());
-                assert!(response.max_capture_samples_required_for_enroll.is_none());
-                assert!(response.template_id.is_none());
-                assert!(response.last_enroll_sample_status.is_none());
-                assert!(response.remaining_samples.is_none());
-                assert!(response.max_template_friendly_name.is_none());
-                let template_infos = response.template_infos.unwrap();
-                assert_eq!(template_infos.len(), 1);
-                assert_eq!(template_infos[0].template_id, template_id);
+                let expected = AuthenticatorBioEnrollmentResponse {
+                    modality: Some(MODALITY),
+                    ..Default::default()
+                };
+                assert_eq!(response, expected);
             }
             _ => panic!("Invalid response type"),
         };
+    }
+
+    fn call_subcommand(
+        env: &mut TestEnv,
+        sub_command: BioEnrollmentSubCommand,
+        sub_command_params: Option<BioEnrollmentSubCommandParams>,
+        use_pin_uv: bool,
+    ) -> CtapResult<ResponseData> {
+        let key_agreement_key = EcdhSk::<TestEnv>::random(env.rng());
+        let pin_uv_auth_token = [0x55; 32];
+        let pin_uv_auth_protocol = PinUvAuthProtocol::V2;
+        let mut client_pin = ClientPin::<TestEnv>::new_test(
+            env,
+            key_agreement_key,
+            pin_uv_auth_token,
+            pin_uv_auth_protocol,
+        );
+        let pin_uv_auth_param = if use_pin_uv {
+            env.persist().set_pin(&[0x88; 16], 4).unwrap();
+            let mut command_data = vec![MODALITY as u8, sub_command as u8];
+            if let Some(sub_command_params) = sub_command_params.clone() {
+                cbor_write(sub_command_params.into(), &mut command_data)?;
+            }
+            Some(authenticate_pin_uv_auth_token(
+                &pin_uv_auth_token,
+                &command_data,
+                pin_uv_auth_protocol,
+            ))
+        } else {
+            None
+        };
+
+        let params = AuthenticatorBioEnrollmentParameters {
+            modality: Some(MODALITY),
+            sub_command: Some(sub_command),
+            sub_command_params,
+            pin_uv_auth_protocol: Some(pin_uv_auth_protocol),
+            pin_uv_auth_param,
+            get_modality: None,
+        };
+        process_bio_enrollment(
+            env,
+            &mut client_pin,
+            params,
+            &mut EnrollmentStatus::default(),
+        )
+    }
+
+    #[test]
+    fn test_enumerate_enrollments_no_fingerprint() {
+        let mut env = TestEnv::default();
+        let response = call_subcommand(
+            &mut env,
+            BioEnrollmentSubCommand::EnumerateEnrollments,
+            None,
+            true,
+        );
+        assert_eq!(response, Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION));
+    }
+
+    #[test]
+    fn test_enumerate_enrollments_no_pin() {
+        let mut env = TestEnv::default();
+        env.create_fingerprint().unwrap();
+        let response = call_subcommand(
+            &mut env,
+            BioEnrollmentSubCommand::EnumerateEnrollments,
+            None,
+            false,
+        );
+        assert_eq!(response, Err(Ctap2StatusCode::CTAP2_ERR_PUAT_REQUIRED));
+    }
+
+    #[test]
+    fn test_enumerate_enrollments() {
+        let mut env = TestEnv::default();
+        let template_id = env.create_fingerprint().unwrap();
+        let response = call_subcommand(
+            &mut env,
+            BioEnrollmentSubCommand::EnumerateEnrollments,
+            None,
+            true,
+        );
+        match response.unwrap() {
+            ResponseData::AuthenticatorBioEnrollment(Some(response)) => {
+                let expected = AuthenticatorBioEnrollmentResponse {
+                    template_infos: Some(vec![TemplateInfo {
+                        template_id,
+                        template_friendly_name: None,
+                    }]),
+                    ..Default::default()
+                };
+                assert_eq!(response, expected);
+            }
+            _ => panic!("Invalid response type"),
+        };
+    }
+
+    #[test]
+    fn test_sensor_info() {
+        let mut env = TestEnv::default();
+        let response = call_subcommand(
+            &mut env,
+            BioEnrollmentSubCommand::GetFingerprintSensorInfo,
+            None,
+            false,
+        );
+        match response.unwrap() {
+            ResponseData::AuthenticatorBioEnrollment(Some(response)) => {
+                assert_eq!(response.modality, Some(MODALITY));
+                assert_eq!(
+                    response.fingerprint_kind,
+                    Some(env.fingerprint().fingerprint_kind() as u64)
+                );
+                assert_eq!(
+                    response.max_capture_samples_required_for_enroll,
+                    Some(env.fingerprint().max_capture_samples_required_for_enroll() as u64)
+                );
+                assert!(response.template_id.is_none());
+                assert!(response.last_enroll_sample_status.is_none());
+                assert!(response.remaining_samples.is_none());
+                assert_eq!(
+                    response.max_template_friendly_name,
+                    Some(env.customization().max_template_friendly_name() as u64)
+                );
+                assert!(response.template_infos.is_none());
+            }
+            _ => panic!("Invalid response type"),
+        };
+    }
+
+    #[test]
+    fn test_enrollments_status_clear() {
+        let mut status = EnrollmentStatus::default();
+        status.insert_hardware_id(&[0x00]).unwrap();
+        status.clear();
+        assert_eq!(status, EnrollmentStatus::default());
+    }
+
+    #[test]
+    fn test_enrollments_status_no_temporary() {
+        let mut status = EnrollmentStatus::default();
+        status.insert_hardware_id(&[0x01]).unwrap();
+        assert_eq!(status.internal_id(), Some(vec![0x01]));
+        assert_eq!(status.external_id(), Some(vec![0x01]));
+        assert!(status.check_template_id(&[0x01]));
+        assert!(!status.check_template_id(&[0x02]));
+    }
+
+    #[test]
+    fn test_enrollments_status_temporary_first() {
+        let mut status = EnrollmentStatus::default();
+        status.insert_temporary_id(&[0x02]).unwrap();
+        status.insert_hardware_id(&[0x01]).unwrap();
+        assert_eq!(status.internal_id(), Some(vec![0x01]));
+        assert_eq!(status.external_id(), Some(vec![0x02]));
+        assert!(!status.check_template_id(&[0x01]));
+        assert!(status.check_template_id(&[0x02]));
+    }
+
+    #[test]
+    fn test_enrollments_status_temporary_last() {
+        let mut status = EnrollmentStatus::default();
+        status.insert_hardware_id(&[0x02]).unwrap();
+        assert_eq!(
+            status.insert_temporary_id(&[0x01]),
+            Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)
+        );
+    }
+
+    #[test]
+    fn test_enrollments_status_multiple_hardware() {
+        let mut status = EnrollmentStatus::default();
+        status.insert_hardware_id(&[0x01]).unwrap();
+        assert_eq!(status.insert_hardware_id(&[0x01]), Ok(()));
+        assert_eq!(
+            status.insert_hardware_id(&[0x02]),
+            Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)
+        );
+        assert_eq!(status.internal_id(), Some(vec![0x01]));
+        assert_eq!(status.external_id(), Some(vec![0x01]));
+        assert!(status.check_template_id(&[0x01]));
+        assert!(!status.check_template_id(&[0x02]));
     }
 }

--- a/libraries/opensk/src/ctap/mod.rs
+++ b/libraries/opensk/src/ctap/mod.rs
@@ -53,7 +53,7 @@ use self::data_formats::{
     PublicKeyCredentialType, PublicKeyCredentialUserEntity, SignatureAlgorithm,
 };
 #[cfg(feature = "fingerprint")]
-use self::fingerprint::{perform_built_in_uv, process_bio_enrollment};
+use self::fingerprint::{perform_built_in_uv, process_bio_enrollment, EnrollmentStatus};
 use self::hid::{
     ChannelID, CtapHid, CtapHidCommand, HidPacketIterator, KeepaliveStatus, ProcessedPacket,
 };
@@ -552,6 +552,11 @@ pub struct CtapState<E: Env> {
     pub(crate) u2f_up_state: U2fUserPresenceState<E>,
     // The state initializes to Reset and its timeout, and never goes back to Reset.
     stateful_command_permission: StatefulPermission<E>,
+    // While fingerprint enrollment is in progress, we store its progress here.
+    // Despite being state of a command, by the CTAP standard, BioEnrollment is
+    // not a "stateful command".
+    #[cfg(feature = "fingerprint")]
+    fingerprint_enrollment_status: EnrollmentStatus,
 }
 
 impl<E: Env> CtapState<E> {
@@ -568,6 +573,8 @@ impl<E: Env> CtapState<E> {
             #[cfg(feature = "with_ctap1")]
             u2f_up_state: U2fUserPresenceState::new(),
             stateful_command_permission,
+            #[cfg(feature = "fingerprint")]
+            fingerprint_enrollment_status: EnrollmentStatus::default(),
         }
     }
 
@@ -697,9 +704,12 @@ impl<E: Env> CtapState<E> {
             }
             Command::AuthenticatorReset => self.process_reset(env, channel),
             #[cfg(feature = "fingerprint")]
-            Command::AuthenticatorBioEnrollment(params) => {
-                process_bio_enrollment(env, &mut self.client_pin, params)
-            }
+            Command::AuthenticatorBioEnrollment(params) => process_bio_enrollment(
+                env,
+                &mut self.client_pin,
+                params,
+                &mut self.fingerprint_enrollment_status,
+            ),
             Command::AuthenticatorCredentialManagement(params) => process_credential_management(
                 env,
                 &mut self.stateful_command_permission,

--- a/libraries/opensk/src/env/test/mod.rs
+++ b/libraries/opensk/src/env/test/mod.rs
@@ -24,6 +24,8 @@ use crate::api::key_store;
 use crate::api::persist::{Persist, PersistIter};
 use crate::api::rng::Rng;
 use crate::api::user_presence::{UserPresence, UserPresenceResult, UserPresenceWaitResult};
+#[cfg(feature = "fingerprint")]
+use crate::ctap::status_code::Ctap2StatusCode;
 use crate::ctap::status_code::CtapResult;
 use crate::env::Env;
 use customization::TestCustomization;
@@ -101,6 +103,7 @@ pub struct TestFingerprint {
     // TODO more complete fake
     template_ids: Vec<Vec<u8>>,
     template_counter: usize,
+    progress: Option<usize>,
 }
 
 pub struct TestWrite;
@@ -196,6 +199,22 @@ impl TestEnv {
     pub fn set_boots_after_soft_reset(&mut self, value: bool) {
         self.soft_reset = value;
     }
+
+    #[cfg(feature = "fingerprint")]
+    pub fn create_fingerprint(&mut self) -> CtapResult<Vec<u8>> {
+        self.fingerprint().prepare_enrollment()?;
+        let mut template_id = None;
+        for _ in 0..self.fingerprint().max_capture_samples_required_for_enroll() {
+            let (_, remaining_samples, hardware_id) = self.fingerprint().capture_sample(None)?;
+            template_id = template_id.or(hardware_id);
+            if remaining_samples == 0 {
+                break;
+            }
+        }
+        let template_id = template_id.unwrap();
+        self.persist().store_template_id(template_id.clone())?;
+        Ok(template_id)
+    }
 }
 
 impl TestUserPresence {
@@ -218,22 +237,33 @@ impl UserPresence for TestUserPresence {
 
 #[cfg(feature = "fingerprint")]
 impl Fingerprint for TestFingerprint {
-    fn prepare_enrollment(&mut self) -> CtapResult<Vec<u8>> {
-        self.template_counter += 1;
-        let template_id = Vec::from(&self.template_counter.to_be_bytes());
-        self.template_ids.push(template_id.clone());
-        Ok(template_id)
+    fn prepare_enrollment(&mut self) -> CtapResult<()> {
+        self.progress = Some(0);
+        Ok(())
     }
 
     fn capture_sample(
         &mut self,
-        _template_id: &[u8],
         _timeout_ms: Option<usize>,
-    ) -> CtapResult<(Ctap2EnrollFeedback, usize)> {
-        Ok((Ctap2EnrollFeedback::FpGood, 0))
+    ) -> CtapResult<(Ctap2EnrollFeedback, usize, Option<Vec<u8>>)> {
+        if let Some(progress) = self.progress {
+            if progress == 0 {
+                self.progress = Some(1);
+                Ok((Ctap2EnrollFeedback::FpPoorQuality, 1, None))
+            } else {
+                self.template_counter += 1;
+                let template_id = Vec::from(&self.template_counter.to_be_bytes());
+                self.template_ids.push(template_id.clone());
+                self.progress = None;
+                Ok((Ctap2EnrollFeedback::FpGood, 0, Some(template_id)))
+            }
+        } else {
+            Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)
+        }
     }
 
     fn cancel_enrollment(&mut self) -> CtapResult<()> {
+        self.progress = None;
         Ok(())
     }
 
@@ -261,7 +291,7 @@ impl Fingerprint for TestFingerprint {
     }
 
     fn max_capture_samples_required_for_enroll(&self) -> usize {
-        1
+        2
     }
 }
 

--- a/src/env/tock/mod.rs
+++ b/src/env/tock/mod.rs
@@ -347,17 +347,16 @@ where
     S: Syscalls,
     C: platform::subscribe::Config + platform::allow_ro::Config,
 {
-    // This is a placeholder implementation, WIP.
-    fn prepare_enrollment(&mut self) -> CtapResult<Vec<u8>> {
-        Ok(Vec::new())
+    // This is a placeholder implementation to make the project compile.
+    fn prepare_enrollment(&mut self) -> CtapResult<()> {
+        Ok(())
     }
 
     fn capture_sample(
         &mut self,
-        _template_id: &[u8],
         _timeout_ms: Option<usize>,
-    ) -> CtapResult<(Ctap2EnrollFeedback, usize)> {
-        Ok((Ctap2EnrollFeedback::FpGood, 0))
+    ) -> CtapResult<(Ctap2EnrollFeedback, usize, Option<Vec<u8>>)> {
+        Ok((Ctap2EnrollFeedback::FpGood, 0, None))
     }
 
     fn cancel_enrollment(&mut self) -> CtapResult<()> {


### PR DESCRIPTION
Before, a fingerprint sensor had to choose a template ID at the start of the enrollment process. Not all sensors assign one immediately, and it conceptually makes more sense to expect an ID after a successful enrollment.

We introduce a state that tracks whether

- The fingerprint sensor chose a template ID already,
- and we sent a random template ID over CTAP until then.

We also add tests for the introduced state. Since the command is not considered stateful by CTAP, it means that enrollment can interleave with other CTAP commands. And the state is not part of `StatefulCommand`.