### PR TITLE
Fixes an integer overflow in a helper class

### DIFF
--- a/src/env/tock/storage_helper.rs
+++ b/src/env/tock/storage_helper.rs
@@ -188,7 +188,7 @@ impl Partition {
         for range in &self.ranges {
             if offset < range.length() {
                 return if range.length() - offset >= length {
-                    Some(range.start() + offset)
+                    range.start().checked_add(offset)
                 } else {
                     None
                 };
@@ -377,5 +377,12 @@ mod tests {
         assert_eq!(&second_range, &all_ranges[1..]);
         let partial_range = partition.ranges_from(0x30000);
         assert_eq!(partial_range[0], ModRange::new(0x30000, 0x30000));
+    }
+
+    #[test]
+    fn partition_find_address_overflow() {
+        let mut partition = Partition::default();
+        partition.append(ModRange::new(usize::MAX - 100, 200));
+        assert_eq!(partition.find_address(150, 1), None);
     }
 }

--- a/src/env/tock/storage_helper.rs
+++ b/src/env/tock/storage_helper.rs
@@ -188,7 +188,7 @@ impl Partition {
         for range in &self.ranges {
             if offset < range.length() {
                 return if range.length() - offset >= length {
-                    range.start().checked_add(offset)
+                    Some(range.start().strict_add(offset))
                 } else {
                     None
                 };
@@ -380,6 +380,7 @@ mod tests {
     }
 
     #[test]
+    #[should_panic]
     fn partition_find_address_overflow() {
         let mut partition = Partition::default();
         partition.append(ModRange::new(usize::MAX - 100, 200));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![feature(strict_overflow_ops)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;


### PR DESCRIPTION
This was not exploitable as a vulnerability as far as I know. All inputs to the function are coming from configs, and are never user inputs.

The new unit test would have panicked without the fix.