### PR TITLE
Start measuring coverage in fingerprint code

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           toolchain: nightly
           command: test
-          args: --manifest-path libraries/opensk/Cargo.toml --features "std,with_ctap1,vendor_hid,software_crypto_ed25519" --no-fail-fast
+          args: --manifest-path libraries/opensk/Cargo.toml --features "std,with_ctap1,vendor_hid,software_crypto_ed25519,fingerprint" --no-fail-fast
         env:
           RUSTFLAGS: "-Cinstrument-coverage"
           LLVM_PROFILE_FILE: "opensk-%p-%m.profraw"


### PR DESCRIPTION
Since fingerprint code is now usable in the library, we should check for holes in coverage.