### PR TITLE
Flash script to simplify installation

### DIFF
--- a/docs/boards/nrf52840_dongle.md
+++ b/docs/boards/nrf52840_dongle.md
@@ -23,12 +23,7 @@ Make sure the dongle is in DFU mode by plugging it while holding the reset butto
 The device indicates DFU mode with a slowly blinking red LED.
 
 ```sh
-cargo xtask --release --native \
-  applet rust ../.. --opt-level=z --features=ctap1,config-command \
-  runner nordic --board=dongle --opt-level=z --features=usb-ctap \
-    --features=software-crypto-aes256-cbc,software-crypto-hmac-sha256 \
-    --features=software-crypto-p256-ecdsa,software-crypto-p256-ecdh \
-  flash
+./flash.sh nrf52840_dongle
 ```
 
 This command will eventually pause and instruct you to enter DFU mode again (by

--- a/docs/boards/nrf52840_feitian.md
+++ b/docs/boards/nrf52840_feitian.md
@@ -13,8 +13,13 @@ hardware. See
 - In V2, push and hold the user button for more than 10 seconds after
   connecting your device.
 
-Afterwards, you can flash your Feitian OpenSK following the
-[instructions for the Nordic nRF52840 Dongle](nrf52840_dongle.md#Flashing).
+Afterwards, you can flash your Feitian OpenSK by running:
+
+```sh
+./flash.sh nrf52840_dongle
+```
+
+Note: Using `nrf52840_dongle` is not a typo. They use similar hardware.
 
 ### Buttons and LEDs
 

--- a/docs/boards/nrf52840_mdk.md
+++ b/docs/boards/nrf52840_mdk.md
@@ -9,12 +9,7 @@ Also make sure the USB mass storage device class is mounted. It should appear as
 UF2BOOT.
 
 ```sh
-cargo xtask --release --native \
-  applet rust ../.. --opt-level=z --features=ctap1,config-command,led-1 \
-  runner nordic --board=makerdiary --opt-level=z --features=usb-ctap \
-    --features=software-crypto-aes256-cbc,software-crypto-hmac-sha256 \
-    --features=software-crypto-p256-ecdsa,software-crypto-p256-ecdh \
-  flash
+./flash.sh nrf52840_mdk
 ```
 
 ### Buttons and LEDs

--- a/docs/boards/nrf52840dk.md
+++ b/docs/boards/nrf52840dk.md
@@ -12,12 +12,7 @@ is the easiest and most convenient. You can flash OpenSK with these steps:
 After connecting a micro USB cable to the JTAG USB port, run:
 
 ```sh
-cargo xtask --release --native \
-  applet rust ../.. --opt-level=z --features=ctap1,config-command \
-  runner nordic --opt-level=z --features=usb-ctap \
-    --features=software-crypto-aes256-cbc,software-crypto-hmac-sha256 \
-    --features=software-crypto-p256-ecdh,software-crypto-p256-ecdsa \
-  flash
+./flash.sh nrf52840dk
 ```
 
 To use OpenSK, connect a micro USB cable to the device USB port.

--- a/docs/install.md
+++ b/docs/install.md
@@ -44,9 +44,7 @@ sudo udevadm control --reload
 
 OpenSK stores data in the devices flash storage, for example your credentials.
 When you flash Wasefire, you will erase that storage.
-
-If you flash Wasefire and OpenSK for the second time, and want to keep your
-storage, replace `flash` in the below commands with `update --both`.
+To keep your storage, use the `--update` flag with the below flash script.
 
 ## Features
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -58,8 +58,14 @@ The applet provides a few customization features (all disabled by default):
 - `ed25519` enables support for Ed25519 (the applet always implements ECDSA P-256)
 - `fingerprint` enables support for fingerprints (requires a sensor)
 
-The hardware specific commands below to flash a firmware contain the default
-argument `--features=ctap1,config-command`. Add or remove features there.
+We provide a `flash.sh` script to flash the OpenSK applet for each platform.
+To customize features, use `--features`. For example, to enable debug prints:
+
+```sh
+./flash.sh --features=ctap1,config-command,debug <target>
+```
+
+The available targets are listed below.
 
 ## Platforms
 
@@ -80,15 +86,10 @@ The applet needs the platform to implement the following features of the board A
 - `api-timer`
 - `api-usb-ctap`
 
-Run commands below from the directory `third_party/wasefire/`.
-They contain the necessary platform features. If you want to use applet
-features like `fingerprint`, you may need to add the corresponding platform
-feature. Set them using `--features=` prefix for the `runner`.
 Some applet features only work for some targets, special notes will indicate
 when a feature is not supported, or extra steps need to be taken.
 
-In the following sections, we provide instructions to flash an OpenSK applet for
-each platform provided by this repository.
+In the following sections, we describe platforms that support OpenSK.
 
 ### Host
 
@@ -97,8 +98,7 @@ The applet feature `fingerprint` is not supported.
 To install, run:
 
 ```sh
-cargo xtask --native applet rust ../.. --features=ctap1,config-command \
-  runner host flash --usb-ctap --interface=web
+./flash.sh host
 ```
 
 ### nRF52840
@@ -117,10 +117,10 @@ using the same platform feature.
 
 For more details on the boards, see:
 
-- [Nordic nRF52840-DK](boards/nrf52840dk.md)
-- [Nordic nRF52840 Dongle](boards/nrf52840_dongle.md)
-- [Makerdiary nRF52840-MDK USB dongle](boards/nrf52840_mdk.md)
-- [Feitian OpenSK dongle](boards/nrf52840_feitian.md)
+- [Nordic nRF52840-DK](boards/nrf52840dk.md) - target: `nrf52840dk`
+- [Nordic nRF52840 Dongle](boards/nrf52840_dongle.md) - target: `nrf52840_dongle`
+- [Makerdiary nRF52840-MDK USB dongle](boards/nrf52840_mdk.md) - target: `nrf52840_mdk`
+- [Feitian OpenSK dongle](boards/nrf52840_feitian.md) - target: `nrf52840_dongle`
 
 ### OpenTitan
 
@@ -135,8 +135,5 @@ A LED (active high) needs to be connected to R10. A capacitive touch needs to be
 connected to R13.
 
 ```sh
-cargo xtask --release --native \
-  applet rust ../.. --opt-level=z --features=ctap1,config-command \
-  runner opentitan --opt-level=z --features=usb-ctap \
-  flash
+./flash.sh opentitan
 ```

--- a/flash.sh
+++ b/flash.sh
@@ -22,6 +22,7 @@ usage() {
   echo ""
   echo "Options:"
   echo "  --features=<features>  Comma-separated list of features to enable (default: $FEATURES)"
+  echo "  --update               Update instead of flashing (preserves storage)"
   echo ""
   echo "Targets:"
   echo "  host               Simulated device on host"
@@ -32,10 +33,16 @@ usage() {
   exit 1
 }
 
+CMD=(flash)
+
 while [[ $# -gt 0 ]]; do
   case $1 in
     --features=*)
       FEATURES="${1#*=}"
+      shift
+      ;;
+    --update)
+      CMD=(update --both)
       shift
       ;;
     -h|--help)
@@ -81,25 +88,30 @@ SOFTWARE_CRYPTO_FEATURES+=",software-crypto-p256-ecdsa"
 
 case $TARGET in
   host)
-    cargo xtask --native applet rust ../.. --features="$FEATURES" \
-      runner host flash --usb-ctap --interface=web
+    if [ "${CMD[0]}" = "update" ]; then
+      cargo xtask --native applet rust ../.. --features="$FEATURES" \
+        runner host "${CMD[@]}"
+    else
+      cargo xtask --native applet rust ../.. --features="$FEATURES" \
+        runner host flash --usb-ctap --interface=web
+    fi
     ;;
   opentitan)
     cargo xtask --release --native applet rust ../.. --opt-level=z --features="$FEATURES" \
       runner opentitan --opt-level=z --features=usb-ctap \
