### PR TITLE
Attestation API cleanup

### DIFF
--- a/libraries/opensk/src/api/persist.rs
+++ b/libraries/opensk/src/api/persist.rs
@@ -530,18 +530,10 @@ pub trait Persist {
 
     fn get_attestation(&self, id: AttestationId) -> CtapResult<Option<Attestation>> {
         let stored_id_bytes = self.find(keys::ATTESTATION_ID)?;
-        if let Some(bytes) = stored_id_bytes {
-            if bytes.len() != 1 {
-                return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
-            }
-            if id != AttestationId::try_from(bytes[0])? {
-                return Ok(None);
-            }
-        } else {
-            // This is for backwards compatibility. No ID stored implies batch.
-            if id != AttestationId::Batch {
-                return Ok(None);
-            }
+        match stored_id_bytes.as_deref() {
+            Some([byte]) if AttestationId::try_from(*byte)? == id => (),
+            Some([_]) | None => return Ok(None),
+            _ => return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR),
         }
         let wrapped_private_key = self.find(keys::ATTESTATION_PRIVATE_KEY)?;
         let certificate = self.find(keys::ATTESTATION_CERTIFICATE)?;

--- a/libraries/opensk/src/api/persist.rs
+++ b/libraries/opensk/src/api/persist.rs
@@ -554,8 +554,11 @@ pub trait Persist {
         attestation: Option<&Attestation>,
     ) -> CtapResult<()> {
         // To overwrite, first call with None, then call again, to avoid mistakes.
-        if self.find(keys::ATTESTATION_ID)?.is_some() {
-            return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR);
+        let stored_id_bytes = self.find(keys::ATTESTATION_ID)?;
+        match (stored_id_bytes.as_deref(), attestation) {
+            (None, _) => (),
+            (Some([byte]), None) if AttestationId::try_from(*byte)? == id => (),
+            _ => return Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR),
         }
         // We set attestation storage in 3 transactions. If that gets interrupted halfway,
         // Register and MakeCredential will error when being called. Needs to be redone then.
@@ -792,6 +795,67 @@ mod test {
         );
         assert_eq!(persist.remove_template_id(&[0x00]), Ok(()));
         assert_eq!(persist.get_friendly_name(&[0x00]).unwrap(), None);
+    }
+
+    #[test]
+    fn test_get_set_no_overwrite_attestation() {
+        let mut env = TestEnv::default();
+        let persist = env.persist();
+
+        assert_eq!(persist.get_attestation(AttestationId::Batch), Ok(None));
+        let attestation = Attestation {
+            wrapped_private_key: vec![0x55],
+            certificate: vec![0xCC],
+        };
+        assert_eq!(
+            persist.set_attestation(AttestationId::Batch, Some(&attestation)),
+            Ok(())
+        );
+        assert_eq!(
+            persist.get_attestation(AttestationId::Batch),
+            Ok(Some(attestation.clone()))
+        );
+        // Neither directly overwriting nor deleting the wrong ID works.
+        assert_eq!(
+            persist.set_attestation(AttestationId::Batch, Some(&attestation)),
+            Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)
+        );
+        assert_eq!(
+            persist.set_attestation(AttestationId::Enterprise, None),
+            Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)
+        );
+    }
+
+    #[test]
+    fn test_overwrite_attestation() {
+        let mut env = TestEnv::default();
+        let persist = env.persist();
+
+        let attestation1 = Attestation {
+            wrapped_private_key: vec![0x55],
+            certificate: vec![0xCC],
+        };
+        assert_eq!(
+            persist.set_attestation(AttestationId::Batch, Some(&attestation1)),
+            Ok(())
+        );
+        assert_eq!(
+            persist.set_attestation(AttestationId::Enterprise, None),
+            Err(Ctap2StatusCode::CTAP2_ERR_VENDOR_INTERNAL_ERROR)
+        );
+        assert_eq!(persist.set_attestation(AttestationId::Batch, None), Ok(()));
+        let attestation2 = Attestation {
+            wrapped_private_key: vec![0x66],
+            certificate: vec![0xDD],
+        };
+        assert_eq!(
+            persist.set_attestation(AttestationId::Enterprise, Some(&attestation2)),
+            Ok(())
+        );
+        assert_eq!(
+            persist.get_attestation(AttestationId::Enterprise),
+            Ok(Some(attestation2))
+        );
     }
 
     #[test]


### PR DESCRIPTION
Wasefire was a breaking change, so we may use the opportunity for a cleanup.

In `get_attestation`, the only functional change is that we don't assume batch attestation when nothing is stored, the rest is style.

While working on this, I noticed a logic error in `set_attestation` and fixed it.