### PR TITLE
Fixes the error code for blocked UV

### DIFF
--- a/libraries/opensk/src/ctap/fingerprint.rs
+++ b/libraries/opensk/src/ctap/fingerprint.rs
@@ -345,7 +345,7 @@ pub fn process_bio_enrollment<E: Env>(
     enrollment_status: &mut EnrollmentStatus,
 ) -> CtapResult<ResponseData> {
     // Enforcing modaility is not explicitly mentioned in the specification.
-    // https://github.com/fido-alliance/fido-2-specs/issues/1673
+    // https://github.com/fido-alliance/fido-2-specs/issues/1673 (private)
     // Let's be strict until we know which is correct.
     if params.sub_command.is_some() {
         let modality = ok_or_missing(params.modality)?;

--- a/libraries/opensk/src/ctap/fingerprint.rs
+++ b/libraries/opensk/src/ctap/fingerprint.rs
@@ -138,7 +138,7 @@ pub fn perform_built_in_uv<E: Env>(
     internal_retry: bool,
 ) -> CtapResult<()> {
     if storage::uv_retries(env)? == 0 {
-        return Err(Ctap2StatusCode::CTAP2_ERR_PIN_BLOCKED);
+        return Err(Ctap2StatusCode::CTAP2_ERR_UV_BLOCKED);
     }
     env.fingerprint().check_fingerprint_init()?;
     let result = check_fingerprint_loop(env, channel, internal_retry);
@@ -180,7 +180,7 @@ fn check_fingerprint_loop<E: Env>(
                     FingerprintCheckError::NoMatch | FingerprintCheckError::Other => {
                         storage::decr_uv_retries(env)?;
                         if storage::uv_retries(env)? == 0 {
-                            return Err(Ctap2StatusCode::CTAP2_ERR_PIN_BLOCKED);
+                            return Err(Ctap2StatusCode::CTAP2_ERR_UV_BLOCKED);
                         }
                         retries -= 1;
                         if retries == 0 {
@@ -446,7 +446,7 @@ mod test {
         {
             assert_eq!(
                 perform_built_in_uv(&mut env, DUMMY_CHANNEL, true),
-                Err(Ctap2StatusCode::CTAP2_ERR_PIN_BLOCKED)
+                Err(Ctap2StatusCode::CTAP2_ERR_UV_BLOCKED)
             );
         } else {
             assert_eq!(

--- a/libraries/opensk/src/ctap/mod.rs
+++ b/libraries/opensk/src/ctap/mod.rs
@@ -265,7 +265,7 @@ fn truncate_to_char_boundary(s: &str, mut max: usize) -> &str {
 
 // For MakeCredential and GetAssertion, the specification says:
 // If the uvRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED. See:
-// https://github.com/fido-alliance/fido-2-specs/issues/1672
+// https://github.com/fido-alliance/fido-2-specs/issues/1672 (private)
 #[cfg(feature = "fingerprint")]
 fn map_uv_block_error(result: CtapResult<()>) -> CtapResult<()> {
     result.map_err(|e| match e {
@@ -856,10 +856,6 @@ impl<E: Env> CtapState<E> {
                 if options.uv {
                     #[cfg(not(feature = "fingerprint"))]
                     return Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION);
-                    // The specification says:
-                    // If the uvRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED.
-                    // But I assume this is a typo and should be UV_BLOCKED instead.
-                    // https://github.com/fido-alliance/fido-2-specs/issues/1672
                     #[cfg(feature = "fingerprint")]
                     map_uv_block_error(perform_built_in_uv(env, channel, true))?;
                     #[cfg(feature = "fingerprint")]
@@ -1237,8 +1233,6 @@ impl<E: Env> CtapState<E> {
                 if options.uv {
                     #[cfg(not(feature = "fingerprint"))]
                     return Err(Ctap2StatusCode::CTAP2_ERR_INVALID_OPTION);
-                    // Same error code ambiguity as in MakeCredential.
-                    // https://github.com/fido-alliance/fido-2-specs/issues/1672
                     #[cfg(feature = "fingerprint")]
                     map_uv_block_error(perform_built_in_uv(env, channel, true))?;
                     #[cfg(feature = "fingerprint")]

--- a/libraries/opensk/src/ctap/mod.rs
+++ b/libraries/opensk/src/ctap/mod.rs
@@ -263,6 +263,20 @@ fn truncate_to_char_boundary(s: &str, mut max: usize) -> &str {
     }
 }
 
+// For MakeCredential and GetAssertion, the specification says:
+// If the uvRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED. See:
+// https://github.com/fido-alliance/fido-2-specs/issues/1672
+#[cfg(feature = "fingerprint")]
+fn map_uv_block_error(result: CtapResult<()>) -> CtapResult<()> {
+    result.map_err(|e| {
+        if e == Ctap2StatusCode::CTAP2_ERR_UV_BLOCKED {
+            Ctap2StatusCode::CTAP2_ERR_PIN_BLOCKED
+        } else {
+            e
+        }
+    })
+}
+
 /// Send non-critical packets using fire-and-forget.
 pub fn send_packets<E: Env>(
     env: &mut E,
@@ -850,7 +864,7 @@ impl<E: Env> CtapState<E> {
                     // But I assume this is a typo and should be UV_BLOCKED instead.
                     // https://github.com/fido-alliance/fido-2-specs/issues/1672
                     #[cfg(feature = "fingerprint")]
-                    perform_built_in_uv(env, channel, true)?;
+                    map_uv_block_error(perform_built_in_uv(env, channel, true))?;
                     #[cfg(feature = "fingerprint")]
                     UV_FLAG
                 } else {
@@ -1229,7 +1243,7 @@ impl<E: Env> CtapState<E> {
                     // Same error code ambiguity as in MakeCredential.
                     // https://github.com/fido-alliance/fido-2-specs/issues/1672
                     #[cfg(feature = "fingerprint")]
-                    perform_built_in_uv(env, channel, true)?;
+                    map_uv_block_error(perform_built_in_uv(env, channel, true))?;
                     #[cfg(feature = "fingerprint")]
                     UV_FLAG
                 } else {

--- a/libraries/opensk/src/ctap/mod.rs
+++ b/libraries/opensk/src/ctap/mod.rs
@@ -268,12 +268,9 @@ fn truncate_to_char_boundary(s: &str, mut max: usize) -> &str {
 // https://github.com/fido-alliance/fido-2-specs/issues/1672
 #[cfg(feature = "fingerprint")]
 fn map_uv_block_error(result: CtapResult<()>) -> CtapResult<()> {
-    result.map_err(|e| {
-        if e == Ctap2StatusCode::CTAP2_ERR_UV_BLOCKED {
-            Ctap2StatusCode::CTAP2_ERR_PIN_BLOCKED
-        } else {
-            e
-        }
+    result.map_err(|e| match e {
+        Ctap2StatusCode::CTAP2_ERR_UV_BLOCKED => Ctap2StatusCode::CTAP2_ERR_PIN_BLOCKED,
+        other => other,
     })
 }
 


### PR DESCRIPTION
First, with an answer on the specification question, we change the comment on the error code being a potential typo: https://github.com/fido-alliance/fido-2-specs/issues/1672

Also, I realized that the default was wrong before, so now the error code with `*_UV_*` is used for UV operations as intended.