### PR TITLE
Renames the feature `with_ctap1` to `ctap1`

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           toolchain: nightly
           command: test
-          args: --manifest-path libraries/opensk/Cargo.toml --features "std,with_ctap1,vendor_hid,software_crypto_ed25519,fingerprint" --no-fail-fast
+          args: --manifest-path libraries/opensk/Cargo.toml --features "std,ctap1,vendor_hid,software_crypto_ed25519,fingerprint" --no-fail-fast
         env:
           RUSTFLAGS: "-Cinstrument-coverage"
           LLVM_PROFILE_FILE: "opensk-%p-%m.profraw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ default-features = false
 
 [features]
 config-command = ["opensk/config_command"]
-ctap1 = ["opensk/with_ctap1"]
+ctap1 = ["opensk/ctap1"]
 debug = ["opensk/debug_ctap"]
 ed25519 = ["opensk/ed25519", "wasefire/api-crypto-ed25519"]
 fingerprint = ["dep:wasefire-common", "opensk/fingerprint", "wasefire/api-fingerprint-matcher"]

--- a/libraries/opensk/Cargo.toml
+++ b/libraries/opensk/Cargo.toml
@@ -34,11 +34,11 @@ features = ["alloc", "ecdh", "ecdsa"]
 optional = true
 
 [features]
-default = ["config_command", "with_ctap1"]
+default = ["config_command", "ctap1"]
 config_command = []
 debug_ctap = []
 std = ["wasefire-store/std", "rand?/std_rng", "config_command", "software_crypto", "ed25519-compact"]
-with_ctap1 = []
+ctap1 = []
 vendor_hid = []
 fuzz = ["arbitrary", "std"]
 software_crypto = ["rand", "sha2", "hmac", "hkdf", "aes", "cbc", "p256"]

