### PR TITLE
Documents macOS support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,10 @@ concurrency:
 jobs:
   runtests:
     name: Continuous Integration
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,15 +145,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8142a83c17aa9461d637e649271eae18bf2edd00e91f2e105df36c3c16355bdb"
+checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
+checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
  "syn",
@@ -582,9 +582,9 @@ version = "0.1.2"
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "1527984ca054dfca79333baec451042863f485fbee01b7bf6d911de915cac865"
 dependencies = [
  "portable-atomic",
 ]
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-one-of"
-version = "0.1.2"
+version = "0.1.3-git"
 
 [[package]]
 name = "wasefire-store"
@@ -716,7 +716,7 @@ checksum = "f49afdab5206771f6d7ad85b556fcd6255004485b704f0f5c084335c5fae3238"
 
 [[package]]
 name = "wasefire-sync"
-version = "0.1.3"
+version = "0.1.4-git"
 dependencies = [
  "portable-atomic",
  "spin",

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -4,8 +4,15 @@
 
 ### Inspecting USB
 
-To check whether your operating system identifies OpenSK over USB, try `lsusb`
-or `dmesg`.
+To check whether your operating system identifies OpenSK over USB:
+
+On Linux, try `lsusb` or `dmesg`.
+
+On macOS, use the `ioreg` tool:
+
+```sh
+ioreg -p IOUSB
+```
 
 ### Debug console
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,7 +2,8 @@
 
 ## Installation guide
 
-This document lists required steps to start build your own OpenSK.
+This document lists required steps to start building your own OpenSK.
+OpenSK installation is supported and tested under Linux and macOS.
 
 OpenSK is installed as a native [Wasefire](https://github.com/google/wasefire)
 applet.

--- a/libraries/cbor/src/macros.rs
+++ b/libraries/cbor/src/macros.rs
@@ -93,21 +93,17 @@ pub fn destructure_cbor_map_peek_value(
     needle: Value,
 ) -> Option<Value> {
     loop {
-        match it.peek() {
-            None => return None,
-            Some(item) => {
-                let key: &Value = &item.0;
-                match key.cmp(&needle) {
-                    Ordering::Less => {
-                        it.next();
-                    }
-                    Ordering::Equal => {
-                        let value: Value = it.next().unwrap().1;
-                        return Some(value);
-                    }
-                    Ordering::Greater => return None,
-                }
+        let item = it.peek()?;
+        let key: &Value = &item.0;
+        match key.cmp(&needle) {
+            Ordering::Less => {
+                it.next();
             }
+            Ordering::Equal => {
+                let value: Value = it.next().unwrap().1;
+                return Some(value);
+            }
+            Ordering::Greater => return None,
         }
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-11-07"
+channel = "nightly-2026-06-03"
 components = ["clippy", "miri", "rustfmt", "rust-src"]
 targets = ["thumbv7em-none-eabi"]


### PR DESCRIPTION
Wasefire made its install script compatible, so we can now claim macOS support again. Adding back the GitHub workflow and documentation.

Since Wasefire bumped its Rust toolchain, we follow. The cbor library change is a clippy lint.