### PR TITLE
Fixes setup and paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,8 +670,6 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "wasefire"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfbe54fbf773c9c03e73b1554e76a1ef4f1ba30e05dc6d97480cdf02e5a72cf0"
 dependencies = [
  "bytemuck",
  "wasefire-applet-api",
@@ -684,8 +682,6 @@ dependencies = [
 [[package]]
 name = "wasefire-applet-api"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f05586ec4c4bd997b32dd973bd9fab5ded523ded392967d7c2bdcd6eb04546"
 dependencies = [
  "bytemuck",
  "wasefire-applet-api-macro",
@@ -696,8 +692,6 @@ dependencies = [
 [[package]]
 name = "wasefire-applet-api-desc"
 version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4eabf7c07b26549731d5bb30e061ef4cc1b377ebb7036a71168efb08175985e"
 dependencies = [
  "data-encoding",
  "data-encoding-macro",
@@ -709,8 +703,6 @@ dependencies = [
 [[package]]
 name = "wasefire-applet-api-macro"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70becd38c1a18a9ace5477deebe62c4105ff739b4c5f60d3af6d0b28d8df018e"
 dependencies = [
  "wasefire-applet-api-desc",
 ]
@@ -718,8 +710,6 @@ dependencies = [
 [[package]]
 name = "wasefire-common"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a4aad51188c34722b5e36f1b1058b503f9c86cda9b593c16cee0d26456a900"
 dependencies = [
  "wasefire-error",
  "wasefire-sync",
@@ -728,8 +718,6 @@ dependencies = [
 [[package]]
 name = "wasefire-error"
 version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5798addec7fb9e601994b2e74778b295b430d692ec2ec234899ac9f9b9a16f0a"
 dependencies = [
  "num_enum",
 ]
@@ -737,8 +725,6 @@ dependencies = [
 [[package]]
 name = "wasefire-one-of"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf9167149e9d56bd27c62666289fc12bb2df3d02aa51a7702283c63a9912500"
 
 [[package]]
 name = "wasefire-store"
@@ -749,8 +735,6 @@ checksum = "f49afdab5206771f6d7ad85b556fcd6255004485b704f0f5c084335c5fae3238"
 [[package]]
 name = "wasefire-sync"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "014bb0d34c696e98305c50466e475c9e17b8d6884c02800a387f2198f402cf02"
 dependencies = [
  "portable-atomic",
  "spin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ edition = "2024"
 
 [dependencies]
 portable-atomic-util = { version = "0.2.6", default-features = false, features = ["alloc"] }
-wasefire-common = { version = "0.1.0", optional = true }
+wasefire-common = { path = "third_party/wasefire/crates/common", optional = true }
 
 [dependencies.wasefire]
-version = "0.8.1"
+path = "third_party/wasefire/crates/prelude"
 default-features = false
 features = [
   "api-button",

--- a/docs/install.md
+++ b/docs/install.md
@@ -13,11 +13,10 @@ In order to compile and flash a working OpenSK firmware, you will need the
 following:
 
 - rustup (can be installed with [Rustup](https://rustup.rs/))
-- uv (can be installed with
-  [uv](https://docs.astral.sh/uv/getting-started/installation/))
-- python3 and pip (can be installed with the `python3-pip` package on Debian)
 - the OpenSSL command line tool (can be installed and configured with the
   `libssl-dev` and `pkg-config` packages on Debian)
+- uv and python3 (optional, for sending CTAP commands for configuration, can be
+  installed with [uv](https://docs.astral.sh/uv/getting-started/installation/))
 
 ## Setup
 

--- a/libraries/opensk/Cargo.toml
+++ b/libraries/opensk/Cargo.toml
@@ -25,7 +25,7 @@ hkdf = { version = "0.12.3", default-features = false, optional = true }
 aes = { version = "0.8.2", default-features = false, optional = true }
 cbc = { version = "0.1.2", default-features = false, optional = true }
 zeroize = { version = "1.5.7", features = ["derive"] }
-wasefire-store = { version = "=0.2.4", optional = true }
+wasefire-store = { version = "0.2.4", optional = true }
 
 [dependencies.p256]
 version = "0.13.0"

--- a/libraries/opensk/src/ctap/status_code.rs
+++ b/libraries/opensk/src/ctap/status_code.rs
@@ -109,7 +109,7 @@ impl From<Ctap2StatusCode> for key_store::Error {
     }
 }
 
-#[cfg(feature = "wasefire-store")]
+#[cfg(feature = "std")]
 impl From<wasefire_store::StoreError> for Ctap2StatusCode {
     fn from(error: wasefire_store::StoreError) -> Ctap2StatusCode {
         use wasefire_store::StoreError;
@@ -144,7 +144,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "wasefire-store")]
+    #[cfg(feature = "std")]
     fn test_wasefire_store_errors() -> () {
         for (store_error, ctap_error) in [
             (

--- a/setup.sh
+++ b/setup.sh
@@ -19,22 +19,16 @@ done_text="$(tput bold)DONE.$(tput sgr0)"
 
 set -e
 
-# Installs uv for OSS-Fuzz
-if [[ -n "${CI}" ]] && ! command -v uv &> /dev/null; then
-    curl -LsSf "https://astral.sh/uv/install.sh" | sh
-    export PATH="${HOME}/.local/bin:${HOME}/.cargo/bin:${PATH}"
+if ! command -v rustup &> /dev/null; then
+  echo "❌ Missing rustup command."
+  echo "Please follow the steps at https://rustup.rs/ to install it."
+  exit 1
 fi
 
-# Check that rustup and pip3 are installed
-check_command () {
-  if ! which "$1" >/dev/null
-  then
-    echo "Missing $1 command. Follow the steps under $2 to install it."
-    exit 1
-  fi
-}
-check_command rustup "https://rustup.rs/"
-check_command uv "https://docs.astral.sh/uv/getting-started/installation/"
+if ! command -v uv &> /dev/null; then
+  echo "uv command not found, optional for device configuration. "
+  echo "Install with: https://docs.astral.sh/uv/getting-started/installation/"
+fi
 
 git submodule update --init
 


### PR DESCRIPTION
Missing uv made the CIFuzz workflow fail. But Python is optional now, so it is not mandatory in the setup anymore.

Also, the Wasefire paths are now correctly set to refer to the local repository.