-      flash
+      "${CMD[@]}"
     ;;
   nrf52840dk)
     cargo xtask --release --native applet rust ../.. --opt-level=z --features="$FEATURES" \
       runner nordic --opt-level=z --features=usb-ctap \
         --features="$SOFTWARE_CRYPTO_FEATURES" \
-      flash
+      "${CMD[@]}"
     ;;
   nrf52840_dongle)
     cargo xtask --release --native applet rust ../.. --opt-level=z --features="$FEATURES" \
       runner nordic --board=dongle --opt-level=z --features=usb-ctap \
         --features="$SOFTWARE_CRYPTO_FEATURES" \
-      flash
+      "${CMD[@]}"
     ;;
   nrf52840_mdk)
     # Ensure led-1 is included for MDK
@@ -110,7 +122,7 @@ case $TARGET in
     cargo xtask --release --native applet rust ../.. --opt-level=z --features="$MDK_FEATURES" \
       runner nordic --board=makerdiary --opt-level=z --features=usb-ctap \
         --features="$SOFTWARE_CRYPTO_FEATURES" \
-      flash
+      "${CMD[@]}"
     ;;
   *)
     echo "Error: Unknown target $TARGET"

--- a/flash.sh
+++ b/flash.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+FEATURES="ctap1,config-command"
+
+usage() {
+  echo "Usage: $0 [options] <target>"
+  echo ""
+  echo "Options:"
+  echo "  --features=<features>  Comma-separated list of features to enable (default: $FEATURES)"
+  echo ""
+  echo "Targets:"
+  echo "  host               Simulated device on host"
+  echo "  opentitan          OpenTitan board"
+  echo "  nrf52840dk         Nordic nRF52840 Development Kit"
+  echo "  nrf52840_dongle    Nordic nRF52840 Dongle"
+  echo "  nrf52840_mdk       Makerdiary nRF52840 MDK USB Dongle"
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --features=*)
+      FEATURES="${1#*=}"
+      shift
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      if [ -z "$TARGET" ]; then
+        TARGET=$1
+        shift
+      else
+        echo "Error: Unknown argument $1"
+        usage
+      fi
+      ;;
+  esac
+done
+
+if [ -z "$TARGET" ]; then
+  echo "Error: Target is required."
+  usage
+fi
+
+# Ensure we are in the root directory of OpenSK
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$SCRIPT_DIR"
+
+WASEFIRE_DIR="third_party/wasefire"
+
+if [ ! -d "$WASEFIRE_DIR" ] || [ -z "$(ls -A "$WASEFIRE_DIR")" ]; then
+  echo "$WASEFIRE_DIR is empty or does not exist. Run './setup.sh' first."
+  exit 1
+fi
+
+cd "$WASEFIRE_DIR"
+
+echo "Flashing target: $TARGET"
+echo "With features: $FEATURES"
+
+SOFTWARE_CRYPTO_FEATURES="software-crypto-aes256-cbc"
+SOFTWARE_CRYPTO_FEATURES+=",software-crypto-hmac-sha256"
+SOFTWARE_CRYPTO_FEATURES+=",software-crypto-p256-ecdh"
+SOFTWARE_CRYPTO_FEATURES+=",software-crypto-p256-ecdsa"
+
+case $TARGET in
+  host)
+    cargo xtask --native applet rust ../.. --features="$FEATURES" \
+      runner host flash --usb-ctap --interface=web
+    ;;
+  opentitan)
+    cargo xtask --release --native applet rust ../.. --opt-level=z --features="$FEATURES" \
+      runner opentitan --opt-level=z --features=usb-ctap \
+      flash
+    ;;
+  nrf52840dk)
+    cargo xtask --release --native applet rust ../.. --opt-level=z --features="$FEATURES" \
+      runner nordic --opt-level=z --features=usb-ctap \
+        --features="$SOFTWARE_CRYPTO_FEATURES" \
+      flash
+    ;;
+  nrf52840_dongle)
+    cargo xtask --release --native applet rust ../.. --opt-level=z --features="$FEATURES" \
+      runner nordic --board=dongle --opt-level=z --features=usb-ctap \
+        --features="$SOFTWARE_CRYPTO_FEATURES" \
+      flash
+    ;;
+  nrf52840_mdk)
+    # Ensure led-1 is included for MDK
+    MDK_FEATURES="$FEATURES"
+    if [[ ! "$MDK_FEATURES" =~ "led-1" ]]; then
+      MDK_FEATURES="$MDK_FEATURES,led-1"
+    fi
+    cargo xtask --release --native applet rust ../.. --opt-level=z --features="$MDK_FEATURES" \
+      runner nordic --board=makerdiary --opt-level=z --features=usb-ctap \
+        --features="$SOFTWARE_CRYPTO_FEATURES" \
+      flash
+    ;;
+  *)
+    echo "Error: Unknown target $TARGET"
+    usage
+    ;;
+esac


### PR DESCRIPTION
Users get a script for flashing, so they don't have to

- move into `third_party/wasefire`,
- manipulate the command for features,
- or find out how to preserve storage.

@jmichelp Is this more intuitive?