### PR TITLE
Allows more errors in the fingerprint API

### DIFF
--- a/libraries/opensk/src/api/fingerprint.rs
+++ b/libraries/opensk/src/api/fingerprint.rs
@@ -89,7 +89,7 @@ pub trait Fingerprint {
     /// Called before [`check_fingerprint`].
     /// Useful for starting any operation that needs to happen before
     /// potentially repeated fingerprint checks, such as blinking LEDs.
-    fn check_fingerprint_init(&mut self);
+    fn check_fingerprint_init(&mut self) -> CtapResult<()>;
 
     /// Collects a fingerprint from the user and verifies it.
     ///
@@ -100,7 +100,7 @@ pub trait Fingerprint {
     /// Deinitilize hardware after a fingerprint check.
     ///
     /// Called after [`check_fingerprint`] is finished.
-    fn check_fingerprint_complete(&mut self);
+    fn check_fingerprint_complete(&mut self) -> CtapResult<()>;
 
     /// The kind of fingerprint sensor.
     fn fingerprint_kind(&self) -> FingerprintKind;

--- a/libraries/opensk/src/ctap/fingerprint.rs
+++ b/libraries/opensk/src/ctap/fingerprint.rs
@@ -145,9 +145,9 @@ pub fn perform_built_in_uv<E: Env>(
     if storage::uv_retries(env)? == 0 {
         return Err(Ctap2StatusCode::CTAP2_ERR_PIN_BLOCKED);
     }
-    env.fingerprint().check_fingerprint_init();
+    env.fingerprint().check_fingerprint_init()?;
     let result = check_fingerprint_loop(env, channel, internal_retry);
-    env.fingerprint().check_fingerprint_complete();
+    env.fingerprint().check_fingerprint_complete()?;
     result
 }
 

--- a/libraries/opensk/src/env/test/mod.rs
+++ b/libraries/opensk/src/env/test/mod.rs
@@ -275,7 +275,9 @@ impl Fingerprint for TestFingerprint {
         Ok(())
     }
 
-    fn check_fingerprint_init(&mut self) {}
+    fn check_fingerprint_init(&mut self) -> CtapResult<()> {
+        Ok(())
+    }
 
     fn check_fingerprint(&mut self, _timeout_ms: usize) -> Result<(), FingerprintCheckError> {
         if self.template_ids.is_empty() {
@@ -284,7 +286,9 @@ impl Fingerprint for TestFingerprint {
         Ok(())
     }
 
-    fn check_fingerprint_complete(&mut self) {}
+    fn check_fingerprint_complete(&mut self) -> CtapResult<()> {
+        Ok(())
+    }
 
     fn fingerprint_kind(&self) -> FingerprintKind {
         FingerprintKind::Touch

--- a/src/env/tock/mod.rs
+++ b/src/env/tock/mod.rs
@@ -367,13 +367,17 @@ where
         Ok(())
     }
 
-    fn check_fingerprint_init(&mut self) {}
+    fn check_fingerprint_init(&mut self) -> CtapResult<()> {
+        Ok(())
+    }
 
     fn check_fingerprint(&mut self, _timeout_ms: usize) -> Result<(), FingerprintCheckError> {
         Ok(())
     }
 
-    fn check_fingerprint_complete(&mut self) {}
+    fn check_fingerprint_complete(&mut self) -> CtapResult<()> {
+        Ok(())
+    }
 
     fn fingerprint_kind(&self) -> FingerprintKind {
         FingerprintKind::Touch


### PR DESCRIPTION
Nothing changes for us, but an actual implementation might need to forward errors when initializing or completing fingerprint checks.