### PR TITLE
Fix U2F UP not timing out

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,13 +36,15 @@ fn main() -> ! {
         update_state(&mut wink, opensk_ctap.should_wink(), || {
             blink::Blink::new_ms(100)
         });
-        let mut packet = Some([0; 64]);
-        let mut timeout = None;
-        timeout = timeout.or(wink.is_some().then_some(500));
+        let mut recv_packet = Some([0; 64]);
+        let mut timeout = false;
+        timeout |= wink.is_some();
         #[cfg(feature = "ctap1")]
-        (timeout = timeout.or(u2f.is_some().then_some(1000)));
-        match env::hid_connection::recv(packet.as_mut().unwrap(), timeout).unwrap() {
-            RecvStatus::Timeout => packet = None,
+        (timeout |= u2f.is_some());
+        match env::hid_connection::recv(recv_packet.as_mut().unwrap(), timeout.then_some(500))
+            .unwrap()
+        {
+            RecvStatus::Timeout => recv_packet = None,
             RecvStatus::Received(endpoint) => assert_eq!(endpoint, UsbEndpoint::MainHid),
         }
         #[cfg(feature = "ctap1")]
@@ -50,12 +52,12 @@ fn main() -> ! {
             u2f = None;
             opensk_ctap.u2f_grant_user_presence();
         }
-        if let Some(packet) = packet {
-            for packet in opensk_ctap.process_hid_packet(&packet, Transport::MainHid) {
+        if let Some(recv_packet) = recv_packet {
+            for send_packet in opensk_ctap.process_hid_packet(&recv_packet, Transport::MainHid) {
                 opensk_ctap
                     .env()
                     .hid_connection()
-                    .send(&packet, UsbEndpoint::MainHid)
+                    .send(&send_packet, UsbEndpoint::MainHid)
                     .unwrap();
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,15 +33,16 @@ fn main() -> ! {
     let mut u2f: Option<touch::Touch> = None;
     debug!("OpenSK initialized");
     loop {
-        match (wink.is_some(), opensk_ctap.should_wink()) {
-            (true, true) | (false, false) => (),
-            (false, true) => wink = Some(blink::Blink::new_ms(100)),
-            (true, false) => wink = None,
-        }
-        let mut packet = [0; 64];
-        let timeout = wink.is_some().then_some(500);
-        match env::hid_connection::recv(&mut packet, timeout).unwrap() {
-            RecvStatus::Timeout => continue,
+        update_state(&mut wink, opensk_ctap.should_wink(), || {
+            blink::Blink::new_ms(100)
+        });
+        let mut packet = Some([0; 64]);
+        let mut timeout = None;
+        timeout = timeout.or(wink.is_some().then_some(500));
+        #[cfg(feature = "ctap1")]
+        (timeout = timeout.or(u2f.is_some().then_some(1000)));
+        match env::hid_connection::recv(packet.as_mut().unwrap(), timeout).unwrap() {
+            RecvStatus::Timeout => packet = None,
             RecvStatus::Received(endpoint) => assert_eq!(endpoint, UsbEndpoint::MainHid),
         }
         #[cfg(feature = "ctap1")]
@@ -49,16 +50,28 @@ fn main() -> ! {
             u2f = None;
             opensk_ctap.u2f_grant_user_presence();
         }
-        for packet in opensk_ctap.process_hid_packet(&packet, Transport::MainHid) {
-            opensk_ctap
-                .env()
-                .hid_connection()
-                .send(&packet, UsbEndpoint::MainHid)
-                .unwrap();
+        if let Some(packet) = packet {
+            for packet in opensk_ctap.process_hid_packet(&packet, Transport::MainHid) {
+                opensk_ctap
+                    .env()
+                    .hid_connection()
+                    .send(&packet, UsbEndpoint::MainHid)
+                    .unwrap();
+            }
         }
         #[cfg(feature = "ctap1")]
-        if opensk_ctap.u2f_needs_user_presence() && u2f.is_none() {
-            u2f = Some(touch::Touch::new());
-        }
+        update_state(
+            &mut u2f,
+            opensk_ctap.u2f_needs_user_presence(),
+            touch::Touch::new,
+        );
+    }
+}
+
+fn update_state<T>(state: &mut Option<T>, target: bool, build: impl FnOnce() -> T) {
+    *state = match (state.is_some(), target) {
+        (true, true) | (false, false) => return,
+        (true, false) => None,
+        (false, true) => Some(build()),
     }
 }


### PR DESCRIPTION
There was 2 issues preventing the U2F UP from timing out:
1. There was no timeout waiting for packets while U2F UP is on.
2. When timing out for packets the U2F UP logic was skipped.

The fixes are:
1. A timeout of 1 second is used when U2F UP is on.
2. We execute the rest of the loop body (except for packet processing).

This needs the `impl Drop for Touch` of #777 to actually fix the blinking.