--- a/libraries/opensk/src/ctap/hid/mod.rs
+++ b/libraries/opensk/src/ctap/hid/mod.rs
@@ -194,7 +194,7 @@ pub struct CtapHid<E: Env> {
 impl<E: Env> CtapHid<E> {
     pub const CAPABILITY_WINK: u8 = 0x01;
     pub const CAPABILITY_CBOR: u8 = 0x04;
-    #[cfg(any(not(feature = "with_ctap1"), feature = "vendor_hid"))]
+    #[cfg(any(not(feature = "ctap1"), feature = "vendor_hid"))]
     pub const CAPABILITY_NMSG: u8 = 0x08;
 
     /// Creates a new CTAP HID packet parser.

--- a/libraries/opensk/src/ctap/main_hid.rs
+++ b/libraries/opensk/src/ctap/main_hid.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 use crate::api::clock::Clock;
-#[cfg(feature = "with_ctap1")]
+#[cfg(feature = "ctap1")]
 use crate::ctap::ctap1;
-#[cfg(feature = "with_ctap1")]
+#[cfg(feature = "ctap1")]
 use crate::ctap::hid::ChannelID;
 use crate::ctap::hid::{
     CtapHid, CtapHidCommand, CtapHidError, HidPacket, HidPacketIterator, Message,
@@ -34,9 +34,9 @@ pub struct MainHid<E: Env> {
 impl<E: Env> Default for MainHid<E> {
     /// Instantiates a HID handler for CTAP1, CTAP2 and Wink.
     fn default() -> Self {
-        #[cfg(feature = "with_ctap1")]
+        #[cfg(feature = "ctap1")]
         let capabilities = CtapHid::<E>::CAPABILITY_WINK | CtapHid::<E>::CAPABILITY_CBOR;
-        #[cfg(not(feature = "with_ctap1"))]
+        #[cfg(not(feature = "ctap1"))]
         let capabilities = CtapHid::<E>::CAPABILITY_WINK
             | CtapHid::<E>::CAPABILITY_CBOR
             | CtapHid::<E>::CAPABILITY_NMSG;
@@ -83,10 +83,10 @@ impl<E: Env> MainHid<E> {
             // CTAP 2.1 from 2021-06-15, section 11.2.9.1.1.
             CtapHidCommand::Msg => {
                 // If we don't have CTAP1 backward compatibilty, this command is invalid.
-                #[cfg(not(feature = "with_ctap1"))]
+                #[cfg(not(feature = "ctap1"))]
                 return CtapHid::<E>::error_message(cid, CtapHidError::InvalidCmd);
 
-                #[cfg(feature = "with_ctap1")]
+                #[cfg(feature = "ctap1")]
                 match ctap1::Ctap1Command::process_command(env, &message.payload, ctap_state) {
                     Ok(payload) => Self::ctap1_success_message(cid, &payload),
                     Err(ctap1_status_code) => Self::ctap1_error_message(cid, ctap1_status_code),
@@ -130,7 +130,7 @@ impl<E: Env> MainHid<E> {
         !env.clock().is_elapsed(&self.wink_permission)
     }
 
-    #[cfg(feature = "with_ctap1")]
+    #[cfg(feature = "ctap1")]
     fn ctap1_error_message(cid: ChannelID, error_code: ctap1::Ctap1StatusCode) -> Message {
         let code: u16 = error_code.into();
         Message {
@@ -140,7 +140,7 @@ impl<E: Env> MainHid<E> {
         }
     }
 
-    #[cfg(feature = "with_ctap1")]
+    #[cfg(feature = "ctap1")]
     fn ctap1_success_message(cid: ChannelID, payload: &[u8]) -> Message {
         let mut response = payload.to_vec();
         let code: u16 = ctap1::Ctap1StatusCode::SW_SUCCESS.into();

--- a/libraries/opensk/src/ctap/mod.rs
+++ b/libraries/opensk/src/ctap/mod.rs
@@ -19,7 +19,7 @@ pub mod command;
 mod config_command;
 mod credential_management;
 pub mod crypto_wrapper;
-#[cfg(feature = "with_ctap1")]
+#[cfg(feature = "ctap1")]
 mod ctap1;
 pub mod data_formats;
 #[cfg(feature = "fingerprint")]
@@ -33,7 +33,7 @@ pub mod secret;
 pub mod status_code;
 mod storage;
 mod token_state;
-#[cfg(feature = "with_ctap1")]
+#[cfg(feature = "ctap1")]
 mod u2f_up;
 #[cfg(feature = "vendor_hid")]
 pub mod vendor_hid;
@@ -64,7 +64,7 @@ use self::response::{
 };
 use self::secret::Secret;
 use self::status_code::{Ctap2StatusCode, CtapResult};
-#[cfg(feature = "with_ctap1")]
+#[cfg(feature = "ctap1")]
 use self::u2f_up::U2fUserPresenceState;
 use crate::api::clock::Clock;
 use crate::api::connection::{HidConnection, RecvStatus, UsbEndpoint};
@@ -109,7 +109,7 @@ const RESET_TIMEOUT_DURATION_MS: usize = 10000;
 const STATEFUL_COMMAND_TIMEOUT_DURATION_MS: usize = 30000;
 
 pub const FIDO2_VERSION_STRING: &str = "FIDO_2_0";
-#[cfg(feature = "with_ctap1")]
+#[cfg(feature = "ctap1")]
 pub const U2F_VERSION_STRING: &str = "U2F_V2";
 pub const FIDO2_1_VERSION_STRING: &str = "FIDO_2_1";
 
@@ -559,7 +559,7 @@ impl<E: Env> StatefulPermission<E> {
 // in the persistent store field.
 pub struct CtapState<E: Env> {
     client_pin: ClientPin<E>,
-    #[cfg(feature = "with_ctap1")]
+    #[cfg(feature = "ctap1")]
     pub(crate) u2f_up_state: U2fUserPresenceState<E>,
     // The state initializes to Reset and its timeout, and never goes back to Reset.
     stateful_command_permission: StatefulPermission<E>,
@@ -581,7 +581,7 @@ impl<E: Env> CtapState<E> {
         };
         CtapState {
             client_pin,
-            #[cfg(feature = "with_ctap1")]
+            #[cfg(feature = "ctap1")]
             u2f_up_state: U2fUserPresenceState::new(),
             stateful_command_permission,
             #[cfg(feature = "fingerprint")]
@@ -600,14 +600,14 @@ impl<E: Env> CtapState<E> {
     // Returns whether CTAP1 commands are currently supported.
     // If alwaysUv is enabled and the authenticator does not support internal UV,
     // CTAP1 needs to be disabled.
-    #[cfg(feature = "with_ctap1")]
+    #[cfg(feature = "ctap1")]
     pub fn allows_ctap1(&self, env: &mut E) -> CtapResult<bool> {
         Ok(!storage::has_always_uv(env)?)
     }
 
     fn clear_other_channels(&mut self, channel: Channel) {
         // Correct behavior between CTAP1 and CTAP2 isn't defined yet. Just a guess.
-        #[cfg(feature = "with_ctap1")]
+        #[cfg(feature = "ctap1")]
         {
             // We create a block statement to wrap this assignment expression, because attributes
             // (like #[cfg]) are not supported on expressions.
@@ -1338,12 +1338,12 @@ impl<E: Env> CtapState<E> {
 
     fn process_get_info(&self, env: &mut E) -> CtapResult<ResponseData> {
         let has_always_uv = storage::has_always_uv(env)?;
-        #[cfg_attr(not(feature = "with_ctap1"), allow(unused_mut))]
+        #[cfg_attr(not(feature = "ctap1"), allow(unused_mut))]
         let mut versions = vec![
             String::from(FIDO2_VERSION_STRING),
             String::from(FIDO2_1_VERSION_STRING),
         ];
-        #[cfg(feature = "with_ctap1")]
+        #[cfg(feature = "ctap1")]
         if !has_always_uv {
             versions.insert(0, String::from(U2F_VERSION_STRING))
         }
@@ -1454,7 +1454,7 @@ impl<E: Env> CtapState<E> {
             }
         }
 
-        #[cfg(feature = "with_ctap1")]
+        #[cfg(feature = "ctap1")]
         {
             // We create a block statement to wrap this assignment expression, because attributes
             // (like #[cfg]) are not supported on expressions.
@@ -1488,12 +1488,12 @@ impl<E: Env> CtapState<E> {
         Ok(auth_data)
     }
 
-    #[cfg(feature = "with_ctap1")]
+    #[cfg(feature = "ctap1")]
     pub fn u2f_grant_user_presence(&mut self, env: &mut E) {
         self.u2f_up_state.grant_up(env)
     }
 
-    #[cfg(feature = "with_ctap1")]
+    #[cfg(feature = "ctap1")]
     pub fn u2f_needs_user_presence(&mut self, env: &mut E) -> bool {
         self.u2f_up_state.is_up_needed(env)
     }
@@ -1584,7 +1584,7 @@ mod test {
         #[allow(clippy::unnecessary_to_owned)]
         let expected_cbor = cbor_map_options! {
              0x01 => cbor_array_vec![vec![
-                    #[cfg(feature = "with_ctap1")]
+                    #[cfg(feature = "ctap1")]
                     String::from(U2F_VERSION_STRING),
                     String::from(FIDO2_VERSION_STRING),
                     String::from(FIDO2_1_VERSION_STRING),
@@ -1650,7 +1650,7 @@ mod test {
         #[allow(clippy::unnecessary_to_owned)]
         let expected_cbor = cbor_map_options! {
              0x01 => cbor_array_vec![vec![
-                    #[cfg(feature = "with_ctap1")]
+                    #[cfg(feature = "ctap1")]
                     String::from(U2F_VERSION_STRING),
                     String::from(FIDO2_VERSION_STRING),
                     String::from(FIDO2_1_VERSION_STRING),

--- a/libraries/opensk/src/ctap/u2f_up.rs
+++ b/libraries/opensk/src/ctap/u2f_up.rs
@@ -64,7 +64,7 @@ impl<E: Env> U2fUserPresenceState<E> {
     }
 }
 
-#[cfg(feature = "with_ctap1")]
+#[cfg(feature = "ctap1")]
 #[cfg(test)]
 mod test {
     use super::*;

--- a/libraries/opensk/src/lib.rs
+++ b/libraries/opensk/src/lib.rs
@@ -120,12 +120,12 @@ impl<E: Env> Ctap<E> {
         !self.should_wink() && self.state.can_sleep(&mut self.env)
     }
 
-    #[cfg(feature = "with_ctap1")]
+    #[cfg(feature = "ctap1")]
     pub fn u2f_grant_user_presence(&mut self) {
         self.state.u2f_grant_user_presence(&mut self.env)
     }
 
-    #[cfg(feature = "with_ctap1")]
+    #[cfg(feature = "ctap1")]
     pub fn u2f_needs_user_presence(&mut self) -> bool {
         self.state.u2f_needs_user_presence(&mut self.env)
     }
@@ -277,7 +277,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "with_ctap1")]
+    #[cfg(feature = "ctap1")]
     fn test_ctap1_initial_state() {
         let env = TestEnv::default();
         let mut ctap = Ctap::<TestEnv>::new(env);

--- a/run_desktop_tests.sh
+++ b/run_desktop_tests.sh
@@ -59,7 +59,7 @@ cargo clippy --lib --tests --bins --benches --features=test,"$MOST_FEATURES" -- 
 echo "Running OpenSK library unit tests..."
 cd libraries/opensk
 cargo test --no-default-features --features=std
-cargo test --features=std,config_command,with_ctap1
+cargo test --features=std,config_command,ctap1
 cargo test --all-features
 cd ../..
 


### PR DESCRIPTION
The old feature name goes against the Rust naming convention.

> Do not include words in the name of a Cargo feature that convey zero meaning, as in use-abc or with-abc. Name the feature abc directly.

https://rust-lang.github.io/api-guidelines/naming.html#c-feature