### PR TITLE
Fixes clippy warnings from nightly

### DIFF
--- a/libraries/cbor/src/reader.rs
+++ b/libraries/cbor/src/reader.rs
@@ -71,7 +71,7 @@ impl<'a> Reader<'a> {
         &mut self,
         remaining_depth: Option<i8>,
     ) -> Result<Value, DecoderError> {
-        if remaining_depth.map_or(false, |d| d < 0) {
+        if remaining_depth.is_some_and(|d| d < 0) {
             return Err(DecoderError::TooMuchNesting);
         }
 

--- a/libraries/cbor/src/writer.rs
+++ b/libraries/cbor/src/writer.rs
@@ -57,7 +57,7 @@ impl<'a> Writer<'a> {
         value: Value,
         remaining_depth: Option<i8>,
     ) -> Result<(), EncoderError> {
-        if remaining_depth.map_or(false, |d| d < 0) {
+        if remaining_depth.is_some_and(|d| d < 0) {
             return Err(EncoderError::TooMuchNesting);
         }
         let type_label = value.0.type_label();

--- a/libraries/opensk/Cargo.toml
+++ b/libraries/opensk/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 license = "Apache-2.0"
 edition = "2018"
-rust-version = "1.66"
+rust-version = "1.80"
 
 [dependencies]
 sk-cbor = { path = "../cbor" }

--- a/libraries/opensk/src/api/crypto/rust_crypto.rs
+++ b/libraries/opensk/src/api/crypto/rust_crypto.rs
@@ -44,7 +44,7 @@ use std::sync::{Mutex, MutexGuard};
 static BUSY: Mutex<()> = Mutex::new(());
 #[cfg(test)]
 thread_local! {
-    static BUSY_GUARD: RefCell<Option<MutexGuard<'static, ()>>> = RefCell::new(None);
+    static BUSY_GUARD: RefCell<Option<MutexGuard<'static, ()>>> = const { RefCell::new(None) };
 }
 
 pub struct SoftwareCrypto;

--- a/libraries/opensk/src/api/fingerprint.rs
+++ b/libraries/opensk/src/api/fingerprint.rs
@@ -57,10 +57,14 @@ pub trait Fingerprint {
     ///
     /// This function returns:
     /// - The `Ctap2EnrollFeedback` contains expected errors from the
-    /// fingerprint capture process.
+    ///   fingerprint capture process.
     /// - The expected number of remaining samples.
-    /// If the sensor finished template creation, return a hardware ID for this
-    /// template. This ID is different from the FIDO template ID, but they are
+    /// - Eventually, a hardware ID for this template.
+    ///
+    /// The template ID must be returned until remaining samples is 0.
+    /// When or how often it is returned is up to the implementation, but it
+    /// needs to be consistent if returned more than once.
+    /// This ID is different from the FIDO template ID, but they are
     /// mapped to each other in OpenSK. This should happen exactly when the
     /// returned number of `remainingSamples` is 0.
     ///

--- a/libraries/opensk/src/ctap/client_pin.rs
+++ b/libraries/opensk/src/ctap/client_pin.rs
@@ -567,6 +567,7 @@ impl<E: Env> ClientPin<E> {
     /// - verified with the shared secret and salt_auth,
     /// - decrypted with the shared secret,
     /// - HMAC'ed with cred_random.
+    ///
     /// The length of the output matches salt_enc and has to be 1 or 2 blocks of
     /// 32 byte.
     pub fn process_hmac_secret(

--- a/libraries/opensk/src/ctap/ctap1.rs
+++ b/libraries/opensk/src/ctap/ctap1.rs
@@ -78,11 +78,7 @@ impl TryFrom<&[u8]> for U2fCommand {
     type Error = Ctap1StatusCode;
 
     fn try_from(message: &[u8]) -> Result<Self, Ctap1StatusCode> {
-        let apdu: Apdu = match Apdu::try_from(message) {
-            Ok(apdu) => apdu,
-            Err(apdu_status_code) => return Err(apdu_status_code),
-        };
-
+        let apdu = Apdu::try_from(message)?;
         let lc = apdu.lc as usize;
 
         // ISO7816 APDU Header format. Each cell is 1 byte. Note that the CTAP flavor always

--- a/libraries/opensk/src/ctap/data_formats.rs
+++ b/libraries/opensk/src/ctap/data_formats.rs
@@ -1260,18 +1260,12 @@ mod test {
 
     #[test]
     fn test_extract_unsigned_limits() {
+        assert_eq!(extract_unsigned(cbor_unsigned!(u64::MAX)), Ok(u64::MAX));
         assert_eq!(
-            extract_unsigned(cbor_unsigned!(std::u64::MAX)),
-            Ok(std::u64::MAX)
+            extract_unsigned(cbor_unsigned!((i64::MAX as u64) + 1)),
+            Ok((i64::MAX as u64) + 1)
         );
-        assert_eq!(
-            extract_unsigned(cbor_unsigned!((std::i64::MAX as u64) + 1)),
-            Ok((std::i64::MAX as u64) + 1)
-        );
-        assert_eq!(
-            extract_unsigned(cbor_int!(std::i64::MAX)),
-            Ok(std::i64::MAX as u64)
-        );
+        assert_eq!(extract_unsigned(cbor_int!(i64::MAX)), Ok(i64::MAX as u64));
         assert_eq!(extract_unsigned(cbor_int!(123)), Ok(123));
         assert_eq!(extract_unsigned(cbor_int!(1)), Ok(1));
         assert_eq!(extract_unsigned(cbor_int!(0)), Ok(0));
@@ -1284,7 +1278,7 @@ mod test {
             Err(CTAP2_ERR_CBOR_UNEXPECTED_TYPE)
         );
         assert_eq!(
-            extract_unsigned(cbor_int!(std::i64::MIN)),
+            extract_unsigned(cbor_int!(i64::MIN)),
             Err(CTAP2_ERR_CBOR_UNEXPECTED_TYPE)
         );
     }
@@ -1318,20 +1312,20 @@ mod test {
     #[test]
     fn test_extract_integer_limits() {
         assert_eq!(
-            extract_integer(cbor_unsigned!(std::u64::MAX)),
+            extract_integer(cbor_unsigned!(u64::MAX)),
             Err(CTAP2_ERR_CBOR_UNEXPECTED_TYPE)
         );
         assert_eq!(
-            extract_integer(cbor_unsigned!((std::i64::MAX as u64) + 1)),
+            extract_integer(cbor_unsigned!((i64::MAX as u64) + 1)),
             Err(CTAP2_ERR_CBOR_UNEXPECTED_TYPE)
         );
-        assert_eq!(extract_integer(cbor_int!(std::i64::MAX)), Ok(std::i64::MAX));
+        assert_eq!(extract_integer(cbor_int!(i64::MAX)), Ok(i64::MAX));
         assert_eq!(extract_integer(cbor_int!(123)), Ok(123));
         assert_eq!(extract_integer(cbor_int!(1)), Ok(1));
         assert_eq!(extract_integer(cbor_int!(0)), Ok(0));
         assert_eq!(extract_integer(cbor_int!(-1)), Ok(-1));
         assert_eq!(extract_integer(cbor_int!(-123)), Ok(-123));
-        assert_eq!(extract_integer(cbor_int!(std::i64::MIN)), Ok(std::i64::MIN));
+        assert_eq!(extract_integer(cbor_int!(i64::MIN)), Ok(i64::MIN));
     }
 
     #[test]

--- a/libraries/opensk/src/ctap/large_blobs.rs
+++ b/libraries/opensk/src/ctap/large_blobs.rs
@@ -478,7 +478,7 @@ mod test {
 
         let large_blobs_params = AuthenticatorLargeBlobsParameters {
             get: None,
-            set: Some(large_blob.to_vec()),
+            set: Some(large_blob),
             offset: 0,
             length: Some(BLOB_LEN),
             pin_uv_auth_param: None,

--- a/libraries/opensk/src/ctap/mod.rs
+++ b/libraries/opensk/src/ctap/mod.rs
@@ -3490,7 +3490,7 @@ mod test {
         // This TestEnv always returns successful user_presence checks.
         let mut env = TestEnv::default();
         let response = check_user_presence(&mut env, DUMMY_CHANNEL);
-        assert!(matches!(response, Ok(_)));
+        assert!(response.is_ok());
     }
 
     #[test]

--- a/run_desktop_tests.sh
+++ b/run_desktop_tests.sh
@@ -61,7 +61,7 @@ cargo clippy --lib --tests --bins --benches --features std,"$MOST_FEATURES" -- -
 # Uncomment when persistent store is fixed:
 # (cd libraries/persistent_store && cargo clippy --features std -- -D warnings)
 
-echo "Checking that fuzz targets..."
+echo "Checking fuzz targets..."
 (cd libraries/opensk && cargo fuzz check)
 (cd libraries/cbor && cargo fuzz check)
 (cd libraries/persistent_store && cargo fuzz check)

--- a/src/env/tock/mod.rs
+++ b/src/env/tock/mod.rs
@@ -483,8 +483,8 @@ pub fn wink_leds<S: Syscalls>(pattern_seed: usize) {
     // * *
     let count = Leds::<S>::count().unwrap() as usize;
     let a = (pattern_seed / 2) % count;
-    let b = ((pattern_seed + 1) / 2) % count;
-    let c = ((pattern_seed + 3) / 2) % count;
+    let b = pattern_seed.div_ceil(2) % count;
+    let c = (pattern_seed.div_ceil(2) + 1) % count;
 
     for l in 0..count {
         // On nRF52840-DK, logically swap LEDs 3 and 4 so that the order of LEDs form a circle.

--- a/src/env/tock/upgrade_helper.rs
+++ b/src/env/tock/upgrade_helper.rs
@@ -32,10 +32,12 @@ pub const METADATA_SIGN_OFFSET: usize = 0x800;
 ///
 /// The metadata is a page starting with:
 /// - 32 B upgrade hash (SHA256)
-/// - 64 B signature,
+/// - 64 B signature
+///
 /// that are not signed over. The second part is included in the signature with
 /// -  8 B version and
 /// -  4 B partition address in little endian encoding
+///
 /// written at METADATA_SIGN_OFFSET.
 ///
 /// Checks signature correctness against the hash, and whether the partition offset matches.


### PR DESCRIPTION
I ran `run_desktop_tests.sh`, but with `+nightly`.
No changes in functionality.